### PR TITLE
boost code compile speed

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -1,7 +1,6 @@
 async function createModule(files) {
   let currentImportMap
   let shim
-  const { transform } = await import(/* webpackIgnore: true */ 'https://esm.sh/sucrase')
 
   async function setupImportMap() {
     if (shim) return shim
@@ -32,18 +31,11 @@ async function createModule(files) {
     return `data:text/javascript;utf-8,${encodeURIComponent(code)}`
   }
 
-
-  function transformCode(code) {
-    return transform(code, {
-      transforms: ['jsx', 'typescript'],
-    }).code
-  }
-
   await setupImportMap()
   const imports = Object.fromEntries(
     Object.entries(files).map(([key, code]) => [
       key,
-      createInlinedModule(transformCode(code)),
+      createInlinedModule(code),
     ])
   )
 

--- a/lib/react.mjs
+++ b/lib/react.mjs
@@ -1,5 +1,12 @@
 import { useEffect, useCallback, useState, useRef } from 'react'
 import { createModule } from './index.mjs'
+import { transform } from 'sucrase'
+
+function transformCode(code) {
+  return transform(code, {
+    transforms: ['jsx', 'typescript'],
+  }).code
+}
 
 function createRenderer(_React, _ReactDOM, _createModule) {
   const _jsx = _React.createElement
@@ -84,17 +91,22 @@ export function useLiveCode() {
 
   const load = useCallback(async (files) => {
     if (files) {
+      const transformedFiles = Object.keys(files).reduce((res, filename) => {
+        res[filename] = transformCode(files[filename])
+        return res
+      }, {})
+
       try {
         const iframe = iframeRef.current
         const script = scriptRef.current
         if (iframe) {
           const render = iframe.contentWindow.__render__
           if (render) {
-            render(files)
+            render(transformedFiles)
           } else {
             // if render is not loaded yet, wait until it's loaded
             script.onload = () => {
-              iframe.contentWindow.__render__(files)
+              iframe.contentWindow.__render__(transformedFiles)
             }
           }
         }


### PR DESCRIPTION
Related to #7

Move sucrase transpilation to the `devjar/react` exports, so that sucrase is bundled and doesn't have to be loaded in each iframem which will speed up a bit the first render