### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "es-module-lexer": "0.10.5",
-    "es-module-shims": "1.5.6",
-    "sucrase": "3.21.0"
+    "es-module-shims": "1.5.9",
+    "sucrase": "3.23.0"
   },
   "devDependencies": {
     "codice": "latest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,10 +119,10 @@ es-module-lexer@0.10.5:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.10.5.tgz#06f76d51fa53b1f78e3bd8bb36dd275eda2fdd53"
   integrity sha512-+7IwY/kiGAacQfY+YBhKMvEmyAJnw5grTUgjG85Pe7vcUI/6b7pZjZG8nQ7+48YhzEAEqrEgD2dCz/JIK+AYvw==
 
-es-module-shims@1.5.6:
-  version "1.5.6"
-  resolved "https://registry.yarnpkg.com/es-module-shims/-/es-module-shims-1.5.6.tgz#f32560381e6c2574e3832a0bfde32d269163e9f3"
-  integrity sha512-P/WNC3j4hncbMjx8mdgNchYaSulXJO8Q7lF6CJthc0Rv3t6ZuzfQnkXkNzluUdgnS9/7mTTJrS9dDgZ2OYbZvA==
+es-module-shims@1.5.9:
+  version "1.5.9"
+  resolved "https://registry.yarnpkg.com/es-module-shims/-/es-module-shims-1.5.9.tgz#eea372aad7bb98236192276407bf5b4505ec68c8"
+  integrity sha512-Qn5zisz4pG6P1q8YZj20UP1WHDSZNc+0am5WAUMpa8lh8fI31f4zZq5VEkPyuBp5vu8mnkdeBru2S38/nFy42g==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -290,10 +290,10 @@ styled-jsx@5.0.2:
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.2.tgz#ff230fd593b737e9e68b630a694d460425478729"
   integrity sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==
 
-sucrase@3.21.0:
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.21.0.tgz#6a5affdbe716b22e4dc99c57d366ad0d216444b9"
-  integrity sha512-FjAhMJjDcifARI7bZej0Bi1yekjWQHoEvWIXhLPwDhC6O4iZ5PtGb86WV56riW87hzpgB13wwBKO9vKAiWu5VQ==
+sucrase@3.23.0:
+  version "3.23.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.23.0.tgz#2a7fa80a04f055fb2e95d2aead03fec1dba52838"
+  integrity sha512-xgC1xboStzGhCnRywlBf/DLmkC+SkdAKqrNCDsxGrzM0phR5oUxoFKiQNrsc2D8wDdAm03iLbSZqjHDddo3IzQ==
   dependencies:
     commander "^4.0.0"
     glob "7.1.6"


### PR DESCRIPTION
bump `es-module-shims` and `sucrase`