### PR TITLE
Render CLI projects without an iframe

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,69 @@
+# CLI performance roadmap
+
+Work through these changes in order. Measure cold startup, navigation, and edit-to-render time after each item before moving to the next.
+
+## 1. Separate the CLI runtime
+
+Status: complete
+
+- Keep the iframe-based `<DevJar>` runtime for embedded editors and untrusted snippets.
+- Render CLI projects directly into the document with a single React root.
+- Keep the existing project payload initially so this step isolates the cost and complexity of the extra React host, iframe, and cross-frame navigation bridge.
+- Preserve development reloads, production builds, error reporting, public files, API files, and custom CDN resolution.
+
+Done when:
+
+- `devjar dev` and `devjar start` render without an iframe.
+- Internal navigation works in the same document.
+- The public `<DevJar>` component remains iframe-based and its API is unchanged.
+
+Result:
+
+- The CLI client renders directly into `#__reactRoot`; the browser regression check found zero iframes.
+- Route navigation keeps the same host root and no longer needs a cross-frame click bridge.
+- The public `<DevJar>` implementation and exports are unchanged.
+- Manual dashboard measurements on 2026-09-02: 1,074 ms client start to first render in a fresh browser context, 5.4 ms `/` to `/projects`, and 124 ms file-change to render. These are local reference points, not stable CI thresholds.
+
+## 4. Compile Tailwind on the server
+
+Status: next
+
+- Remove `@tailwindcss/browser` from the CLI runtime.
+- Compile one stylesheet on the server and update it incrementally during development.
+- Emit ordinary CSS in production builds.
+
+Done when:
+
+- CLI pages make no request for the Tailwind browser runtime.
+- Tailwind class edits update without a full page reload.
+- Production output contains compiled CSS.
+
+## 5. Use module-based routing
+
+Status: queued
+
+- Generate a route manifest whose entries load page modules.
+- Keep one React root alive across navigation.
+- Preload route modules on navigation intent.
+- Preserve browser history, back/forward navigation, 404 handling, and normal external links.
+
+Done when:
+
+- Navigating does not fetch or reconstruct the complete project graph.
+- Shared modules remain loaded between routes.
+- Prefetched routes transition without a network wait.
+
+## 6. Add module-level HMR
+
+Status: queued
+
+- Maintain a server-side module and reverse-import graph.
+- Transform and invalidate only changed modules and their affected importers.
+- Send precise update messages to the browser and apply React Refresh at an HMR boundary.
+- Reload only when an update cannot be accepted safely.
+
+Done when:
+
+- Editing one component does not refetch the complete project.
+- Unrelated file edits do not rerender the active route.
+- Component state survives accepted updates.

