### PR TITLE
Add CLI build and hosting workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Build Site
         run: pnpm run build:site
+
+      - name: Test CLI
+        run: pnpm test
+
+      - name: Check Package
+        run: pnpm test:package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build Package
         run: pnpm run build
 
+      - name: Test Package
+        run: pnpm test && pnpm test:package
+
       - name: Determine npm tag
         id: npm-tag
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dist
 next-env.d.ts
 tsconfig.tsbuildinfo
 .pnpm-store
-.devjar

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 next-env.d.ts
 tsconfig.tsbuildinfo
 .pnpm-store
+.devjar

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Repository guidance
+
+## TypeScript and API design
+
+- Avoid optional parameters and default arguments when callers can pass values explicitly.
+- Prefer required fields in options objects, using an explicit union such as `string | undefined` only when absence is meaningful.
+- Keep optional parameters when they are necessary for compatibility or accurately model the API.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The dashboard demonstrates page navigation, shared components, a CDN-loaded
 icon package, Tailwind, static API data, and a public SVG asset.
 
 ```sh
-devjar dev [root] --host 127.0.0.1 --port 3000
+devjar dev [root] --host localhost --port 3000
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ watching or on-request transforms:
 
 ```sh
 devjar build
-devjar start .devjar
+devjar start dist
 ```
 
 The build contains the transformed route graph, runtime assets, public files,

--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ The repository includes two runnable examples:
 
 ```sh
 devjar dev examples/basic
-devjar dev examples/dashboard --open
+devjar dev examples/dashboard
 ```
 
 The dashboard demonstrates page navigation, shared components, a CDN-loaded
 icon package, Tailwind, static API data, and a public SVG asset.
 
 ```sh
-devjar dev [root] --host 127.0.0.1 --port 3000 --open
+devjar dev [root] --host 127.0.0.1 --port 3000
 ```
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ my-prototype/
 ```
 
 ```sh
-npx devjar
+npx devjar dev
 ```
+
+Running `devjar` without a command is an alias for `devjar dev`. The development
+server watches the project and updates the preview as files change.
 
 The pages directory maps directly to URLs:
 
@@ -61,8 +64,50 @@ not supported.
 The embedded browser runtime loads Tailwind automatically. For CLI projects,
 add `tailwindcss` or `@tailwindcss/browser` to `package.json` to enable it.
 
+Bare imports use esm.sh by default. An ESM-compatible CDN can be selected on the
+command line or stored in `package.json`:
+
 ```sh
-devjar [root] --host 127.0.0.1 --port 3000
+devjar dev --cdn https://modules.example.com
+```
+
+```json
+{
+  "devjar": {
+    "cdn": "https://modules.example.com"
+  }
+}
+```
+
+The CLI applies dependency versions to CDN URLs using the
+`package@version/subpath` convention.
+
+## Build and host
+
+Create a self-contained production build, then serve it without source-file
+watching or on-request transforms:
+
+```sh
+devjar build
+devjar start .devjar
+```
+
+The build contains the transformed route graph, runtime assets, public files,
+and static API data. Use `--out-dir <directory>` to change its location. The
+output directory must remain inside the project root.
+
+The repository includes two runnable examples:
+
+```sh
+devjar dev examples/basic
+devjar dev examples/dashboard --open
+```
+
+The dashboard demonstrates page navigation, shared components, a CDN-loaded
+icon package, Tailwind, static API data, and a public SVG asset.
+
+```sh
+devjar dev [root] --host 127.0.0.1 --port 3000 --open
 ```
 
 ## Demo

--- a/examples/basic/components/shell.tsx
+++ b/examples/basic/components/shell.tsx
@@ -1,24 +1,26 @@
 import type { ReactNode } from 'react'
 
 export function Shell({ page, children }: { page: 'home' | 'about', children: ReactNode }) {
-  const link = (active: boolean) => `text-sm ${
-    active ? 'font-medium text-neutral-950' : 'text-neutral-500 hover:text-neutral-950'
+  const link = (active: boolean) => `border-2 border-neutral-950 px-3 py-2 text-xs font-bold uppercase tracking-wider ${
+    active ? 'bg-neutral-950 text-white' : 'bg-white text-neutral-950 hover:bg-[#d9ff54]'
   }`
 
   return (
-    <div className="min-h-screen bg-stone-50 text-neutral-900">
-      <header className="border-b border-neutral-200">
-        <nav className="mx-auto flex max-w-3xl items-center justify-between px-6 py-6">
-          <a href="/" className="font-serif text-xl font-semibold tracking-tight">Field Notes</a>
-          <div className="flex items-center gap-6">
+    <div className="min-h-screen bg-[#f1efe7] text-neutral-950">
+      <header>
+        <nav className="mx-auto flex max-w-4xl items-center justify-between px-4 pt-6 sm:px-6">
+          <a href="/" className="text-lg font-black uppercase tracking-tight text-neutral-950">Field / Notes</a>
+          <div className="flex items-center gap-2">
             <a href="/" className={link(page === 'home')}>Writing</a>
             <a href="/about" className={link(page === 'about')}>About</a>
           </div>
         </nav>
       </header>
-      <main className="mx-auto max-w-3xl px-6 py-16">{children}</main>
-      <footer className="mx-auto max-w-3xl border-t border-neutral-200 px-6 py-8 text-sm text-neutral-500">
-        A small blog built with Devjar.
+      <main className="mx-auto max-w-4xl px-4 py-8 sm:px-6 sm:py-10">{children}</main>
+      <footer className="mx-auto max-w-4xl px-4 pb-8 sm:px-6">
+        <div className="border-t-2 border-neutral-950 pt-4 text-xs font-bold uppercase tracking-wider">
+          A small blog built with Devjar.
+        </div>
       </footer>
     </div>
   )

--- a/examples/basic/pages/about.tsx
+++ b/examples/basic/pages/about.tsx
@@ -4,15 +4,15 @@ import '../styles.css'
 export default function About() {
   return (
     <Shell page="about">
-      <article className="max-w-2xl">
-        <p className="text-sm text-neutral-500">About this site</p>
-        <h1 className="mt-3 font-serif text-4xl font-semibold tracking-tight">A simple place to publish notes.</h1>
-        <div className="mt-8 space-y-5 text-lg leading-8 text-neutral-700">
+      <article className="border-2 border-neutral-950 bg-white p-6 sm:p-8">
+        <p className="text-xs font-bold uppercase tracking-[0.16em]">About this site</p>
+        <h1 className="mt-4 max-w-2xl text-4xl font-black leading-none tracking-[-0.04em] sm:text-5xl">A simple place to publish notes.</h1>
+        <div className="mt-7 max-w-2xl space-y-4 border-l-4 border-[#b6e800] pl-5 text-base leading-7 text-neutral-800">
           <p>Field Notes is a small example of a multi-page Devjar project. It uses ordinary TSX files, a shared component, and Tailwind utility classes.</p>
           <p>The source stays intentionally modest. There is enough structure to feel like a real website without turning the example into a framework demonstration.</p>
           <p>Devjar transforms the files locally and loads browser packages from a CDN, so the folder can remain small and portable.</p>
         </div>
-        <a href="/" className="mt-10 inline-block text-sm font-medium underline decoration-neutral-300 underline-offset-4 hover:decoration-neutral-700">← Back to writing</a>
+        <a href="/" className="mt-8 inline-block border-2 border-neutral-950 bg-neutral-950 px-4 py-3 text-xs font-bold uppercase tracking-wider text-white">← Back to writing</a>
       </article>
     </Shell>
   )

--- a/examples/basic/pages/index.tsx
+++ b/examples/basic/pages/index.tsx
@@ -22,19 +22,21 @@ export default function Home() {
 
   return (
     <Shell page="home">
-      <section className="max-w-2xl">
-        <p className="text-sm text-neutral-500">Notes on software and small tools</p>
-        <h1 className="mt-3 font-serif text-4xl font-semibold leading-tight tracking-tight sm:text-5xl">Writing things down while building them.</h1>
-        <p className="mt-5 text-lg leading-8 text-neutral-600">A quiet collection of observations from making software, prototypes, and tools for the web.</p>
+      <section className="border-2 border-neutral-950 bg-[#d9ff54] p-6 sm:p-8">
+        <p className="text-xs font-bold uppercase tracking-[0.16em]">Notes on software and small tools</p>
+        <h1 className="mt-4 max-w-2xl text-4xl font-black leading-[0.95] tracking-[-0.04em] sm:text-6xl">Writing things down while building them.</h1>
+        <p className="mt-5 max-w-xl text-base font-medium leading-7">A compact collection of observations from making software, prototypes, and tools for the web.</p>
       </section>
 
-      <section className="mt-14 divide-y divide-neutral-200 border-y border-neutral-200">
+      <section className="mt-5 border-2 border-neutral-950 bg-white">
         {posts.map(post => (
-          <article className="py-8" key={post.title}>
-            <p className="text-sm text-neutral-500">{post.date}</p>
-            <h2 className="mt-2 font-serif text-2xl font-semibold tracking-tight"><a href="/about" className="hover:text-neutral-600">{post.title}</a></h2>
-            <p className="mt-3 max-w-2xl leading-7 text-neutral-600">{post.excerpt}</p>
-            <a href="/about" className="mt-4 inline-block text-sm font-medium underline decoration-neutral-300 underline-offset-4 hover:decoration-neutral-700">Read note</a>
+          <article className="border-b-2 border-neutral-950 p-5 last:border-b-0 sm:grid sm:grid-cols-[8rem_1fr] sm:gap-6" key={post.title}>
+            <p className="text-xs font-bold uppercase leading-5 tracking-wider">{post.date}</p>
+            <div>
+              <h2 className="text-xl font-black leading-tight tracking-tight"><a className="text-neutral-950" href="/about">{post.title}</a></h2>
+              <p className="mt-2 max-w-xl text-sm leading-6 text-neutral-700">{post.excerpt}</p>
+              <a href="/about" className="mt-3 inline-block text-xs font-bold uppercase tracking-wider text-neutral-950 underline decoration-2 underline-offset-4">Read note →</a>
+            </div>
           </article>
         ))}
       </section>

--- a/examples/basic/styles.css
+++ b/examples/basic/styles.css
@@ -4,7 +4,6 @@ body {
 }
 
 a {
-  color: inherit;
   text-decoration: none;
   text-decoration-thickness: 1px;
   text-underline-offset: 0.2em;
@@ -15,6 +14,11 @@ a:hover {
 }
 
 a:focus-visible {
-  outline: 2px solid #404040;
+  outline: 3px solid #84cc16;
   outline-offset: 3px;
+}
+
+::selection {
+  background: #171717;
+  color: #d9ff54;
 }

--- a/examples/dashboard/api/projects.json
+++ b/examples/dashboard/api/projects.json
@@ -1,0 +1,6 @@
+[
+  { "id": 1, "name": "Mobile refresh", "owner": "Mina", "progress": 72, "status": "On track" },
+  { "id": 2, "name": "Usage insights", "owner": "Noah", "progress": 46, "status": "At risk" },
+  { "id": 3, "name": "Team onboarding", "owner": "Iris", "progress": 88, "status": "On track" },
+  { "id": 4, "name": "Billing cleanup", "owner": "Theo", "progress": 31, "status": "Planning" }
+]

--- a/examples/dashboard/components/project-card.tsx
+++ b/examples/dashboard/components/project-card.tsx
@@ -1,0 +1,23 @@
+import { ArrowUpRight } from 'lucide-react'
+import type { Project } from '../lib/projects'
+
+export function ProjectCard({ project }: { project: Project }) {
+  return (
+    <article className="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm text-stone-500">{project.owner}</p>
+          <h2 className="mt-1 text-lg font-semibold">{project.name}</h2>
+        </div>
+        <ArrowUpRight className="text-stone-400" size={18} />
+      </div>
+      <div className="mt-6 h-2 overflow-hidden rounded-full bg-stone-100">
+        <div className="h-full rounded-full bg-lime-500" style={{ width: `${project.progress}%` }} />
+      </div>
+      <div className="mt-3 flex justify-between text-sm">
+        <span className="text-stone-500">{project.status}</span>
+        <span className="font-medium">{project.progress}%</span>
+      </div>
+    </article>
+  )
+}

--- a/examples/dashboard/components/project-card.tsx
+++ b/examples/dashboard/components/project-card.tsx
@@ -3,20 +3,20 @@ import type { Project } from '../lib/projects'
 
 export function ProjectCard({ project }: { project: Project }) {
   return (
-    <article className="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+    <article className="border-2 border-stone-950 bg-white p-4">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-sm text-stone-500">{project.owner}</p>
-          <h2 className="mt-1 text-lg font-semibold">{project.name}</h2>
+          <p className="text-xs font-bold uppercase tracking-wider text-stone-500">{project.owner}</p>
+          <h2 className="mt-1 text-lg font-black tracking-tight">{project.name}</h2>
         </div>
         <ArrowUpRight className="text-stone-400" size={18} />
       </div>
-      <div className="mt-6 h-2 overflow-hidden rounded-full bg-stone-100">
-        <div className="h-full rounded-full bg-lime-500" style={{ width: `${project.progress}%` }} />
+      <div className="mt-5 h-3 border border-stone-950 bg-stone-100">
+        <div className="h-full bg-[#b6e800]" style={{ width: `${project.progress}%` }} />
       </div>
-      <div className="mt-3 flex justify-between text-sm">
-        <span className="text-stone-500">{project.status}</span>
-        <span className="font-medium">{project.progress}%</span>
+      <div className="mt-2 flex justify-between text-xs font-bold uppercase tracking-wider">
+        <span>{project.status}</span>
+        <span>{project.progress}%</span>
       </div>
     </article>
   )

--- a/examples/dashboard/components/shell.tsx
+++ b/examples/dashboard/components/shell.tsx
@@ -9,17 +9,17 @@ const links = [
 
 export function Shell({ page, children }: { page: string, children: ReactNode }) {
   return (
-    <div className="min-h-screen bg-[#f4f5f2] text-stone-950">
-      <header className="border-b border-stone-200 bg-white">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
-          <a className="flex items-center gap-3 font-semibold" href="/">
-            <img alt="Northstar" className="size-8" src="/mark.svg" />
-            Northstar
+    <div className="min-h-screen bg-[#efeee8] text-stone-950">
+      <header className="border-b-2 border-stone-950 bg-[#d9ff54]">
+        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3 sm:px-6">
+          <a className="flex items-center gap-3 font-black uppercase tracking-tight text-stone-950" href="/">
+            <img alt="Northstar" className="size-7 border-2 border-stone-950" src="/mark.svg" />
+            Northstar / Ops
           </a>
-          <nav className="flex items-center gap-1">
+          <nav className="flex items-center gap-2">
             {links.map(({ href, label, icon: Icon }) => (
               <a
-                className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm ${page === href ? 'bg-stone-900 text-white' : 'text-stone-500 hover:bg-stone-100 hover:text-stone-950'}`}
+                className={`flex items-center gap-2 border-2 border-stone-950 px-2.5 py-2 text-xs font-bold uppercase tracking-wider ${page === href ? 'bg-stone-950 text-white' : 'bg-[#d9ff54] text-stone-950 hover:bg-white'}`}
                 href={href}
                 key={href}
               >
