### PR TITLE
Fix wrong textarea position (in Firefox)

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -57,6 +57,8 @@ textarea {
   bottom: 0;
   left: 0;
   right: 0;
+  height: 100%;
+  width: 100%;
 }
 textarea:focus,
 textarea:focus-visible {


### PR DESCRIPTION
This is what it currently looks like in Firefox:

![изображение](https://user-images.githubusercontent.com/48491463/180616663-2da12bf8-e6e7-47aa-beb8-99beeb63b1d0.png)