--- a/scripts/build-client.ts
+++ b/scripts/build-client.ts
@@ -4,6 +4,12 @@ import { fileURLToPath } from 'node:url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const entry = join(root, 'src/client.tsx')
+const inputs = [
+  entry,
+  join(root, 'src/_cdn.ts'),
+  join(root, 'src/core.ts'),
+  join(root, 'src/module.ts'),
+]
 
 async function buildClient() {
   const result = await Bun.build({
@@ -12,7 +18,7 @@ async function buildClient() {
     naming: 'client.js',
     target: 'browser',
     format: 'esm',
-    external: ['devjar', 'react', 'react-dom'],
+    external: ['react', 'react-dom'],
   })
 
   if (!result.success) {
@@ -29,15 +35,17 @@ await buildClient()
 
 if (process.argv.includes('--watch')) {
   let building = false
-  watch(entry, async () => {
-    if (building) return
-    building = true
-    try {
-      await buildClient()
-    } catch (error) {
-      console.error(error)
-    } finally {
-      building = false
-    }
-  })
+  for (const input of inputs) {
+    watch(input, async () => {
+      if (building) return
+      building = true
+      try {
+        await buildClient()
+      } catch (error) {
+        console.error(error)
+      } finally {
+        building = false
+      }
+    })
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -256,12 +256,12 @@ function html(dependencies: Record<string, string>, cdn: string) {
   return `<!doctype html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Devjar</title><script type="importmap">${JSON.stringify({ imports })}</script>
-<style>html,body,#root{width:100%;height:100%;margin:0}iframe{display:block;width:100%;height:100%;border:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>
-</head><body><div id="root"></div><script>
-const root = document.getElementById('root')
+<style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>
+</head><body><div id="root"></div><pre id="__devjarError" class="devjar-error" hidden></pre><script>
+const errorRoot = document.getElementById('__devjarError')
 const showBootstrapError = value => {
-  root.className = 'devjar-error'
-  root.textContent = 'Devjar could not start:\\n\\n' + value
+  errorRoot.hidden = false
+  errorRoot.textContent = 'Devjar could not start:\\n\\n' + value
 }
 addEventListener('error', event => showBootstrapError(event.message || 'A browser module failed to load'))
 addEventListener('unhandledrejection', event => showBootstrapError(event.reason?.stack || event.reason || 'An asynchronous module failed'))

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { createRoot } from 'react-dom/client'
-import { DevJar } from 'devjar'
 import { createEsmShResolver } from './_cdn'
+import { createRenderer, linkModules } from './core'
+import { createModule } from './module'
+
+performance.mark('devjar:client-start')
 
 type Project = {
   files: Record<string, string>
@@ -11,6 +12,28 @@ type Project = {
   page: string
   tailwind: boolean
 }
+
+const tailwindSrc = 'https://unpkg.com/@tailwindcss/browser@4'
+
+function getRoot(id: string) {
+  const root = document.getElementById(id)
+  if (!root) throw new Error(`Devjar could not find #${id}`)
+  return root
+}
+
+const hostRoot = getRoot('root')
+const errorRoot = getRoot('__devjarError')
+
+const appRoot = document.createElement('div')
+appRoot.id = '__reactRoot'
+hostRoot.appendChild(appRoot)
+
+let loadRevision = 0
+let moduleResolver = (_specifier: string): string => {
+  throw new Error('Devjar module resolution is not initialized')
+}
+let tailwindReady: Promise<void> | undefined
+const render = createRenderer(createModule, specifier => moduleResolver(specifier))
 
 async function getProject(route: string): Promise<Project> {
   const response = await fetch('/__devjar/project?route=' + encodeURIComponent(route))
@@ -24,92 +47,101 @@ function errorMessage(error: unknown) {
   return String(error)
 }
 
-function App() {
-  const [project, setProject] = useState<Project | null>(null)
-  const [error, setError] = useState<unknown>(null)
-  const previewRef = useRef<HTMLIFrameElement>(null)
-  const resolveModule = useMemo(
-    () => project ? createEsmShResolver(project.dependencies, project.cdn) : undefined,
-    [project?.cdn, project?.dependencies],
-  )
-  const load = useCallback((route = location.pathname) => {
-    getProject(route).then(value => {
-      setProject(value)
-      setError(null)
-    }, setError)
-  }, [])
-
-  useEffect(() => {
-    load()
-    const navigateHistory = () => load(location.pathname)
-    addEventListener('popstate', navigateHistory)
-    return () => {
-      removeEventListener('popstate', navigateHistory)
-    }
-  }, [load])
-
-  useEffect(() => {
-    if (!project?.liveReload) return
-    const events = new EventSource('/__devjar/events')
-    const reload = () => load(location.pathname)
-    events.addEventListener('change', reload)
-    return () => {
-      events.removeEventListener('change', reload)
-      events.close()
-    }
-  }, [load, project?.liveReload])
-
-  useEffect(() => {
-    const iframe = previewRef.current
-    if (!iframe) return
-    let previewDocument: Document | null = null
-    const navigate = (event: MouseEvent) => {
-      const target = event.target as Element | null
-      const anchor = typeof target?.closest === 'function'
-        ? target.closest<HTMLAnchorElement>('a[href]')
-        : null
-      if (!anchor || event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
-      if ((anchor.target && anchor.target !== '_self') || anchor.hasAttribute('download')) return
-      const url = new URL(anchor.href, location.href)
-      if (url.origin !== location.origin || url.pathname.startsWith('/api/') || url.pathname.startsWith('/__devjar/')) return
-      if (/\.[^/]+$/.test(url.pathname)) return
-      if (url.pathname === location.pathname && url.search === location.search && url.hash) return
-      event.preventDefault()
-      history.pushState(null, '', url.pathname + url.search + url.hash)
-      load(url.pathname)
-    }
-    const connect = () => {
-      if (previewDocument === iframe.contentDocument) return
-      previewDocument?.removeEventListener('click', navigate)
-      previewDocument = iframe.contentDocument
-      previewDocument?.addEventListener('click', navigate)
-    }
-    connect()
-    iframe.addEventListener('devjar:render', connect)
-    return () => {
-      iframe.removeEventListener('devjar:render', connect)
-      previewDocument?.removeEventListener('click', navigate)
-    }
-  }, [project?.page, load])
-
-  if (!project) {
-    return error ? <pre className="devjar-error">{errorMessage(error)}</pre> : null
-  }
-
-  return (
-    <>
-      <DevJar
-        files={project.files}
-        resolveModule={resolveModule}
-        transform={false}
-        tailwind={project.tailwind}
-        onError={value => setError(value || null)}
-        title={project.page}
-        ref={previewRef}
-      />
-      {error && <pre className="devjar-error">{errorMessage(error)}</pre>}
-    </>
-  )
+function showError(error: unknown) {
+  errorRoot.textContent = errorMessage(error)
+  errorRoot.hidden = false
 }
 
-createRoot(document.getElementById('root')!).render(<App />)
+function hideError() {
+  errorRoot.hidden = true
+  errorRoot.textContent = ''
+}
+
+function loadTailwind(enabled: boolean) {
+  if (!enabled) return Promise.resolve()
+  if (tailwindReady) return tailwindReady
+
+  tailwindReady = new Promise<void>(resolvePromise => {
+    const script = document.createElement('script')
+    const ready = () => resolvePromise()
+    script.src = tailwindSrc
+    script.addEventListener('load', ready, { once: true })
+    script.addEventListener('error', ready, { once: true })
+    document.head.appendChild(script)
+  })
+  return tailwindReady
+}
+
+async function load(route: string) {
+  const revision = ++loadRevision
+  try {
+    const project = await getProject(route)
+    if (revision !== loadRevision) return project
+
+    moduleResolver = createEsmShResolver(project.dependencies, project.cdn)
+    const linked = await linkModules(project.files, moduleResolver)
+    await loadTailwind(project.tailwind)
+    if (revision !== loadRevision) return project
+
+    await render(linked.files, linked.dependencies)
+    if (revision === loadRevision) {
+      document.title = project.page
+      hideError()
+      if (!performance.getEntriesByName('devjar:first-render').length) {
+        performance.mark('devjar:first-render')
+        performance.measure(
+          'devjar:first-render',
+          'devjar:client-start',
+          'devjar:first-render',
+        )
+      }
+      dispatchEvent(new CustomEvent('devjar:render'))
+    }
+    return project
+  } catch (error) {
+    if (revision === loadRevision) showError(error)
+    throw error
+  }
+}
+
+function shouldNavigate(event: MouseEvent, anchor: HTMLAnchorElement) {
+  if (event.defaultPrevented || event.button !== 0) return false
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return false
+  if ((anchor.target && anchor.target !== '_self') || anchor.hasAttribute('download')) return false
+  return true
+}
+
+function navigate(event: MouseEvent) {
+  const target = event.target
+  const anchor = target instanceof Element
+    ? target.closest<HTMLAnchorElement>('a[href]')
+    : null
+  if (!anchor || !shouldNavigate(event, anchor)) return
+
+  const url = new URL(anchor.href, location.href)
+  if (url.origin !== location.origin) return
+  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/__devjar/')) return
+  if (/\.[^/]+$/.test(url.pathname)) return
+  if (url.pathname === location.pathname && url.search === location.search && url.hash) return
+
+  event.preventDefault()
+  history.pushState(null, '', url.pathname + url.search + url.hash)
+  void load(url.pathname).catch(() => {})
+}
+
+async function start() {
+  document.addEventListener('click', navigate)
+  addEventListener('popstate', () => {
+    void load(location.pathname).catch(() => {})
+  })
+
+  const project = await load(location.pathname)
+  if (project.liveReload) {
+    const events = new EventSource('/__devjar/events')
+    events.addEventListener('change', () => {
+      void load(location.pathname).catch(() => {})
+    })
+  }
+}
+
+void start().catch(() => {})

--- a/src/core.ts
+++ b/src/core.ts
@@ -155,7 +155,42 @@ function replaceImports(
   return { code, dependencies }
 }
 
-// createRenderer is going to be stringified and executed in the iframe
+async function linkModules(
+  files: Record<string, string>,
+  resolveModule: ResolveModule,
+) {
+  if (!esModuleLexerInit) {
+    await init
+    esModuleLexerInit = true
+  }
+
+  const localModules = new Set(Object.keys(files).map(getModuleKey))
+  const dependencies: Record<string, string[]> = {}
+  const linkedFiles: Record<string, string> = {}
+
+  for (const [filename, source] of Object.entries(files)) {
+    const moduleKey = getModuleKey(filename)
+    if (filename.endsWith('.css')) {
+      linkedFiles[moduleKey] = source
+      dependencies[moduleKey] = []
+      continue
+    }
+
+    const linked = replaceImports(
+      source,
+      filename,
+      moduleKey,
+      resolveModule,
+      localModules,
+    )
+    linkedFiles[moduleKey] = linked.code
+    dependencies[moduleKey] = linked.dependencies
+  }
+
+  return { files: linkedFiles, dependencies }
+}
+
+// This is used directly by the CLI client and stringified for the iframe runtime.
 function createRenderer(createModule_: typeof createModule, resolveModule: ResolveModule) {
   function isElementType(value: unknown): value is React.ElementType {
     return typeof value === 'string'
@@ -184,6 +219,12 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
   let reactRoot: import('react-dom/client').Root | undefined
   let ErrorBoundary: ErrorBoundaryClass | undefined
   let errorBoundary: ErrorBoundaryInstance | null = null
+  let reactModuleUrl = ''
+  let reactDomModuleUrl = ''
+  let rendererModules: Promise<[
+    typeof import('react'),
+    typeof import('react-dom/client'),
+  ]> | undefined
   let revision = 0
   const moduleRuntime: ModuleRuntime = {}
   const setErrorBoundaryRef = (value: ErrorBoundaryInstance | null) => {
@@ -192,8 +233,19 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
 
   async function render(files: Record<string, string>, dependencies: Record<string, string[]>) {
     const result = await createModule_(files, { resolveModule, dependencies, runtime: moduleRuntime })
-    const ReactMod: typeof import('react') = await import(/* webpackIgnore: true */ /* @vite-ignore */ /* turbopackIgnore: true */ resolveModule('react'))
-    const ReactDOMMod: typeof import('react-dom/client') = await import(/* webpackIgnore: true */ /* @vite-ignore */ /* turbopackIgnore: true */ resolveModule('react-dom/client'))
+    const nextReactModuleUrl = resolveModule('react')
+    const nextReactDomModuleUrl = resolveModule('react-dom/client')
+    if (!rendererModules
+      || reactModuleUrl !== nextReactModuleUrl
+      || reactDomModuleUrl !== nextReactDomModuleUrl) {
+      reactModuleUrl = nextReactModuleUrl
+      reactDomModuleUrl = nextReactDomModuleUrl
+      rendererModules = Promise.all([
+        import(/* webpackIgnore: true */ /* @vite-ignore */ /* turbopackIgnore: true */ reactModuleUrl),
+        import(/* webpackIgnore: true */ /* @vite-ignore */ /* turbopackIgnore: true */ reactDomModuleUrl),
+      ])
+    }
+    const [ReactMod, ReactDOMMod] = await rendererModules
 
     const _jsx = ReactMod.createElement
     const root = document.getElementById('__reactRoot')
@@ -548,6 +600,8 @@ function useLiveCode({
 
 export { 
   createModule,
+  createRenderer,
+  linkModules,
   replaceImports,
   useLiveCode,
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -95,6 +95,7 @@ describe('dev server', () => {
     expect(shellSource).toContain('/__devjar/client.js')
     expect(shellSource).toContain('Devjar could not start')
     expect(shellSource).toContain(`Devjar could not start:\\n\\n`)
+    expect(shellSource).not.toContain('<iframe')
     expect(await (await fetch(`${base}/about`, { method: 'HEAD' })).text()).toBe('')
     const bootstrap = shellSource.match(/<script>\n([\s\S]+)<\/script><script type="module"/)?.[1]
     expect(() => new Function(bootstrap || '')).not.toThrow()
@@ -106,9 +107,10 @@ describe('dev server', () => {
     expect(() => parse(client)).not.toThrow()
     expect(client).not.toContain('function dependencyUrl')
     expect(client).toContain('createEsmShResolver(project.dependencies, project.cdn)')
-    expect(client).toContain('transform: false')
-    expect(client).toContain('tailwind: project.tailwind')
-    expect(client).toContain('project?.liveReload')
+    expect(client).toContain('createRenderer(createModule')
+    expect(client).toContain('linkModules(project.files, moduleResolver)')
+    expect(client).not.toContain('createElement("iframe")')
+    expect(client).toContain('project.liveReload')
     expect(client).toContain('popstate')
     expect(client).toContain('history.pushState')
 


### PR DESCRIPTION
## Summary
- add a checked-in performance roadmap for items 1, 4, 5, and 6
- render CLI projects directly into one document and React root
- keep the public DevJar iframe runtime unchanged
- preserve client navigation, live reload, Tailwind loading, errors, and custom CDN resolution
- rebuild the CLI client when its internal runtime dependencies change

## Validation
- pnpm build
- pnpm exec tsc --noEmit
- pnpm test
- pnpm test:package
- browser: zero iframes, same host root across / to /projects
- local reference: 1,074 ms first render, 5.4 ms navigation, 124 ms edit-to-render