@@ -30,7 +30,7 @@ export function Shell({ page, children }: { page: string, children: ReactNode })
           </nav>
         </div>
       </header>
-      <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>
+      <main className="mx-auto max-w-5xl px-4 py-7 sm:px-6 sm:py-9">{children}</main>
     </div>
   )
 }

--- a/examples/dashboard/components/shell.tsx
+++ b/examples/dashboard/components/shell.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from 'react'
+import { FolderKanban, LayoutDashboard, Settings } from 'lucide-react'
+
+const links = [
+  { href: '/', label: 'Overview', icon: LayoutDashboard },
+  { href: '/projects', label: 'Projects', icon: FolderKanban },
+  { href: '/settings', label: 'Settings', icon: Settings },
+]
+
+export function Shell({ page, children }: { page: string, children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[#f4f5f2] text-stone-950">
+      <header className="border-b border-stone-200 bg-white">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <a className="flex items-center gap-3 font-semibold" href="/">
+            <img alt="Northstar" className="size-8" src="/mark.svg" />
+            Northstar
+          </a>
+          <nav className="flex items-center gap-1">
+            {links.map(({ href, label, icon: Icon }) => (
+              <a
+                className={`flex items-center gap-2 rounded-lg px-3 py-2 text-sm ${page === href ? 'bg-stone-900 text-white' : 'text-stone-500 hover:bg-stone-100 hover:text-stone-950'}`}
+                href={href}
+                key={href}
+              >
+                <Icon size={16} />
+                <span className="hidden sm:inline">{label}</span>
+              </a>
+            ))}
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>
+    </div>
+  )
+}

--- a/examples/dashboard/lib/projects.ts
+++ b/examples/dashboard/lib/projects.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+
+export type Project = {
+  id: number
+  name: string
+  owner: string
+  progress: number
+  status: 'On track' | 'At risk' | 'Planning'
+}
+
+export function useProjects() {
+  const [projects, setProjects] = useState<Project[]>([])
+
+  useEffect(() => {
+    fetch('/api/projects.json')
+      .then(response => response.json())
+      .then(setProjects)
+  }, [])
+
+  return projects
+}

--- a/examples/dashboard/package.json
+++ b/examples/dashboard/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "dependencies": {
+    "lucide-react": "0.542.0",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "tailwindcss": "^4.1.0"
+  },
+  "devjar": {
+    "cdn": "https://esm.sh"
+  }
+}

--- a/examples/dashboard/pages/404.tsx
+++ b/examples/dashboard/pages/404.tsx
@@ -4,9 +4,11 @@ import '../styles.css'
 export default function NotFound() {
   return (
     <Shell page="">
-      <p className="text-sm font-medium text-lime-700">404</p>
-      <h1 className="mt-2 text-4xl font-semibold tracking-tight">That page wandered off.</h1>
-      <a className="mt-6 inline-block text-sm font-medium underline underline-offset-4" href="/">Return to overview</a>
+      <div className="max-w-2xl border-2 border-stone-950 bg-white p-7 shadow-[5px_5px_0_#1c1917]">
+        <p className="text-xs font-black uppercase tracking-[0.16em]">Error / 404</p>
+        <h1 className="mt-4 text-4xl font-black leading-none tracking-[-0.04em]">That page wandered off.</h1>
+        <a className="mt-7 inline-block border-2 border-stone-950 bg-stone-950 px-4 py-3 text-xs font-bold uppercase tracking-wider text-white" href="/">Return to overview</a>
+      </div>
     </Shell>
   )
 }

--- a/examples/dashboard/pages/404.tsx
+++ b/examples/dashboard/pages/404.tsx
@@ -1,0 +1,12 @@
+import { Shell } from '../components/shell'
+import '../styles.css'
+
+export default function NotFound() {
+  return (
+    <Shell page="">
+      <p className="text-sm font-medium text-lime-700">404</p>
+      <h1 className="mt-2 text-4xl font-semibold tracking-tight">That page wandered off.</h1>
+      <a className="mt-6 inline-block text-sm font-medium underline underline-offset-4" href="/">Return to overview</a>
+    </Shell>
+  )
+}

--- a/examples/dashboard/pages/index.tsx
+++ b/examples/dashboard/pages/index.tsx
@@ -1,0 +1,53 @@
+import { ArrowRight, CircleCheck, Clock3, FolderKanban } from 'lucide-react'
+import { ProjectCard } from '../components/project-card'
+import { Shell } from '../components/shell'
+import { useProjects } from '../lib/projects'
+import '../styles.css'
+
+export default function Overview() {
+  const projects = useProjects()
+  const onTrack = projects.filter(project => project.status === 'On track').length
+  const stats = [
+    { icon: FolderKanban, label: 'Active projects', value: projects.length || '—' },
+    { icon: CircleCheck, label: 'On track', value: projects.length ? onTrack : '—' },
+    {
+      icon: Clock3,
+      label: 'Average progress',
+      value: projects.length
+        ? `${Math.round(projects.reduce((sum, project) => sum + project.progress, 0) / projects.length)}%`
+        : '—',
+    },
+  ]
+
+  return (
+    <Shell page="/">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-lime-700">Monday, September 2</p>
+          <h1 className="mt-2 text-4xl font-semibold tracking-tight">Good morning, Alex.</h1>
+          <p className="mt-3 text-stone-500">Here is what your team is moving today.</p>
+        </div>
+        <a className="flex items-center gap-2 rounded-xl bg-stone-900 px-4 py-3 text-sm font-medium text-white" href="/projects">
+          View all projects <ArrowRight size={16} />
+        </a>
+      </div>
+
+      <section className="mt-10 grid gap-4 sm:grid-cols-3">
+        {stats.map(({ icon: Icon, label, value }) => (
+          <article className="rounded-2xl border border-stone-200 bg-white p-5" key={label}>
+            <Icon className="text-stone-400" size={20} />
+            <p className="mt-6 text-sm text-stone-500">{label}</p>
+            <p className="mt-1 text-3xl font-semibold">{value}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="mt-10">
+        <h2 className="text-xl font-semibold">Recent projects</h2>
+        <div className="mt-4 grid gap-4 md:grid-cols-2">
+          {projects.slice(0, 4).map(project => <ProjectCard key={project.id} project={project} />)}
+        </div>
+      </section>
+    </Shell>
+  )
+}

--- a/examples/dashboard/pages/index.tsx
+++ b/examples/dashboard/pages/index.tsx
@@ -21,30 +21,32 @@ export default function Overview() {
 
   return (
     <Shell page="/">
-      <div className="flex flex-wrap items-end justify-between gap-4">
+      <div className="flex flex-wrap items-end justify-between gap-5 border-b-2 border-stone-950 pb-6">
         <div>
-          <p className="text-sm font-medium text-lime-700">Monday, September 2</p>
-          <h1 className="mt-2 text-4xl font-semibold tracking-tight">Good morning, Alex.</h1>
-          <p className="mt-3 text-stone-500">Here is what your team is moving today.</p>
+          <p className="text-xs font-bold uppercase tracking-[0.16em]">Monday, September 2</p>
+          <h1 className="mt-3 text-4xl font-black leading-none tracking-[-0.04em] sm:text-5xl">Good morning, Alex.</h1>
+          <p className="mt-3 text-sm text-stone-700">Here is what your team is moving today.</p>
         </div>
-        <a className="flex items-center gap-2 rounded-xl bg-stone-900 px-4 py-3 text-sm font-medium text-white" href="/projects">
+        <a className="flex items-center gap-2 border-2 border-stone-950 bg-stone-950 px-4 py-3 text-xs font-bold uppercase tracking-wider text-white" href="/projects">
           View all projects <ArrowRight size={16} />
         </a>
       </div>
 
-      <section className="mt-10 grid gap-4 sm:grid-cols-3">
+      <section className="mt-5 grid gap-3 sm:grid-cols-3">
         {stats.map(({ icon: Icon, label, value }) => (
-          <article className="rounded-2xl border border-stone-200 bg-white p-5" key={label}>
-            <Icon className="text-stone-400" size={20} />
-            <p className="mt-6 text-sm text-stone-500">{label}</p>
-            <p className="mt-1 text-3xl font-semibold">{value}</p>
+          <article className="border-2 border-stone-950 bg-white p-4 shadow-[3px_3px_0_#1c1917]" key={label}>
+            <div className="flex items-start justify-between">
+              <p className="text-xs font-bold uppercase tracking-wider">{label}</p>
+              <Icon size={18} />
+            </div>
+            <p className="mt-7 text-3xl font-black tracking-tight">{value}</p>
           </article>
         ))}
       </section>
 
-      <section className="mt-10">
-        <h2 className="text-xl font-semibold">Recent projects</h2>
-        <div className="mt-4 grid gap-4 md:grid-cols-2">
+      <section className="mt-8">
+        <h2 className="text-xs font-black uppercase tracking-[0.16em]">Recent projects</h2>
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
           {projects.slice(0, 4).map(project => <ProjectCard key={project.id} project={project} />)}
         </div>
       </section>

--- a/examples/dashboard/pages/projects.tsx
+++ b/examples/dashboard/pages/projects.tsx
@@ -1,0 +1,18 @@
+import { ProjectCard } from '../components/project-card'
+import { Shell } from '../components/shell'
+import { useProjects } from '../lib/projects'
+import '../styles.css'
+
+export default function Projects() {
+  const projects = useProjects()
+  return (
+    <Shell page="/projects">
+      <p className="text-sm font-medium text-lime-700">Portfolio</p>
+      <h1 className="mt-2 text-4xl font-semibold tracking-tight">Projects</h1>
+      <p className="mt-3 text-stone-500">A live view loaded from a static Devjar API route.</p>
+      <div className="mt-8 grid gap-4 md:grid-cols-2">
+        {projects.map(project => <ProjectCard key={project.id} project={project} />)}
+      </div>
+    </Shell>
+  )
+}

--- a/examples/dashboard/pages/projects.tsx
+++ b/examples/dashboard/pages/projects.tsx
@@ -7,10 +7,12 @@ export default function Projects() {
   const projects = useProjects()
   return (
     <Shell page="/projects">
-      <p className="text-sm font-medium text-lime-700">Portfolio</p>
-      <h1 className="mt-2 text-4xl font-semibold tracking-tight">Projects</h1>
-      <p className="mt-3 text-stone-500">A live view loaded from a static Devjar API route.</p>
-      <div className="mt-8 grid gap-4 md:grid-cols-2">
+      <div className="border-b-2 border-stone-950 pb-6">
+        <p className="text-xs font-bold uppercase tracking-[0.16em]">Portfolio</p>
+        <h1 className="mt-3 text-5xl font-black leading-none tracking-[-0.04em]">Projects</h1>
+        <p className="mt-3 text-sm text-stone-700">A live view loaded from a static Devjar API route.</p>
+      </div>
+      <div className="mt-5 grid gap-3 md:grid-cols-2">
         {projects.map(project => <ProjectCard key={project.id} project={project} />)}
       </div>
     </Shell>

--- a/examples/dashboard/pages/settings.tsx
+++ b/examples/dashboard/pages/settings.tsx
@@ -14,10 +14,10 @@ function Setting({
   onChange: (checked: boolean) => void
 }) {
   return (
-    <label className="flex cursor-pointer items-center justify-between gap-6 border-b border-stone-100 p-5 last:border-0">
+    <label className="flex cursor-pointer items-center justify-between gap-6 border-b-2 border-stone-950 p-4 last:border-0">
       <span>
-        <span className="block font-medium">{label}</span>
-        <span className="mt-1 block text-sm text-stone-500">{description}</span>
+        <span className="block font-black">{label}</span>
+        <span className="mt-1 block text-sm text-stone-600">{description}</span>
       </span>
       <input checked={checked} onChange={event => onChange(event.target.checked)} type="checkbox" />
     </label>
@@ -30,9 +30,11 @@ export default function Settings() {
 
   return (
     <Shell page="/settings">
-      <p className="text-sm font-medium text-lime-700">Workspace</p>
-      <h1 className="mt-2 text-4xl font-semibold tracking-tight">Settings</h1>
-      <div className="mt-8 max-w-2xl overflow-hidden rounded-2xl border border-stone-200 bg-white">
+      <div className="border-b-2 border-stone-950 pb-6">
+        <p className="text-xs font-bold uppercase tracking-[0.16em]">Workspace</p>
+        <h1 className="mt-3 text-5xl font-black leading-none tracking-[-0.04em]">Settings</h1>
+      </div>
+      <div className="mt-5 max-w-2xl border-2 border-stone-950 bg-white">
         <Setting
           checked={weeklyDigest}
           description="Receive a summary every Monday morning."

--- a/examples/dashboard/pages/settings.tsx
+++ b/examples/dashboard/pages/settings.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { Shell } from '../components/shell'
+import '../styles.css'
+
+function Setting({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+}) {
+  return (
+    <label className="flex cursor-pointer items-center justify-between gap-6 border-b border-stone-100 p-5 last:border-0">
+      <span>
+        <span className="block font-medium">{label}</span>
+        <span className="mt-1 block text-sm text-stone-500">{description}</span>
+      </span>
+      <input checked={checked} onChange={event => onChange(event.target.checked)} type="checkbox" />
+    </label>
+  )
+}
+
+export default function Settings() {
+  const [weeklyDigest, setWeeklyDigest] = useState(true)
+  const [compactView, setCompactView] = useState(false)
+
+  return (
+    <Shell page="/settings">
+      <p className="text-sm font-medium text-lime-700">Workspace</p>
+      <h1 className="mt-2 text-4xl font-semibold tracking-tight">Settings</h1>
+      <div className="mt-8 max-w-2xl overflow-hidden rounded-2xl border border-stone-200 bg-white">
+        <Setting
+          checked={weeklyDigest}
+          description="Receive a summary every Monday morning."
+          label="Weekly digest"
+          onChange={setWeeklyDigest}
+        />
+        <Setting
+          checked={compactView}
+          description="Fit more project information on screen."
+          label="Compact view"
+          onChange={setCompactView}
+        />
+      </div>
+    </Shell>
+  )
+}

--- a/examples/dashboard/public/mark.svg
+++ b/examples/dashboard/public/mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="9" fill="#1c1917"/>
+  <path d="M8 21 14 9l3.2 6.2L20 11l4 10h-4.4l-2.8-5.2L14 21H8Z" fill="#a3e635"/>
+</svg>

--- a/examples/dashboard/public/mark.svg
+++ b/examples/dashboard/public/mark.svg
@@ -1,4 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="9" fill="#1c1917"/>
-  <path d="M8 21 14 9l3.2 6.2L20 11l4 10h-4.4l-2.8-5.2L14 21H8Z" fill="#a3e635"/>
+  <circle cx="16" cy="16" r="16" fill="#000"/>
 </svg>

--- a/examples/dashboard/styles.css
+++ b/examples/dashboard/styles.css
@@ -1,0 +1,4 @@
+* { box-sizing: border-box; }
+body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+a { color: inherit; text-decoration: none; }
+input[type='checkbox'] { width: 2.5rem; height: 1.25rem; accent-color: #84cc16; }

--- a/examples/dashboard/styles.css
+++ b/examples/dashboard/styles.css
@@ -1,4 +1,6 @@
 * { box-sizing: border-box; }
 body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
-a { color: inherit; text-decoration: none; }
-input[type='checkbox'] { width: 2.5rem; height: 1.25rem; accent-color: #84cc16; }
+a { text-decoration: none; }
+input[type='checkbox'] { width: 2rem; height: 1.25rem; accent-color: #84cc16; }
+a:focus-visible { outline: 3px solid #65a30d; outline-offset: 3px; }
+::selection { background: #171717; color: #d9ff54; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devjar",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "type": "module",
   "exports": {
     ".": {
@@ -33,8 +33,11 @@
     "dev:client": "bun scripts/build-client.ts --watch",
     "dev:worker": "bun --watch scripts/build-workers.ts",
     "dev:site": "next dev ./site",
-    "dev:cli": "node ./dist/bin.js",
-    "test": "bun test"
+    "dev:cli": "node ./dist/bin.js dev examples/dashboard",
+    "demo:build": "node ./dist/bin.js build examples/dashboard",
+    "demo:start": "node ./dist/bin.js start examples/dashboard/.devjar",
+    "test": "bun test",
+    "test:package": "bun scripts/check-package.ts"
   },
   "peerDependencies": {
     "react": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dev:site": "next dev ./site",
     "dev:cli": "node ./dist/bin.js dev examples/dashboard",
     "demo:build": "node ./dist/bin.js build examples/dashboard",
-    "demo:start": "node ./dist/bin.js start examples/dashboard/.devjar",
+    "demo:start": "node ./dist/bin.js start examples/dashboard/dist",
     "test": "bun test",
     "test:package": "bun scripts/check-package.ts"
   },

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -1,0 +1,44 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const packageJson = await Bun.file(join(root, 'package.json')).json()
+if (packageJson.bin?.devjar !== './dist/bin.js') {
+  throw new Error('package.json must expose dist/bin.js as the devjar binary')
+}
+
+const cache = mkdtempSync(join(tmpdir(), 'devjar-npm-cache-'))
+const env = Object.fromEntries(
+  Object.entries(process.env).filter(([name]) => !name.toLowerCase().startsWith('npm_config_')),
+)
+const result = Bun.spawnSync(['npm', 'pack', '--dry-run', '--json'], {
+  cwd: root,
+  env: { ...env, npm_config_cache: cache },
+  stderr: 'inherit',
+})
+rmSync(cache, { recursive: true, force: true })
+
+if (result.exitCode !== 0) process.exit(result.exitCode)
+const pack = JSON.parse(result.stdout.toString())[0]
+const files = new Set<string>(pack.files.map((file: { path: string }) => file.path))
+const required = [
+  'dist/bin.js',
+  'dist/client.js',
+  'dist/index.js',
+  'dist/transform-worker.js',
+  'dist/transform.wasm32-wasi.wasm',
+]
+const missing = required.filter(file => !files.has(file))
+
+if (missing.length) {
+  throw new Error(`Package is missing required files: ${missing.join(', ')}`)
+}
+
+const cli = Bun.spawnSync(['node', 'dist/bin.js', '--version'], { cwd: root })
+if (cli.exitCode !== 0 || cli.stdout.toString().trim() !== packageJson.version) {
+  throw new Error('The packaged CLI did not report the package version')
+}
+
+console.log(`Package contains the CLI and required runtime assets (${files.size} files total).`)

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -39,6 +39,19 @@ if (missing.length) {
 const cli = Bun.spawnSync(['node', 'dist/bin.js', '--version'], { cwd: root })
 if (cli.exitCode !== 0 || cli.stdout.toString().trim() !== packageJson.version) {
   throw new Error('The packaged CLI did not report the package version')
+}
+
+const cliProject = mkdtempSync(join(tmpdir(), 'devjar-cli-'))
+cpSync(join(root, 'examples/basic'), cliProject, { recursive: true })
+const build = Bun.spawnSync(['node', 'dist/bin.js', 'build', cliProject], {
+  cwd: root,
+  stderr: 'inherit',
+})
+const usedDefaultOutput = existsSync(join(cliProject, 'dist', 'manifest.json'))
+rmSync(cliProject, { recursive: true, force: true })
+
+if (build.exitCode !== 0 || !usedDefaultOutput) {
+  throw new Error('The packaged CLI did not build to dist by default')
 }
 
 console.log(`Package contains the CLI and required runtime assets (${files.size} files total).`)

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -24,6 +24,7 @@ if (result.exitCode !== 0) process.exit(result.exitCode)
 const pack = JSON.parse(result.stdout.toString())[0]
 const files = new Set<string>(pack.files.map((file: { path: string }) => file.path))
 const required = [
+  'dist/_cdn.js',
   'dist/bin.js',
   'dist/client.js',
   'dist/index.js',
@@ -41,6 +42,11 @@ if (cli.exitCode !== 0 || cli.stdout.toString().trim() !== packageJson.version) 
   throw new Error('The packaged CLI did not report the package version')
 }
 
+const help = Bun.spawnSync(['node', 'dist/bin.js', '--help'], { cwd: root })
+if (help.exitCode !== 0 || !help.stdout.toString().includes('default: localhost')) {
+  throw new Error('The packaged CLI did not advertise localhost as the default host')
+}
+
 const cliProject = mkdtempSync(join(tmpdir(), 'devjar-cli-'))
 cpSync(join(root, 'examples/basic'), cliProject, { recursive: true })
 const build = Bun.spawnSync(['node', 'dist/bin.js', 'build', cliProject], {
@@ -48,10 +54,17 @@ const build = Bun.spawnSync(['node', 'dist/bin.js', 'build', cliProject], {
   stderr: 'inherit',
 })
 const usedDefaultOutput = existsSync(join(cliProject, 'dist', 'manifest.json'))
+const buildOutput = build.stdout.toString()
 rmSync(cliProject, { recursive: true, force: true })
 
-if (build.exitCode !== 0 || !usedDefaultOutput) {
-  throw new Error('The packaged CLI did not build to dist by default')
+if (
+  build.exitCode !== 0
+  || !usedDefaultOutput
+  || !buildOutput.includes('Devjar build complete')
+  || !buildOutput.includes('  Output: ')
+  || !buildOutput.includes('  Routes: 2')
+) {
+  throw new Error('The packaged CLI did not report a completed build in dist')
 }
 
 console.log(`Package contains the CLI and required runtime assets (${files.size} files total).`)

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -61,8 +61,8 @@ if (
   build.exitCode !== 0
   || !usedDefaultOutput
   || !buildOutput.includes('Devjar build complete')
-  || !buildOutput.includes('  Output: ')
-  || !buildOutput.includes('  Routes: 2')
+  || !buildOutput.includes('Output  ')
+  || !buildOutput.includes('Routes  2')
 ) {
   throw new Error('The packaged CLI did not report a completed build in dist')
 }

--- a/src/_cdn.ts
+++ b/src/_cdn.ts
@@ -11,7 +11,7 @@ function packageName(specifier: string) {
   return specifier.split('/')[0]
 }
 
-export function normalizeCdnHost(cdn = CDN_HOST) {
+export function normalizeCdnHost(cdn: string) {
   const url = new URL(cdn)
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     throw new Error(`Module CDN must use http or https: ${cdn}`)
@@ -20,8 +20,8 @@ export function normalizeCdnHost(cdn = CDN_HOST) {
 }
 
 export function createEsmShResolver(
-  dependencies: Record<string, string> = {},
-  cdn = CDN_HOST,
+  dependencies: Record<string, string>,
+  cdn: string,
 ) {
   const host = normalizeCdnHost(cdn)
   return (specifier: string) => {

--- a/src/_cdn.ts
+++ b/src/_cdn.ts
@@ -11,16 +11,28 @@ function packageName(specifier: string) {
   return specifier.split('/')[0]
 }
 
-export function createEsmShResolver(dependencies: Record<string, string> = {}) {
+export function normalizeCdnHost(cdn = CDN_HOST) {
+  const url = new URL(cdn)
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Module CDN must use http or https: ${cdn}`)
+  }
+  return url.href.replace(/\/$/, '')
+}
+
+export function createEsmShResolver(
+  dependencies: Record<string, string> = {},
+  cdn = CDN_HOST,
+) {
+  const host = normalizeCdnHost(cdn)
   return (specifier: string) => {
     const name = packageName(specifier)
     const version = dependencies[name] || defaultVersions[name]
-    if (!version) return `${CDN_HOST}/${specifier}`
+    if (!version) return `${host}/${specifier}`
     if (/^(?:file:|link:|workspace:|git|https?:)/.test(version)) {
       throw new Error(`CDN dependencies cannot use ${name}@${version}`)
     }
     const subpath = specifier.slice(name.length)
     const dev = name === 'react' || name === 'react-dom' || name === 'react-refresh'
-    return `${CDN_HOST}/${name}@${encodeURIComponent(version)}${subpath}${dev ? '?dev' : ''}`
+    return `${host}/${name}@${encodeURIComponent(version)}${subpath}${dev ? '?dev' : ''}`
   }
 }

--- a/src/bin/devjar.ts
+++ b/src/bin/devjar.ts
@@ -12,14 +12,14 @@ Turn a folder of React pages into a prototype.
 
 Commands:
   dev      Start a development server (default)
-  build    Create production output in <root>/.devjar
+  build    Create production output in <root>/dist
   start    Serve a directory created by devjar build
 
 Options:
   --cdn <url>      ESM-compatible module CDN (dev and build)
   --host <host>    Host to listen on (dev and start; default: 127.0.0.1)
   --port <port>    Port to listen on (dev and start; default: 3000)
-  -o, --out-dir   Build output relative to the project root (default: .devjar)
+  -o, --out-dir   Build output relative to the project root (default: dist)
   -v, --version    Show the installed version
   -h, --help       Show this help
 
@@ -27,7 +27,7 @@ Examples:
   devjar
   devjar dev examples/dashboard
   devjar build examples/dashboard
-  devjar start examples/dashboard/.devjar`)
+  devjar start examples/dashboard/dist`)
 }
 
 function valueAfter(args: string[], index: number) {
@@ -101,7 +101,7 @@ async function run() {
   if (command === 'build') {
     const result = await buildProject({
       root: root || process.cwd(),
-      outDir: outDir || '.devjar',
+      outDir: outDir || 'dist',
       cdn,
     })
     console.log(`Devjar built ${result.routes.length} routes`)
@@ -111,7 +111,7 @@ async function run() {
 
   const server = command === 'start'
     ? await startBuiltServer({
-        root: root || join(process.cwd(), '.devjar'),
+        root: root || join(process.cwd(), 'dist'),
         host: host || '127.0.0.1',
         port: port ?? 3000,
       })

--- a/src/bin/devjar.ts
+++ b/src/bin/devjar.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
 import { buildProject, startBuiltServer, startDevServer } from '../cli'
 
 type Command = 'dev' | 'build' | 'start'
@@ -98,15 +99,28 @@ async function run() {
   if (command === 'dev' && outDir) throw new Error('dev does not accept --out-dir')
 
   if (command === 'build') {
-    const result = await buildProject({ root, outDir, cdn })
+    const result = await buildProject({
+      root: root || process.cwd(),
+      outDir: outDir || '.devjar',
+      cdn,
+    })
     console.log(`Devjar built ${result.routes.length} routes`)
     console.log(result.outDir)
     return
   }
 
   const server = command === 'start'
-    ? await startBuiltServer({ root, host, port })
-    : await startDevServer({ root, host, port, cdn })
+    ? await startBuiltServer({
+        root: root || join(process.cwd(), '.devjar'),
+        host: host || '127.0.0.1',
+        port: port ?? 3000,
+      })
+    : await startDevServer({
+        root: root || process.cwd(),
+        host: host || '127.0.0.1',
+        port: port ?? 3000,
+        cdn,
+      })
   const browserHost = server.host === '0.0.0.0' || server.host === '::'
     ? '127.0.0.1'
     : server.host.includes(':') ? `[${server.host}]` : server.host

--- a/src/bin/devjar.ts
+++ b/src/bin/devjar.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { buildProject, startBuiltServer, startDevServer } from '../cli'
 
@@ -20,13 +19,12 @@ Options:
   --host <host>    Host to listen on (dev and start; default: 127.0.0.1)
   --port <port>    Port to listen on (dev and start; default: 3000)
   -o, --out-dir   Build output relative to the project root (default: .devjar)
-  --open           Open the server in a browser
   -v, --version    Show the installed version
   -h, --help       Show this help
 
 Examples:
   devjar
-  devjar dev examples/dashboard --open
+  devjar dev examples/dashboard
   devjar build examples/dashboard
   devjar start examples/dashboard/.devjar`)
 }
@@ -49,17 +47,6 @@ async function version() {
     } catch {}
   }
   return 'unknown'
-}
-
-function openBrowser(url: string) {
-  const command = process.platform === 'darwin'
-    ? ['open', url]
-    : process.platform === 'win32'
-      ? ['rundll32', 'url.dll,FileProtocolHandler', url]
-      : ['xdg-open', url]
-  const child = spawn(command[0], command.slice(1), { detached: true, stdio: 'ignore' })
-  child.on('error', () => {})
-  child.unref()
 }
 
 function friendlyError(error: unknown) {
@@ -87,7 +74,6 @@ async function run() {
   let port: number | undefined
   let cdn: string | undefined
   let outDir: string | undefined
-  let shouldOpen = false
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index]
@@ -95,7 +81,6 @@ async function run() {
     else if (arg === '--port' || arg === '-p') port = Number(valueAfter(args, index++))
     else if (arg === '--cdn') cdn = valueAfter(args, index++)
     else if (arg === '--out-dir' || arg === '-o') outDir = valueAfter(args, index++)
-    else if (arg === '--open') shouldOpen = true
     else if (arg.startsWith('-')) throw new Error(`Unknown option: ${arg}`)
     else if (!root) root = arg
     else throw new Error(`Unexpected argument: ${arg}`)
@@ -104,8 +89,8 @@ async function run() {
   if (port !== undefined && (!Number.isInteger(port) || port < 0 || port > 65535)) {
     throw new Error(`Invalid port: ${port}`)
   }
-  if (command === 'build' && (host || port !== undefined || shouldOpen)) {
-    throw new Error('build does not accept --host, --port, or --open')
+  if (command === 'build' && (host || port !== undefined)) {
+    throw new Error('build does not accept --host or --port')
   }
   if (command === 'start' && (cdn || outDir)) {
     throw new Error('start does not accept --cdn or --out-dir; configure these when building')
@@ -128,7 +113,6 @@ async function run() {
   const url = `http://${browserHost}:${server.port}`
   console.log(command === 'start' ? `Devjar serving build ${server.root}` : `Devjar serving ${server.root}`)
   console.log(url)
-  if (shouldOpen) openBrowser(url)
 
   let shuttingDown = false
   async function close(signal: string) {

--- a/src/bin/devjar.ts
+++ b/src/bin/devjar.ts
@@ -1,53 +1,152 @@
 #!/usr/bin/env node
-import { startDevServer } from '../cli'
+import { spawn } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { buildProject, startBuiltServer, startDevServer } from '../cli'
+
+type Command = 'dev' | 'build' | 'start'
 
 function help() {
-  console.log(`devjar [root] [options]
+  console.log(`devjar [command] [root] [options]
 
-Serve a folder of React pages with CDN dependencies.
+Turn a folder of React pages into a prototype.
+
+Commands:
+  dev      Start a development server (default)
+  build    Create production output in <root>/.devjar
+  start    Serve a directory created by devjar build
 
 Options:
-  --host <host>  Host to listen on (default: 127.0.0.1)
-  --port <port>  Port to listen on (default: 3000)
-  --help         Show this help`)
+  --cdn <url>      ESM-compatible module CDN (dev and build)
+  --host <host>    Host to listen on (dev and start; default: 127.0.0.1)
+  --port <port>    Port to listen on (dev and start; default: 3000)
+  -o, --out-dir   Build output relative to the project root (default: .devjar)
+  --open           Open the server in a browser
+  -v, --version    Show the installed version
+  -h, --help       Show this help
+
+Examples:
+  devjar
+  devjar dev examples/dashboard --open
+  devjar build examples/dashboard
+  devjar start examples/dashboard/.devjar`)
 }
 
-const args = process.argv.slice(2)
-if (args.includes('--help') || args.includes('-h')) {
-  help()
-  process.exit(0)
+function valueAfter(args: string[], index: number) {
+  const value = args[index + 1]
+  if (!value || value.startsWith('-')) throw new Error(`Missing value for ${args[index]}`)
+  return value
 }
 
-let root: string | undefined
-let host: string | undefined
-let port: number | undefined
-for (let index = 0; index < args.length; index++) {
-  const arg = args[index]
-  if (arg === '--host') host = args[++index]
-  else if (arg === '--port' || arg === '-p') port = Number(args[++index])
-  else if (arg.startsWith('-')) throw new Error(`Unknown option: ${arg}`)
-  else if (!root) root = arg
-  else throw new Error(`Unexpected argument: ${arg}`)
-}
-if (port !== undefined && (!Number.isInteger(port) || port < 0 || port > 65535)) {
-  throw new Error(`Invalid port: ${port}`)
-}
-
-const server = await startDevServer({ root, host, port })
-console.log(`Devjar serving ${server.root}`)
-console.log(`http://${server.host}:${server.port}`)
-
-let shuttingDown = false
-async function close(signal: string) {
-  if (shuttingDown) return
-  shuttingDown = true
-  console.log(`\n${signal} received, shutting down…`)
-  try {
-    await server.close()
-  } catch (error) {
-    console.error(error)
-    process.exitCode = 1
+async function version() {
+  const candidates = [
+    new URL('../package.json', import.meta.url),
+    new URL('../../package.json', import.meta.url),
+  ]
+  for (const url of candidates) {
+    try {
+      const packageJson = JSON.parse(await readFile(url, 'utf8'))
+      if (packageJson.name === 'devjar' && packageJson.version) return packageJson.version as string
+    } catch {}
   }
+  return 'unknown'
 }
-process.once('SIGINT', () => void close('SIGINT'))
-process.once('SIGTERM', () => void close('SIGTERM'))
+
+function openBrowser(url: string) {
+  const command = process.platform === 'darwin'
+    ? ['open', url]
+    : process.platform === 'win32'
+      ? ['rundll32', 'url.dll,FileProtocolHandler', url]
+      : ['xdg-open', url]
+  const child = spawn(command[0], command.slice(1), { detached: true, stdio: 'ignore' })
+  child.on('error', () => {})
+  child.unref()
+}
+
+function friendlyError(error: unknown) {
+  if ((error as NodeJS.ErrnoException)?.code === 'EADDRINUSE') {
+    return 'Port is already in use. Choose another one with --port <port>.'
+  }
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function run() {
+  const args = process.argv.slice(2)
+  if (args.includes('--help') || args.includes('-h')) {
+    help()
+    return
+  }
+  if (args.includes('--version') || args.includes('-v')) {
+    console.log(await version())
+    return
+  }
+
+  const commands = new Set<Command>(['dev', 'build', 'start'])
+  const command: Command = commands.has(args[0] as Command) ? args.shift() as Command : 'dev'
+  let root: string | undefined
+  let host: string | undefined
+  let port: number | undefined
+  let cdn: string | undefined
+  let outDir: string | undefined
+  let shouldOpen = false
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === '--host') host = valueAfter(args, index++)
+    else if (arg === '--port' || arg === '-p') port = Number(valueAfter(args, index++))
+    else if (arg === '--cdn') cdn = valueAfter(args, index++)
+    else if (arg === '--out-dir' || arg === '-o') outDir = valueAfter(args, index++)
+    else if (arg === '--open') shouldOpen = true
+    else if (arg.startsWith('-')) throw new Error(`Unknown option: ${arg}`)
+    else if (!root) root = arg
+    else throw new Error(`Unexpected argument: ${arg}`)
+  }
+
+  if (port !== undefined && (!Number.isInteger(port) || port < 0 || port > 65535)) {
+    throw new Error(`Invalid port: ${port}`)
+  }
+  if (command === 'build' && (host || port !== undefined || shouldOpen)) {
+    throw new Error('build does not accept --host, --port, or --open')
+  }
+  if (command === 'start' && (cdn || outDir)) {
+    throw new Error('start does not accept --cdn or --out-dir; configure these when building')
+  }
+  if (command === 'dev' && outDir) throw new Error('dev does not accept --out-dir')
+
+  if (command === 'build') {
+    const result = await buildProject({ root, outDir, cdn })
+    console.log(`Devjar built ${result.routes.length} routes`)
+    console.log(result.outDir)
+    return
+  }
+
+  const server = command === 'start'
+    ? await startBuiltServer({ root, host, port })
+    : await startDevServer({ root, host, port, cdn })
+  const browserHost = server.host === '0.0.0.0' || server.host === '::'
+    ? '127.0.0.1'
+    : server.host.includes(':') ? `[${server.host}]` : server.host
+  const url = `http://${browserHost}:${server.port}`
+  console.log(command === 'start' ? `Devjar serving build ${server.root}` : `Devjar serving ${server.root}`)
+  console.log(url)
+  if (shouldOpen) openBrowser(url)
+
+  let shuttingDown = false
+  async function close(signal: string) {
+    if (shuttingDown) return
+    shuttingDown = true
+    console.log(`\n${signal} received, shutting down…`)
+    try {
+      await server.close()
+    } catch (error) {
+      console.error(friendlyError(error))
+      process.exitCode = 1
+    }
+  }
+  process.once('SIGINT', () => void close('SIGINT'))
+  process.once('SIGTERM', () => void close('SIGTERM'))
+}
+
+run().catch(error => {
+  console.error(`Devjar: ${friendlyError(error)}`)
+  process.exitCode = 1
+})

--- a/src/bin/devjar.ts
+++ b/src/bin/devjar.ts
@@ -5,6 +5,12 @@ import { buildProject, startBuiltServer, startDevServer } from '../cli'
 
 type Command = 'dev' | 'build' | 'start'
 
+const useColor = Boolean(process.stdout.isTTY && !process.env.NO_COLOR)
+
+function style(code: number, value: string) {
+  return useColor ? `\u001b[${code}m${value}\u001b[0m` : value
+}
+
 function help() {
   console.log(`devjar [command] [root] [options]
 
@@ -104,9 +110,10 @@ async function run() {
       outDir: outDir || 'dist',
       cdn,
     })
-    console.log('Devjar build complete')
-    console.log(`  Output: ${result.outDir}`)
-    console.log(`  Routes: ${result.routes.length}`)
+    console.log(style(1, 'Devjar build complete'))
+    console.log('')
+    console.log(`Output  ${style(36, result.outDir)}`)
+    console.log(`Routes  ${result.routes.length}`)
     return
   }
 
@@ -126,9 +133,9 @@ async function run() {
     ? 'localhost'
     : server.host.includes(':') ? `[${server.host}]` : server.host
   const url = `http://${browserHost}:${server.port}/`
-  console.log(command === 'start' ? 'Devjar production server ready' : 'Devjar development server ready')
-  console.log(`  Local:   ${url}`)
-  console.log(command === 'start' ? `  Build:   ${server.root}` : `  Project: ${server.root}`)
+  console.log(style(1, command === 'start' ? 'Devjar production server ready' : 'Devjar development server ready'))
+  console.log('')
+  console.log(`Local  ${style(36, url)}`)
 
   let shuttingDown = false
   async function close(signal: string) {

--- a/src/bin/devjar.ts
+++ b/src/bin/devjar.ts
@@ -17,7 +17,7 @@ Commands:
 
 Options:
   --cdn <url>      ESM-compatible module CDN (dev and build)
-  --host <host>    Host to listen on (dev and start; default: 127.0.0.1)
+  --host <host>    Host to listen on (dev and start; default: localhost)
   --port <port>    Port to listen on (dev and start; default: 3000)
   -o, --out-dir   Build output relative to the project root (default: dist)
   -v, --version    Show the installed version
@@ -104,29 +104,31 @@ async function run() {
       outDir: outDir || 'dist',
       cdn,
     })
-    console.log(`Devjar built ${result.routes.length} routes`)
-    console.log(result.outDir)
+    console.log('Devjar build complete')
+    console.log(`  Output: ${result.outDir}`)
+    console.log(`  Routes: ${result.routes.length}`)
     return
   }
 
   const server = command === 'start'
     ? await startBuiltServer({
         root: root || join(process.cwd(), 'dist'),
-        host: host || '127.0.0.1',
+        host: host || 'localhost',
         port: port ?? 3000,
       })
     : await startDevServer({
         root: root || process.cwd(),
-        host: host || '127.0.0.1',
+        host: host || 'localhost',
         port: port ?? 3000,
         cdn,
       })
   const browserHost = server.host === '0.0.0.0' || server.host === '::'
-    ? '127.0.0.1'
+    ? 'localhost'
     : server.host.includes(':') ? `[${server.host}]` : server.host
-  const url = `http://${browserHost}:${server.port}`
-  console.log(command === 'start' ? `Devjar serving build ${server.root}` : `Devjar serving ${server.root}`)
-  console.log(url)
+  const url = `http://${browserHost}:${server.port}/`
+  console.log(command === 'start' ? 'Devjar production server ready' : 'Devjar development server ready')
+  console.log(`  Local:   ${url}`)
+  console.log(command === 'start' ? `  Build:   ${server.root}` : `  Project: ${server.root}`)
 
   let shuttingDown = false
   async function close(signal: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -387,7 +387,7 @@ export async function startDevServer(options: DevServerOptions) {
 
   let timer: NodeJS.Timeout | undefined
   const watcher = watch(root, { recursive: true }, (_event, filename) => {
-    if (!filename || /(?:^|[/\\])(?:\.git|\.devjar|node_modules|dist)(?:[/\\]|$)/.test(filename)) return
+    if (!filename || /(?:^|[/\\])(?:\.git|node_modules|dist)(?:[/\\]|$)/.test(filename)) return
     clearTimeout(timer)
     timer = setTimeout(() => {
       for (const response of events) response.write('event: change\ndata: {}\n\n')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,22 +37,27 @@ type BuiltManifest = {
 }
 
 export type DevServerOptions = {
-  root?: string
-  host?: string
-  port?: number
-  cdn?: string
+  root: string
+  host: string
+  port: number
+  cdn: string | undefined
 }
 
 export type BuildOptions = {
-  root?: string
-  outDir?: string
-  cdn?: string
+  root: string
+  outDir: string
+  cdn: string | undefined
 }
 
 export type StartServerOptions = {
-  root?: string
-  host?: string
-  port?: number
+  root: string
+  host: string
+  port: number
+}
+
+export type LoadProjectOptions = {
+  cdn: string | undefined
+  liveReload: boolean
 }
 
 function isInside(root: string, path: string) {
@@ -181,14 +186,14 @@ function packageDependencies(packageJson: PackageJson) {
   }
 }
 
-function projectCdn(packageJson: PackageJson, override?: string) {
+function projectCdn(packageJson: PackageJson, override: string | undefined) {
   return normalizeCdnHost(override || packageJson.devjar?.cdn || CDN_HOST)
 }
 
 export async function loadProject(
   root: string,
   route: string,
-  options: { cdn?: string, liveReload?: boolean } = {},
+  options: LoadProjectOptions,
 ): Promise<Project> {
   root = await realpath(root)
   const page = await resolvePage(root, route)
@@ -212,7 +217,7 @@ export async function loadProject(
     files,
     dependencies,
     cdn: projectCdn(packageJson, options.cdn),
-    liveReload: options.liveReload ?? true,
+    liveReload: options.liveReload,
     page: projectPath,
     route,
     tailwind: 'tailwindcss' in dependencies || '@tailwindcss/browser' in dependencies,
@@ -286,7 +291,7 @@ async function serveFile(
   response: ServerResponse,
   root: string,
   requestPath: string,
-  allowed?: Set<string>,
+  allowed: Set<string> | undefined,
 ) {
   const path = resolve(root, `.${normalize('/' + requestPath)}`)
   if (!isInside(root, path) || (allowed && !allowed.has(extname(path)))) return false
@@ -305,10 +310,10 @@ async function serveFile(
   return true
 }
 
-export async function startDevServer(options: DevServerOptions = {}) {
-  const root = await realpath(resolve(options.root || process.cwd()))
-  const host = options.host || '127.0.0.1'
-  const port = options.port ?? 3000
+export async function startDevServer(options: DevServerOptions) {
+  const root = await realpath(resolve(options.root))
+  const host = options.host
+  const port = options.port
   const events = new Set<ServerResponse>()
   const assetsRoot = await runtimeRoot()
 
@@ -345,7 +350,7 @@ export async function startDevServer(options: DevServerOptions = {}) {
       if (url.pathname === '/__devjar/project') {
         const route = url.searchParams.get('route') || '/'
         try {
-          const project = await loadProject(root, route, { cdn: options.cdn })
+          const project = await loadProject(root, route, { cdn: options.cdn, liveReload: true })
           send(request, response, 200, 'application/json; charset=utf-8', JSON.stringify(project))
         } catch (error) {
           send(request, response, 404, 'application/json; charset=utf-8', JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
@@ -353,11 +358,11 @@ export async function startDevServer(options: DevServerOptions = {}) {
         return
       }
       if (url.pathname === '/__devjar/runtime.js') {
-        if (!await serveFile(request, response, assetsRoot, 'index.js')) send(request, response, 500, 'text/plain', 'Devjar runtime is missing')
+        if (!await serveFile(request, response, assetsRoot, 'index.js', undefined)) send(request, response, 500, 'text/plain', 'Devjar runtime is missing')
         return
       }
       if (url.pathname.startsWith('/__devjar/')) {
-        if (!await serveFile(request, response, assetsRoot, url.pathname.slice('/__devjar/'.length))) send(request, response, 404, 'text/plain', 'Not found')
+        if (!await serveFile(request, response, assetsRoot, url.pathname.slice('/__devjar/'.length), undefined)) send(request, response, 404, 'text/plain', 'Not found')
         return
       }
       if (url.pathname.startsWith('/api/')) {
@@ -366,7 +371,7 @@ export async function startDevServer(options: DevServerOptions = {}) {
         }
         return
       }
-      if (await serveFile(request, response, join(root, 'public'), url.pathname.slice(1))) return
+      if (await serveFile(request, response, join(root, 'public'), url.pathname.slice(1), undefined)) return
       const packageJson = await readPackage(root)
       send(
         request,
@@ -494,9 +499,9 @@ async function copyRuntimeAssets(destination: string) {
   }
 }
 
-export async function buildProject(options: BuildOptions = {}) {
-  const root = await realpath(resolve(options.root || process.cwd()))
-  const outDir = resolve(root, options.outDir || '.devjar')
+export async function buildProject(options: BuildOptions) {
+  const root = await realpath(resolve(options.root))
+  const outDir = resolve(root, options.outDir)
   const outputBoundary = await existingDirectory(outDir)
   if (outDir === root || !isInside(root, outDir) || !isInside(root, outputBoundary)) {
     throw new Error('The build output must be a directory inside the project root')
@@ -532,14 +537,14 @@ export async function buildProject(options: BuildOptions = {}) {
   return { root, outDir, routes: Object.keys(routes) }
 }
 
-export async function startBuiltServer(options: StartServerOptions = {}) {
-  const requestedRoot = resolve(options.root || join(process.cwd(), '.devjar'))
+export async function startBuiltServer(options: StartServerOptions) {
+  const requestedRoot = resolve(options.root)
   if (!await directoryExists(requestedRoot)) {
     throw new Error(`Devjar build directory not found: ${requestedRoot}`)
   }
   const root = await realpath(requestedRoot)
-  const host = options.host || '127.0.0.1'
-  const port = options.port ?? 3000
+  const host = options.host
+  const port = options.port
   const manifest = JSON.parse(await readFile(join(root, 'manifest.json'), 'utf8')) as BuiltManifest
   if (manifest.version !== 1) throw new Error(`Unsupported Devjar build version: ${manifest.version}`)
   const shell = await readFile(join(root, 'index.html'), 'utf8')
@@ -560,7 +565,7 @@ export async function startBuiltServer(options: StartServerOptions = {}) {
         return
       }
       if (url.pathname.startsWith('/__devjar/')) {
-        if (!await serveFile(request, response, join(root, '__devjar'), url.pathname.slice('/__devjar/'.length))) {
+        if (!await serveFile(request, response, join(root, '__devjar'), url.pathname.slice('/__devjar/'.length), undefined)) {
           send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
         }
         return
@@ -571,7 +576,7 @@ export async function startBuiltServer(options: StartServerOptions = {}) {
         }
         return
       }
-      if (await serveFile(request, response, join(root, 'public'), url.pathname.slice(1))) return
+      if (await serveFile(request, response, join(root, 'public'), url.pathname.slice(1), undefined)) return
       send(request, response, 200, 'text/html; charset=utf-8', shell)
     } catch (error) {
       send(request, response, 500, 'text/plain; charset=utf-8', error instanceof Error ? error.stack || error.message : String(error))

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,11 @@
 import { createReadStream } from 'node:fs'
-import { readFile, realpath, stat } from 'node:fs/promises'
-import { createServer, type ServerResponse } from 'node:http'
-import { extname, join, normalize, relative, resolve, sep } from 'node:path'
+import { cp, mkdir, readdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { dirname, extname, join, normalize, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { watch } from 'node:fs'
 import { transformSync } from 'oxc-transform'
-import { CDN_HOST, createEsmShResolver } from './_cdn'
+import { CDN_HOST, createEsmShResolver, normalizeCdnHost } from './_cdn'
 import { getTransformErrorMessage, getTransformOptions } from './_transform'
 
 const sourceExtensions = ['.tsx', '.ts', '.jsx', '.js']
@@ -13,17 +13,43 @@ const localExtensions = [...sourceExtensions, '.css']
 type PackageJson = {
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
+  devjar?: {
+    cdn?: string
+  }
 }
 
 type Project = {
   files: Record<string, string>
   dependencies: Record<string, string>
+  cdn: string
+  liveReload: boolean
   page: string
   route: string
   tailwind: boolean
 }
 
+type BuiltManifest = {
+  version: 1
+  dependencies: Record<string, string>
+  cdn: string
+  routes: Record<string, Project>
+  notFound?: Project
+}
+
 export type DevServerOptions = {
+  root?: string
+  host?: string
+  port?: number
+  cdn?: string
+}
+
+export type BuildOptions = {
+  root?: string
+  outDir?: string
+  cdn?: string
+}
+
+export type StartServerOptions = {
   root?: string
   host?: string
   port?: number
@@ -40,6 +66,33 @@ async function fileExists(path: string) {
   } catch {
     return false
   }
+}
+
+async function directoryExists(path: string) {
+  try {
+    return (await stat(path)).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+async function existingDirectory(path: string): Promise<string> {
+  if (await directoryExists(path)) return realpath(path)
+  const parent = dirname(path)
+  if (parent === path) return path
+  return existingDirectory(parent)
+}
+
+async function runtimeRoot() {
+  const moduleRoot = fileURLToPath(new URL('.', import.meta.url))
+  return await fileExists(join(moduleRoot, 'index.js'))
+    ? moduleRoot
+    : resolve(moduleRoot, '../dist')
+}
+
+function normalizeRoute(route: string) {
+  const cleanRoute = route.replace(/^\/+|\/+$/g, '')
+  return cleanRoute ? `/${cleanRoute}` : '/'
 }
 
 async function findSourceFile(path: string) {
@@ -93,7 +146,7 @@ async function collectFiles(root: string, entry: string) {
 }
 
 function routeCandidates(route: string) {
-  const cleanRoute = route.replace(/^\/+|\/+$/g, '')
+  const cleanRoute = normalizeRoute(route).slice(1)
   const base = cleanRoute || 'index'
   const candidates = sourceExtensions.flatMap(extension => [
     `${base}${extension}`,
@@ -121,7 +174,23 @@ async function readPackage(root: string): Promise<PackageJson> {
   }
 }
 
-export async function loadProject(root: string, route: string): Promise<Project> {
+function packageDependencies(packageJson: PackageJson) {
+  return {
+    ...packageJson.devDependencies,
+    ...packageJson.dependencies,
+  }
+}
+
+function projectCdn(packageJson: PackageJson, override?: string) {
+  return normalizeCdnHost(override || packageJson.devjar?.cdn || CDN_HOST)
+}
+
+export async function loadProject(
+  root: string,
+  route: string,
+  options: { cdn?: string, liveReload?: boolean } = {},
+): Promise<Project> {
+  root = await realpath(root)
   const page = await resolvePage(root, route)
   if (!page) throw new Error(`No page found for /${route.replace(/^\/+/, '')}`)
   const packageJson = await readPackage(root)
@@ -137,37 +206,46 @@ export async function loadProject(root: string, route: string): Promise<Project>
     files[filename] = output.code
   }
 
-  const dependencies = {
-    ...packageJson.devDependencies,
-    ...packageJson.dependencies,
-  }
+  const dependencies = packageDependencies(packageJson)
 
   return {
     files,
     dependencies,
+    cdn: projectCdn(packageJson, options.cdn),
+    liveReload: options.liveReload ?? true,
     page: projectPath,
     route,
     tailwind: 'tailwindcss' in dependencies || '@tailwindcss/browser' in dependencies,
   }
 }
 
-function send(response: ServerResponse, status: number, type: string, body: string | Buffer) {
+function send(
+  request: IncomingMessage,
+  response: ServerResponse,
+  status: number,
+  type: string,
+  body: string | Buffer,
+) {
   response.writeHead(status, {
     'Content-Type': type,
     'Cache-Control': 'no-store',
   })
-  response.end(body)
+  response.end(request.method === 'HEAD' ? undefined : body)
 }
 
-function html(dependencies: Record<string, string>) {
-  const resolveModule = createEsmShResolver(dependencies)
+function html(dependencies: Record<string, string>, cdn: string) {
+  const resolveModule = createEsmShResolver(dependencies, cdn)
+  const resolveRuntimeModule = createEsmShResolver({
+    ...dependencies,
+    'es-module-lexer': '1.6.0',
+  }, cdn)
   const imports = {
     react: resolveModule('react'),
     'react-dom': resolveModule('react-dom'),
     'react/jsx-runtime': resolveModule('react/jsx-runtime'),
     'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
     'react-dom/client': resolveModule('react-dom/client'),
-    'es-module-lexer': `${CDN_HOST}/es-module-lexer@1.6.0`,
+    'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
     devjar: '/__devjar/runtime.js',
   }
   return `<!doctype html>
@@ -203,7 +281,13 @@ const contentTypes: Record<string, string> = {
   '.woff2': 'font/woff2',
 }
 
-async function serveFile(response: ServerResponse, root: string, requestPath: string, allowed?: Set<string>) {
+async function serveFile(
+  request: IncomingMessage,
+  response: ServerResponse,
+  root: string,
+  requestPath: string,
+  allowed?: Set<string>,
+) {
   const path = resolve(root, `.${normalize('/' + requestPath)}`)
   if (!isInside(root, path) || (allowed && !allowed.has(extname(path)))) return false
   if (!(await fileExists(path))) return false
@@ -216,19 +300,17 @@ async function serveFile(response: ServerResponse, root: string, requestPath: st
     'Content-Length': info.size,
     'Cache-Control': 'no-store',
   })
-  createReadStream(canonicalPath).pipe(response)
+  if (request.method === 'HEAD') response.end()
+  else createReadStream(canonicalPath).pipe(response)
   return true
 }
 
 export async function startDevServer(options: DevServerOptions = {}) {
-  const root = resolve(options.root || process.cwd())
+  const root = await realpath(resolve(options.root || process.cwd()))
   const host = options.host || '127.0.0.1'
   const port = options.port ?? 3000
   const events = new Set<ServerResponse>()
-  const moduleRoot = fileURLToPath(new URL('.', import.meta.url))
-  const runtimeRoot = await fileExists(join(moduleRoot, 'index.js'))
-    ? moduleRoot
-    : resolve(moduleRoot, '../dist')
+  const assetsRoot = await runtimeRoot()
 
   if (!(await fileExists(join(root, 'pages/index.tsx')))
     && !(await fileExists(join(root, 'pages/index.ts')))
@@ -251,6 +333,10 @@ export async function startDevServer(options: DevServerOptions = {}) {
           'Cache-Control': 'no-cache',
           Connection: 'keep-alive',
         })
+        if (request.method === 'HEAD') {
+          response.end()
+          return
+        }
         response.write(': connected\n\n')
         events.add(response)
         request.on('close', () => events.delete(response))
@@ -259,38 +345,44 @@ export async function startDevServer(options: DevServerOptions = {}) {
       if (url.pathname === '/__devjar/project') {
         const route = url.searchParams.get('route') || '/'
         try {
-          const project = await loadProject(root, route)
-          send(response, 200, 'application/json; charset=utf-8', JSON.stringify(project))
+          const project = await loadProject(root, route, { cdn: options.cdn })
+          send(request, response, 200, 'application/json; charset=utf-8', JSON.stringify(project))
         } catch (error) {
-          send(response, 404, 'application/json; charset=utf-8', JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+          send(request, response, 404, 'application/json; charset=utf-8', JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
         }
         return
       }
       if (url.pathname === '/__devjar/runtime.js') {
-        if (!await serveFile(response, runtimeRoot, 'index.js')) send(response, 500, 'text/plain', 'Devjar runtime is missing')
+        if (!await serveFile(request, response, assetsRoot, 'index.js')) send(request, response, 500, 'text/plain', 'Devjar runtime is missing')
         return
       }
       if (url.pathname.startsWith('/__devjar/')) {
-        if (!await serveFile(response, runtimeRoot, url.pathname.slice('/__devjar/'.length))) send(response, 404, 'text/plain', 'Not found')
+        if (!await serveFile(request, response, assetsRoot, url.pathname.slice('/__devjar/'.length))) send(request, response, 404, 'text/plain', 'Not found')
         return
       }
       if (url.pathname.startsWith('/api/')) {
-        if (!await serveFile(response, join(root, 'api'), url.pathname.slice('/api/'.length), new Set(['.json', '.txt']))) {
-          send(response, 404, 'text/plain; charset=utf-8', 'Not found')
+        if (!await serveFile(request, response, join(root, 'api'), url.pathname.slice('/api/'.length), new Set(['.json', '.txt']))) {
+          send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
         }
         return
       }
-      if (await serveFile(response, join(root, 'public'), url.pathname.slice(1))) return
+      if (await serveFile(request, response, join(root, 'public'), url.pathname.slice(1))) return
       const packageJson = await readPackage(root)
-      send(response, 200, 'text/html; charset=utf-8', html({ ...packageJson.devDependencies, ...packageJson.dependencies }))
+      send(
+        request,
+        response,
+        200,
+        'text/html; charset=utf-8',
+        html(packageDependencies(packageJson), projectCdn(packageJson, options.cdn)),
+      )
     } catch (error) {
-      send(response, 500, 'text/plain; charset=utf-8', error instanceof Error ? error.stack || error.message : String(error))
+      send(request, response, 500, 'text/plain; charset=utf-8', error instanceof Error ? error.stack || error.message : String(error))
     }
   })
 
   let timer: NodeJS.Timeout | undefined
   const watcher = watch(root, { recursive: true }, (_event, filename) => {
-    if (!filename || /(?:^|[/\\])(?:\.git|node_modules|dist)(?:[/\\]|$)/.test(filename)) return
+    if (!filename || /(?:^|[/\\])(?:\.git|\.devjar|node_modules|dist)(?:[/\\]|$)/.test(filename)) return
     clearTimeout(timer)
     timer = setTimeout(() => {
       for (const response of events) response.write('event: change\ndata: {}\n\n')
@@ -316,6 +408,185 @@ export async function startDevServer(options: DevServerOptions = {}) {
       for (const response of events) response.end()
       events.clear()
 
+      const forceClose = setTimeout(() => server.closeAllConnections(), 5_000)
+      forceClose.unref()
+      server.close(error => {
+        clearTimeout(forceClose)
+        if (error && (error as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING') reject(error)
+        else resolvePromise()
+      })
+      server.closeIdleConnections()
+    })
+    return closePromise
+  }
+
+  return {
+    host,
+    port: (server.address() as import('node:net').AddressInfo).port,
+    root,
+    close,
+  }
+}
+
+async function discoverRoutes(root: string) {
+  const pagesRoot = join(root, 'pages')
+  if (!await directoryExists(pagesRoot)) {
+    throw new Error(`Devjar expected a pages directory in ${root}`)
+  }
+
+  const files: string[] = []
+  const visit = async (directory: string) => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name)
+      if (entry.isDirectory()) await visit(path)
+      else if (entry.isFile() && sourceExtensions.includes(extname(entry.name))) files.push(path)
+    }
+  }
+  await visit(pagesRoot)
+
+  const routes = new Map<string, string>()
+  let notFound: string | undefined
+  for (const path of files.sort()) {
+    let pagePath = relative(pagesRoot, path).split(sep).join('/')
+    pagePath = pagePath.slice(0, -extname(pagePath).length)
+    if (pagePath === '404') notFound = path
+    const route = normalizeRoute(pagePath.replace(/(?:^|\/)index$/, ''))
+    if (routes.has(route)) {
+      throw new Error(`Multiple pages resolve to ${route}: ${relative(root, routes.get(route)!)} and ${relative(root, path)}`)
+    }
+    routes.set(route, path)
+  }
+
+  if (!routes.has('/')) {
+    throw new Error(`Devjar expected an index page in ${pagesRoot}`)
+  }
+  return { routes, notFound }
+}
+
+async function copyApiFiles(source: string, destination: string) {
+  if (!await directoryExists(source)) return
+  for (const entry of await readdir(source, { withFileTypes: true })) {
+    const sourcePath = join(source, entry.name)
+    const destinationPath = join(destination, entry.name)
+    if (entry.isDirectory()) await copyApiFiles(sourcePath, destinationPath)
+    else if (entry.isFile() && (extname(entry.name) === '.json' || extname(entry.name) === '.txt')) {
+      await mkdir(dirname(destinationPath), { recursive: true })
+      await cp(sourcePath, destinationPath)
+    }
+  }
+}
+
+async function copyRuntimeAssets(destination: string) {
+  const source = await runtimeRoot()
+  await mkdir(destination, { recursive: true })
+  const assets = [
+    ['index.js', 'runtime.js'],
+    ['client.js', 'client.js'],
+    ['transform-worker.js', 'transform-worker.js'],
+    ['transform.wasi-browser.js', 'transform.wasi-browser.js'],
+    ['transform.wasm32-wasi.wasm', 'transform.wasm32-wasi.wasm'],
+    ['wasi-worker-browser.js', 'wasi-worker-browser.js'],
+  ] as const
+  for (const [sourceName, destinationName] of assets) {
+    const sourcePath = join(source, sourceName)
+    if (!await fileExists(sourcePath)) throw new Error(`Devjar runtime asset is missing: ${sourceName}`)
+    await cp(sourcePath, join(destination, destinationName))
+  }
+}
+
+export async function buildProject(options: BuildOptions = {}) {
+  const root = await realpath(resolve(options.root || process.cwd()))
+  const outDir = resolve(root, options.outDir || '.devjar')
+  const outputBoundary = await existingDirectory(outDir)
+  if (outDir === root || !isInside(root, outDir) || !isInside(root, outputBoundary)) {
+    throw new Error('The build output must be a directory inside the project root')
+  }
+
+  const packageJson = await readPackage(root)
+  const dependencies = packageDependencies(packageJson)
+  const cdn = projectCdn(packageJson, options.cdn)
+  const discovered = await discoverRoutes(root)
+  const routes: Record<string, Project> = {}
+  let notFound: Project | undefined
+
+  for (const route of discovered.routes.keys()) {
+    const project = await loadProject(root, route, { cdn, liveReload: false })
+    routes[route] = project
+    if (discovered.notFound && resolve(root, project.page) === discovered.notFound) notFound = project
+  }
+  if (discovered.notFound && !notFound) {
+    notFound = await loadProject(root, '/__devjar_not_found__', { cdn, liveReload: false })
+  }
+
+  const manifest: BuiltManifest = { version: 1, dependencies, cdn, routes, notFound }
+  await rm(outDir, { recursive: true, force: true })
+  await mkdir(outDir, { recursive: true })
+  await writeFile(join(outDir, 'manifest.json'), JSON.stringify(manifest))
+  await writeFile(join(outDir, 'index.html'), html(dependencies, cdn))
+  await copyRuntimeAssets(join(outDir, '__devjar'))
+  if (await directoryExists(join(root, 'public'))) {
+    await cp(join(root, 'public'), join(outDir, 'public'), { recursive: true })
+  }
+  await copyApiFiles(join(root, 'api'), join(outDir, 'api'))
+
+  return { root, outDir, routes: Object.keys(routes) }
+}
+
+export async function startBuiltServer(options: StartServerOptions = {}) {
+  const requestedRoot = resolve(options.root || join(process.cwd(), '.devjar'))
+  if (!await directoryExists(requestedRoot)) {
+    throw new Error(`Devjar build directory not found: ${requestedRoot}`)
+  }
+  const root = await realpath(requestedRoot)
+  const host = options.host || '127.0.0.1'
+  const port = options.port ?? 3000
+  const manifest = JSON.parse(await readFile(join(root, 'manifest.json'), 'utf8')) as BuiltManifest
+  if (manifest.version !== 1) throw new Error(`Unsupported Devjar build version: ${manifest.version}`)
+  const shell = await readFile(join(root, 'index.html'), 'utf8')
+
+  const server = createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url || '/', `http://${request.headers.host || 'localhost'}`)
+      if (request.method !== 'GET' && request.method !== 'HEAD') {
+        response.writeHead(405, { Allow: 'GET, HEAD' })
+        response.end(request.method === 'HEAD' ? undefined : 'Method not allowed')
+        return
+      }
+      if (url.pathname === '/__devjar/project') {
+        const route = normalizeRoute(url.searchParams.get('route') || '/')
+        const project = manifest.routes[route] || manifest.notFound
+        if (project) send(request, response, 200, 'application/json; charset=utf-8', JSON.stringify(project))
+        else send(request, response, 404, 'application/json; charset=utf-8', JSON.stringify({ error: `No page found for ${route}` }))
+        return
+      }
+      if (url.pathname.startsWith('/__devjar/')) {
+        if (!await serveFile(request, response, join(root, '__devjar'), url.pathname.slice('/__devjar/'.length))) {
+          send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
+        }
+        return
+      }
+      if (url.pathname.startsWith('/api/')) {
+        if (!await serveFile(request, response, join(root, 'api'), url.pathname.slice('/api/'.length), new Set(['.json', '.txt']))) {
+          send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
+        }
+        return
+      }
+      if (await serveFile(request, response, join(root, 'public'), url.pathname.slice(1))) return
+      send(request, response, 200, 'text/html; charset=utf-8', shell)
+    } catch (error) {
+      send(request, response, 500, 'text/plain; charset=utf-8', error instanceof Error ? error.stack || error.message : String(error))
+    }
+  })
+
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once('error', reject)
+    server.listen(port, host, resolvePromise)
+  })
+
+  let closePromise: Promise<void> | undefined
+  const close = () => {
+    if (closePromise) return closePromise
+    closePromise = new Promise<void>((resolvePromise, reject) => {
       const forceClose = setTimeout(() => server.closeAllConnections(), 5_000)
       forceClose.unref()
       server.close(error => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -486,6 +486,7 @@ async function copyRuntimeAssets(destination: string) {
   await mkdir(destination, { recursive: true })
   const assets = [
     ['index.js', 'runtime.js'],
+    ['_cdn.js', '_cdn.js'],
     ['client.js', 'client.js'],
     ['transform-worker.js', 'transform-worker.js'],
     ['transform.wasi-browser.js', 'transform.wasi-browser.js'],

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,10 +1,13 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { DevJar } from 'devjar'
+import { createEsmShResolver } from './_cdn'
 
 type Project = {
   files: Record<string, string>
   dependencies: Record<string, string>
+  cdn: string
+  liveReload: boolean
   page: string
   tailwind: boolean
 }
@@ -25,6 +28,10 @@ function App() {
   const [project, setProject] = useState<Project | null>(null)
   const [error, setError] = useState<unknown>(null)
   const previewRef = useRef<HTMLIFrameElement>(null)
+  const resolveModule = useMemo(
+    () => project ? createEsmShResolver(project.dependencies, project.cdn) : undefined,
+    [project?.cdn, project?.dependencies],
+  )
   const load = useCallback((route = location.pathname) => {
     getProject(route).then(value => {
       setProject(value)
@@ -34,25 +41,32 @@ function App() {
 
   useEffect(() => {
     load()
-    const events = new EventSource('/__devjar/events')
-    const reload = () => load(location.pathname)
     const navigateHistory = () => load(location.pathname)
-    events.addEventListener('change', reload)
     addEventListener('popstate', navigateHistory)
     return () => {
-      events.removeEventListener('change', reload)
-      events.close()
       removeEventListener('popstate', navigateHistory)
     }
   }, [load])
+
+  useEffect(() => {
+    if (!project?.liveReload) return
+    const events = new EventSource('/__devjar/events')
+    const reload = () => load(location.pathname)
+    events.addEventListener('change', reload)
+    return () => {
+      events.removeEventListener('change', reload)
+      events.close()
+    }
+  }, [load, project?.liveReload])
 
   useEffect(() => {
     const iframe = previewRef.current
     if (!iframe) return
     let previewDocument: Document | null = null
     const navigate = (event: MouseEvent) => {
-      const anchor = event.target instanceof Element
-        ? event.target.closest<HTMLAnchorElement>('a[href]')
+      const target = event.target as Element | null
+      const anchor = typeof target?.closest === 'function'
+        ? target.closest<HTMLAnchorElement>('a[href]')
         : null
       if (!anchor || event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
       if ((anchor.target && anchor.target !== '_self') || anchor.hasAttribute('download')) return
@@ -86,7 +100,7 @@ function App() {
     <>
       <DevJar
         files={project.files}
-        dependencies={project.dependencies}
+        resolveModule={resolveModule}
         transform={false}
         tailwind={project.tailwind}
         onError={value => setError(value || null)}

--- a/src/core.ts
+++ b/src/core.ts
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useState, useId, useMemo, useRef } from 'react'
 import { createModule } from './module'
 import type { ModuleRuntime } from './module'
 import { init, parse } from 'es-module-lexer'
-import { createEsmShResolver } from './_cdn'
+import { CDN_HOST, createEsmShResolver } from './_cdn'
 
 type ResolveModule = (specifier: string) => string
 type RenderFunction = (
@@ -320,7 +320,7 @@ function useLiveCode({
   transformWorkerUrl?: string | URL
 }) {
   const resolveModule = useMemo(
-    () => customResolveModule || createEsmShResolver(dependencies),
+    () => customResolveModule || createEsmShResolver(dependencies || {}, CDN_HOST),
     [customResolveModule, dependencies]
   )
   const iframeRef = useRef<HTMLIFrameElement | null>(null)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -141,7 +141,7 @@ describe('production build', () => {
     await cp(dashboardRoot, projectRoot, { recursive: true })
     const result = await buildProject({
       root: projectRoot,
-      outDir: '.devjar',
+      outDir: 'dist',
       cdn: 'https://modules.example.test/',
     })
     buildRoot = result.outDir

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,11 +1,14 @@
-import { afterAll, describe, expect, test } from 'bun:test'
-import { resolve } from 'node:path'
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { cp, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
 import { init, parse } from 'es-module-lexer'
-import { loadProject, startDevServer } from '../src/cli'
+import { buildProject, loadProject, startBuiltServer, startDevServer } from '../src/cli'
 import { createEsmShResolver } from '../src/_cdn'
 import { replaceImports } from '../src/core'
 
 const root = resolve(import.meta.dir, '../examples/basic')
+const dashboardRoot = resolve(import.meta.dir, '../examples/dashboard')
 
 describe('project loading', () => {
   test('keeps parent-directory imports in the local module graph', async () => {
@@ -45,6 +48,24 @@ describe('project loading', () => {
     const project = await loadProject(root, '/about')
     expect(project.page).toBe('pages/about.tsx')
   })
+
+  test('uses a custom module CDN', async () => {
+    const project = await loadProject(root, '/', { cdn: 'https://modules.example.test/' })
+    expect(project.cdn).toBe('https://modules.example.test')
+    expect(createEsmShResolver(project.dependencies, project.cdn)('react')).toBe(
+      'https://modules.example.test/react@19.2.0?dev',
+    )
+  })
+
+  test('loads the hosted dashboard example and its 404 page', async () => {
+    const project = await loadProject(dashboardRoot, '/')
+    expect(project.dependencies['lucide-react']).toBe('0.542.0')
+    expect(project.files['./components/project-card.tsx']).toBeDefined()
+    expect(project.files['./lib/projects.ts']).toBeDefined()
+
+    const notFound = await loadProject(dashboardRoot, '/missing')
+    expect(notFound.page).toBe('pages/404.tsx')
+  })
 })
 
 describe('dev server', () => {
@@ -62,6 +83,7 @@ describe('dev server', () => {
     expect(shellSource).toContain('/__devjar/client.js')
     expect(shellSource).toContain('Devjar could not start')
     expect(shellSource).toContain(`Devjar could not start:\\n\\n`)
+    expect(await (await fetch(`${base}/about`, { method: 'HEAD' })).text()).toBe('')
     const bootstrap = shellSource.match(/<script>\n([\s\S]+)<\/script><script type="module"/)?.[1]
     expect(() => new Function(bootstrap || '')).not.toThrow()
 
@@ -71,9 +93,10 @@ describe('dev server', () => {
     await init
     expect(() => parse(client)).not.toThrow()
     expect(client).not.toContain('function dependencyUrl')
-    expect(client).toContain('dependencies: project.dependencies')
+    expect(client).toContain('createEsmShResolver(project.dependencies, project.cdn)')
     expect(client).toContain('transform: false')
     expect(client).toContain('tailwind: project.tailwind')
+    expect(client).toContain('project?.liveReload')
     expect(client).toContain('popstate')
     expect(client).toContain('history.pushState')
 
@@ -93,5 +116,60 @@ describe('dev server', () => {
 
     await server.close()
     await expect(server.close()).resolves.toBeUndefined()
+  })
+})
+
+describe('production build', () => {
+  let projectRoot = ''
+  let buildRoot = ''
+  let server: Awaited<ReturnType<typeof startBuiltServer>> | undefined
+
+  beforeAll(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), 'devjar-build-'))
+    await cp(dashboardRoot, projectRoot, { recursive: true })
+    const result = await buildProject({
+      root: projectRoot,
+      cdn: 'https://modules.example.test/',
+    })
+    buildRoot = result.outDir
+  })
+
+  afterAll(async () => {
+    await server?.close()
+    if (projectRoot) await rm(projectRoot, { recursive: true, force: true })
+  })
+
+  test('writes routes, runtime assets, public files, and static APIs', async () => {
+    const manifest = JSON.parse(await readFile(join(buildRoot, 'manifest.json'), 'utf8'))
+    expect(Object.keys(manifest.routes).sort()).toEqual(['/', '/404', '/projects', '/settings'])
+    expect(manifest.routes['/'].liveReload).toBe(false)
+    expect(manifest.cdn).toBe('https://modules.example.test')
+    expect(await readFile(join(buildRoot, '__devjar/client.js'), 'utf8')).toContain('__devjar/project')
+    expect(await readFile(join(buildRoot, 'api/projects.json'), 'utf8')).toContain('Mobile refresh')
+    expect(await readFile(join(buildRoot, 'public/mark.svg'), 'utf8')).toContain('<svg')
+  })
+
+  test('refuses to clean an output directory outside the project', async () => {
+    await expect(buildProject({ root: projectRoot, outDir: '../outside' })).rejects.toThrow(
+      'The build output must be a directory inside the project root',
+    )
+  })
+
+  test('serves prebuilt projects without development events', async () => {
+    server = await startBuiltServer({ root: buildRoot, port: 0 })
+    const base = `http://${server.host}:${server.port}`
+
+    const shell = await (await fetch(`${base}/projects`)).text()
+    expect(shell).toContain('https://modules.example.test/react@19.2.0?dev')
+    const project = await (await fetch(`${base}/__devjar/project?route=%2Fprojects`)).json()
+    expect(project.page).toBe('pages/projects.tsx')
+    expect(project.liveReload).toBe(false)
+    const notFound = await (await fetch(`${base}/__devjar/project?route=%2Fmissing`)).json()
+    expect(notFound.page).toBe('pages/404.tsx')
+    expect((await fetch(`${base}/__devjar/events`)).status).toBe(404)
+    expect(await (await fetch(`${base}/api/projects.json`)).json()).toHaveLength(4)
+    expect(await (await fetch(`${base}/mark.svg`)).text()).toContain('<svg')
+
+    await server.close()
   })
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -4,11 +4,12 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { init, parse } from 'es-module-lexer'
 import { buildProject, loadProject, startBuiltServer, startDevServer } from '../src/cli'
-import { createEsmShResolver } from '../src/_cdn'
+import { CDN_HOST, createEsmShResolver } from '../src/_cdn'
 import { replaceImports } from '../src/core'
 
 const root = resolve(import.meta.dir, '../examples/basic')
 const dashboardRoot = resolve(import.meta.dir, '../examples/dashboard')
+const liveProjectOptions = { cdn: undefined, liveReload: true }
 
 describe('project loading', () => {
   test('keeps parent-directory imports in the local module graph', async () => {
@@ -25,13 +26,16 @@ describe('project loading', () => {
   })
 
   test('shares the runtime CDN resolver', () => {
-    const resolveModule = createEsmShResolver({ react: '19.1.0', '@scope/pkg': '^2.0.0' })
+    const resolveModule = createEsmShResolver(
+      { react: '19.1.0', '@scope/pkg': '^2.0.0' },
+      CDN_HOST,
+    )
     expect(resolveModule('react/jsx-runtime')).toBe('https://esm.sh/react@19.1.0/jsx-runtime?dev')
     expect(resolveModule('@scope/pkg/subpath')).toBe('https://esm.sh/@scope/pkg@%5E2.0.0/subpath')
   })
 
   test('loads a page and its local dependency graph', async () => {
-    const project = await loadProject(root, '/')
+    const project = await loadProject(root, '/', liveProjectOptions)
     expect(project.page).toBe('pages/index.tsx')
     expect(Object.keys(project.files).sort()).toEqual([
       './components/shell.tsx',
@@ -45,12 +49,15 @@ describe('project loading', () => {
   })
 
   test('loads a second page route', async () => {
-    const project = await loadProject(root, '/about')
+    const project = await loadProject(root, '/about', liveProjectOptions)
     expect(project.page).toBe('pages/about.tsx')
   })
 
   test('uses a custom module CDN', async () => {
-    const project = await loadProject(root, '/', { cdn: 'https://modules.example.test/' })
+    const project = await loadProject(root, '/', {
+      cdn: 'https://modules.example.test/',
+      liveReload: true,
+    })
     expect(project.cdn).toBe('https://modules.example.test')
     expect(createEsmShResolver(project.dependencies, project.cdn)('react')).toBe(
       'https://modules.example.test/react@19.2.0?dev',
@@ -58,12 +65,12 @@ describe('project loading', () => {
   })
 
   test('loads the hosted dashboard example and its 404 page', async () => {
-    const project = await loadProject(dashboardRoot, '/')
+    const project = await loadProject(dashboardRoot, '/', liveProjectOptions)
     expect(project.dependencies['lucide-react']).toBe('0.542.0')
     expect(project.files['./components/project-card.tsx']).toBeDefined()
     expect(project.files['./lib/projects.ts']).toBeDefined()
 
-    const notFound = await loadProject(dashboardRoot, '/missing')
+    const notFound = await loadProject(dashboardRoot, '/missing', liveProjectOptions)
     expect(notFound.page).toBe('pages/404.tsx')
   })
 })
@@ -73,7 +80,12 @@ describe('dev server', () => {
   afterAll(async () => server?.close())
 
   test('serves pages, static APIs, public files, and runtime assets', async () => {
-    server = await startDevServer({ root, port: 0 })
+    server = await startDevServer({
+      root,
+      host: '127.0.0.1',
+      port: 0,
+      cdn: undefined,
+    })
     const base = `http://${server.host}:${server.port}`
 
     const shell = await fetch(`${base}/about`)
@@ -129,6 +141,7 @@ describe('production build', () => {
     await cp(dashboardRoot, projectRoot, { recursive: true })
     const result = await buildProject({
       root: projectRoot,
+      outDir: '.devjar',
       cdn: 'https://modules.example.test/',
     })
     buildRoot = result.outDir
@@ -150,13 +163,17 @@ describe('production build', () => {
   })
 
   test('refuses to clean an output directory outside the project', async () => {
-    await expect(buildProject({ root: projectRoot, outDir: '../outside' })).rejects.toThrow(
+    await expect(buildProject({
+      root: projectRoot,
+      outDir: '../outside',
+      cdn: undefined,
+    })).rejects.toThrow(
       'The build output must be a directory inside the project root',
     )
   })
 
   test('serves prebuilt projects without development events', async () => {
-    server = await startBuiltServer({ root: buildRoot, port: 0 })
+    server = await startBuiltServer({ root: buildRoot, host: '127.0.0.1', port: 0 })
     const base = `http://${server.host}:${server.port}`
 
     const shell = await (await fetch(`${base}/projects`)).text()

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -158,6 +158,7 @@ describe('production build', () => {
     expect(manifest.routes['/'].liveReload).toBe(false)
     expect(manifest.cdn).toBe('https://modules.example.test')
     expect(await readFile(join(buildRoot, '__devjar/client.js'), 'utf8')).toContain('__devjar/project')
+    expect(await readFile(join(buildRoot, '__devjar/_cdn.js'), 'utf8')).toContain('createEsmShResolver')
     expect(await readFile(join(buildRoot, 'api/projects.json'), 'utf8')).toContain('Mobile refresh')
     expect(await readFile(join(buildRoot, 'public/mark.svg'), 'utf8')).toContain('<svg')
   })


### PR DESCRIPTION
## Summary
- add `dev`, `build`, and `start` commands while keeping bare `devjar` as the development-server alias
- make the ESM module CDN configurable with `--cdn` or `package.json`, and carry it through development and production runtimes
- emit self-contained `dist` builds with pre-transformed routes, runtime assets, public files, and static API data
- align the default output with Vite's deployable-build convention while retaining `--out-dir`
- use `localhost` by default and report a compact, colored `Local` URL without opening a browser or printing the project path
- add `--version`, friendlier CLI errors, safe output cleanup, correct HEAD responses, and production serving without file watchers
- redesign both examples with compact, restrained brutalist layouts and accessible dark-button contrast
- add a dashboard example that demonstrates routing, a 404 page, Tailwind, CDN dependencies, static API data, and public assets
- fix cross-frame link interception and include the CDN helper required by production runtime builds
- add CLI/package checks to CI and publishing and prepare the feature release as `0.11.0`

No Next.js configuration support is added.

## Verification
- `pnpm build:site`
- `pnpm test` (10 tests, 56 assertions)
- `pnpm test:package`, including packaged-CLI assertions for default `dist` output and `localhost`
- browser-tested both examples at desktop width and the dashboard at 390px
- browser-tested dashboard static data, public assets, dark-button contrast, and client-side navigation
- exercised `devjar build` and `devjar start` end to end for both examples