### PR TITLE
Load routes as shared browser modules

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -48,7 +48,7 @@ Result:
 
 ## 5. Use module-based routing
 
-Status: next
+Status: complete
 
 - Generate a route manifest whose entries load page modules.
 - Keep one React root alive across navigation.
@@ -61,9 +61,17 @@ Done when:
 - Shared modules remain loaded between routes.
 - Prefetched routes transition without a network wait.
 
+Result:
+
+- Development and production expose a compact route manifest whose entries point to native browser modules.
+- Local imports are served as separate modules, so the browser keeps shared components, data modules, and styles loaded between routes.
+- Hovering or focusing an internal link module-preloads and imports its route entry before navigation.
+- The dashboard production manifest shrank from 42,692 bytes of duplicated route graphs to 508 bytes. Its eight deduplicated module assets total 18,155 bytes.
+- Manual dashboard measurements on 2026-09-03: hovering `/projects` fetched only its page module; the prefetched click made no requests and scheduled the render in 0.4 ms. Back, forward, direct 404 routes, live reload, and the production build continued to work.
+
 ## 6. Add module-level HMR
 
-Status: queued
+Status: next
 
 - Maintain a server-side module and reverse-import graph.
 - Transform and invalidate only changed modules and their affected importers.

--- a/scripts/build-client.ts
+++ b/scripts/build-client.ts
@@ -4,12 +4,7 @@ import { fileURLToPath } from 'node:url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const entry = join(root, 'src/client.tsx')
-const inputs = [
-  entry,
-  join(root, 'src/_cdn.ts'),
-  join(root, 'src/core.ts'),
-  join(root, 'src/module.ts'),
-]
+const inputs = [entry]
 
 async function buildClient() {
   const result = await Bun.build({

--- a/src/_transform.ts
+++ b/src/_transform.ts
@@ -1,6 +1,6 @@
 import type { OxcError, TransformOptions } from 'oxc-transform'
 
-export function getTransformOptions(filename: string): TransformOptions {
+export function getTransformOptions(filename: string, refresh: boolean): TransformOptions {
   return {
     lang: /\.[cm]?tsx?$/.test(filename) ? 'tsx' : 'jsx',
     sourceType: 'module',
@@ -11,7 +11,7 @@ export function getTransformOptions(filename: string): TransformOptions {
     jsx: {
       runtime: 'automatic',
       development: true,
-      refresh: true,
+      refresh,
     },
     sourcemap: false,
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { dirname, extname, join, normalize, relative, resolve, sep } from 'node:
 import { fileURLToPath } from 'node:url'
 import { watch } from 'node:fs'
 import { transformSync } from 'oxc-transform'
+import { init, parse } from 'es-module-lexer'
 import { CDN_HOST, createEsmShResolver, normalizeCdnHost } from './_cdn'
 import { getTailwindBrowserUrl } from './tailwind'
 import { getTransformErrorMessage, getTransformOptions } from './_transform'
@@ -19,22 +20,17 @@ type PackageJson = {
   }
 }
 
-type Project = {
-  files: Record<string, string>
-  dependencies: Record<string, string>
-  cdn: string
-  liveReload: boolean
+type RouteEntry = {
+  module: string
   page: string
-  route: string
-  tailwind: boolean
 }
 
-type BuiltManifest = {
-  version: 1
-  dependencies: Record<string, string>
-  cdn: string
-  routes: Record<string, Project>
-  notFound?: Project
+type RouteManifest = {
+  version: 2
+  liveReload: boolean
+  revision: number
+  routes: Record<string, RouteEntry>
+  notFound: RouteEntry | undefined
 }
 
 export type DevServerOptions = {
@@ -56,9 +52,10 @@ export type StartServerOptions = {
   port: number
 }
 
-export type LoadProjectOptions = {
-  cdn: string | undefined
+export type LoadRouteManifestOptions = {
   liveReload: boolean
+  revision: number
+  moduleUrl: (projectPath: string) => string
 }
 
 function isInside(root: string, path: string) {
@@ -151,26 +148,6 @@ async function collectFiles(root: string, entry: string) {
   return files
 }
 
-function routeCandidates(route: string) {
-  const cleanRoute = normalizeRoute(route).slice(1)
-  const base = cleanRoute || 'index'
-  const candidates = sourceExtensions.flatMap(extension => [
-    `${base}${extension}`,
-    `${base}/index${extension}`,
-  ])
-  if (cleanRoute) candidates.push(...sourceExtensions.map(extension => `404${extension}`))
-  return candidates
-}
-
-async function resolvePage(root: string, route: string) {
-  const pagesRoot = join(root, 'pages')
-  for (const candidate of routeCandidates(route)) {
-    const path = resolve(pagesRoot, candidate)
-    if (!isInside(pagesRoot, path)) continue
-    if (await fileExists(path)) return path
-  }
-}
-
 async function readPackage(root: string): Promise<PackageJson> {
   try {
     return JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
@@ -191,39 +168,125 @@ function projectCdn(packageJson: PackageJson, override: string | undefined) {
   return normalizeCdnHost(override || packageJson.devjar?.cdn || CDN_HOST)
 }
 
-export async function loadProject(
+export async function loadRouteManifest(
   root: string,
-  route: string,
-  options: LoadProjectOptions,
-): Promise<Project> {
+  options: LoadRouteManifestOptions,
+): Promise<RouteManifest> {
   root = await realpath(root)
-  const page = await resolvePage(root, route)
-  if (!page) throw new Error(`No page found for /${route.replace(/^\/+/, '')}`)
-  const packageJson = await readPackage(root)
-  const projectPath = relative(root, page).split(sep).join('/')
-  const files = await collectFiles(root, page)
-  files['index.tsx'] = `export { default } from ${JSON.stringify(`./${projectPath}`)}\n`
-
-  for (const [filename, source] of Object.entries(files)) {
-    if (filename.endsWith('.css')) continue
-    const output = transformSync(filename, source, getTransformOptions(filename))
-    const error = getTransformErrorMessage(output.errors)
-    if (error) throw new Error(error)
-    files[filename] = output.code
+  const discovered = await discoverRoutes(root)
+  const routes: Record<string, RouteEntry> = {}
+  for (const [route, page] of discovered.routes) {
+    const projectPath = relative(root, page).split(sep).join('/')
+    routes[route] = { module: options.moduleUrl(projectPath), page: projectPath }
   }
 
-  const dependencies = packageDependencies(packageJson)
-  const cdn = projectCdn(packageJson, options.cdn)
+  const notFoundPath = discovered.notFound
+    ? relative(root, discovered.notFound).split(sep).join('/')
+    : undefined
 
   return {
-    files,
-    dependencies,
-    cdn,
+    version: 2,
     liveReload: options.liveReload,
-    page: projectPath,
-    route,
-    tailwind: Boolean(getTailwindBrowserUrl(dependencies, cdn)),
+    revision: options.revision,
+    routes,
+    notFound: notFoundPath
+      ? { module: options.moduleUrl(notFoundPath), page: notFoundPath }
+      : undefined,
   }
+}
+
+function devModuleUrl(projectPath: string, revision: number) {
+  const parameters = new URLSearchParams({ path: projectPath })
+  if (revision) parameters.set('v', String(revision))
+  return `/__devjar/module?${parameters}`
+}
+
+function moduleAssetName(projectPath: string) {
+  return `${Buffer.from(projectPath).toString('base64url')}.js`
+}
+
+function builtModuleUrl(projectPath: string) {
+  return `/__devjar/modules/${moduleAssetName(projectPath)}`
+}
+
+function cssModule(source: string, projectPath: string) {
+  return `const sheet = new CSSStyleSheet()
+sheet.replaceSync(${JSON.stringify(source)})
+globalThis.__devjarStyleSheets ||= new Map()
+const previous = globalThis.__devjarStyleSheets.get(${JSON.stringify(projectPath)})
+const sheets = [...document.adoptedStyleSheets]
+const index = sheets.indexOf(previous)
+if (index < 0) sheets.push(sheet)
+else sheets[index] = sheet
+document.adoptedStyleSheets = sheets
+globalThis.__devjarStyleSheets.set(${JSON.stringify(projectPath)}, sheet)
+export default sheet
+`
+}
+
+async function resolveProjectSource(root: string, projectPath: string) {
+  const requestedPath = resolve(root, projectPath)
+  if (!isInside(root, requestedPath)) {
+    throw new Error(`Local module escapes the project root: ${projectPath}`)
+  }
+  const sourcePath = await findSourceFile(requestedPath)
+  if (!sourcePath) throw new Error(`Module not found: ${projectPath}`)
+  const canonicalPath = await realpath(sourcePath)
+  if (!isInside(root, canonicalPath)) {
+    throw new Error(`Local module escapes the project root: ${projectPath}`)
+  }
+  return canonicalPath
+}
+
+export async function compileProjectModule(
+  root: string,
+  projectPath: string,
+  dependencies: Record<string, string>,
+  cdn: string,
+  moduleUrl: (projectPath: string) => string,
+) {
+  const sourcePath = await resolveProjectSource(root, projectPath)
+  const canonicalProjectPath = relative(root, sourcePath).split(sep).join('/')
+  const source = await readFile(sourcePath, 'utf8')
+  if (extname(sourcePath) === '.css') return cssModule(source, canonicalProjectPath)
+
+  const output = transformSync(
+    canonicalProjectPath,
+    source,
+    getTransformOptions(canonicalProjectPath, false),
+  )
+  const error = getTransformErrorMessage(output.errors)
+  if (error) throw new Error(error)
+
+  await init
+  const [imports] = parse(output.code)
+  const replacements: Array<{ start: number, end: number, value: string }> = []
+  const resolveModule = createEsmShResolver(dependencies, cdn)
+  for (const imported of imports) {
+    if (!imported.n) continue
+    let value: string
+    if (imported.n.startsWith('./') || imported.n.startsWith('../')) {
+      const importedPath = await resolveProjectSource(
+        root,
+        relative(root, resolve(sourcePath, '..', imported.n)),
+      )
+      const importedProjectPath = relative(root, importedPath).split(sep).join('/')
+      value = moduleUrl(importedProjectPath)
+    } else {
+      value = resolveModule(imported.n)
+    }
+    replacements.push({
+      start: imported.s,
+      end: imported.e,
+      value: imported.d >= 0 ? JSON.stringify(value) : value,
+    })
+  }
+
+  let code = output.code
+  for (const replacement of replacements.reverse()) {
+    code = code.slice(0, replacement.start) + replacement.value + code.slice(replacement.end)
+  }
+  return code
 }
 
 function send(
@@ -325,6 +388,7 @@ export async function startDevServer(options: DevServerOptions) {
   const port = options.port
   const events = new Set<ServerResponse>()
   const assetsRoot = await runtimeRoot()
+  let revision = 0
 
   if (!(await fileExists(join(root, 'pages/index.tsx')))
     && !(await fileExists(join(root, 'pages/index.ts')))
@@ -356,13 +420,40 @@ export async function startDevServer(options: DevServerOptions) {
         request.on('close', () => events.delete(response))
         return
       }
-      if (url.pathname === '/__devjar/project') {
-        const route = url.searchParams.get('route') || '/'
+      if (url.pathname === '/__devjar/routes.json') {
         try {
-          const project = await loadProject(root, route, { cdn: options.cdn, liveReload: true })
-          send(request, response, 200, 'application/json; charset=utf-8', JSON.stringify(project))
+          const manifest = await loadRouteManifest(root, {
+            liveReload: true,
+            revision,
+            moduleUrl: projectPath => devModuleUrl(projectPath, revision),
+          })
+          send(request, response, 200, 'application/json; charset=utf-8', JSON.stringify(manifest))
         } catch (error) {
-          send(request, response, 404, 'application/json; charset=utf-8', JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+          send(request, response, 500, 'application/json; charset=utf-8', JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+        }
+        return
+      }
+      if (url.pathname === '/__devjar/module') {
+        const projectPath = url.searchParams.get('path')
+        if (!projectPath) {
+          send(request, response, 400, 'text/plain; charset=utf-8', 'Module path is required')
+          return
+        }
+        try {
+          const moduleRevision = Number(url.searchParams.get('v')) || 0
+          const packageJson = await readPackage(root)
+          const dependencies = packageDependencies(packageJson)
+          const cdn = projectCdn(packageJson, options.cdn)
+          const code = await compileProjectModule(
+            root,
+            projectPath,
+            dependencies,
+            cdn,
+            importedPath => devModuleUrl(importedPath, moduleRevision),
+          )
+          send(request, response, 200, 'text/javascript; charset=utf-8', code)
+        } catch (error) {
+          send(request, response, 404, 'text/javascript; charset=utf-8', `throw new Error(${JSON.stringify(error instanceof Error ? error.message : String(error))})`)
         }
         return
       }
@@ -399,7 +490,10 @@ export async function startDevServer(options: DevServerOptions) {
     if (!filename || /(?:^|[/\\])(?:\.git|node_modules|dist)(?:[/\\]|$)/.test(filename)) return
     clearTimeout(timer)
     timer = setTimeout(() => {
-      for (const response of events) response.write('event: change\ndata: {}\n\n')
+      revision++
+      for (const response of events) {
+        response.write(`event: change\ndata: ${JSON.stringify({ revision })}\n\n`)
+      }
     }, 40)
   })
 
@@ -521,30 +615,41 @@ export async function buildProject(options: BuildOptions) {
   const dependencies = packageDependencies(packageJson)
   const cdn = projectCdn(packageJson, options.cdn)
   const discovered = await discoverRoutes(root)
-  const routes: Record<string, Project> = {}
-  let notFound: Project | undefined
-
-  for (const route of discovered.routes.keys()) {
-    const project = await loadProject(root, route, { cdn, liveReload: false })
-    routes[route] = project
-    if (discovered.notFound && resolve(root, project.page) === discovered.notFound) notFound = project
+  const manifest = await loadRouteManifest(root, {
+    liveReload: false,
+    revision: 0,
+    moduleUrl: builtModuleUrl,
+  })
+  const projectPaths = new Set<string>()
+  for (const page of discovered.routes.values()) {
+    const files = await collectFiles(root, page)
+    for (const projectPath of Object.keys(files)) projectPaths.add(projectPath.slice(2))
   }
-  if (discovered.notFound && !notFound) {
-    notFound = await loadProject(root, '/__devjar_not_found__', { cdn, liveReload: false })
-  }
 
-  const manifest: BuiltManifest = { version: 1, dependencies, cdn, routes, notFound }
   await rm(outDir, { recursive: true, force: true })
   await mkdir(outDir, { recursive: true })
   await writeFile(join(outDir, 'manifest.json'), JSON.stringify(manifest))
   await writeFile(join(outDir, 'index.html'), html(dependencies, cdn))
   await copyRuntimeAssets(join(outDir, '__devjar'))
+  const modulesRoot = join(outDir, '__devjar/modules')
+  await mkdir(modulesRoot, { recursive: true })
+  for (const projectPath of projectPaths) {
+    const code = await compileProjectModule(
+      root,
+      projectPath,
+      dependencies,
+      cdn,
+      builtModuleUrl,
+    )
+    await writeFile(join(modulesRoot, moduleAssetName(projectPath)), code)
+  }
+  await writeFile(join(outDir, '__devjar/routes.json'), JSON.stringify(manifest))
   if (await directoryExists(join(root, 'public'))) {
     await cp(join(root, 'public'), join(outDir, 'public'), { recursive: true })
   }
   await copyApiFiles(join(root, 'api'), join(outDir, 'api'))
 
-  return { root, outDir, routes: Object.keys(routes) }
+  return { root, outDir, routes: Object.keys(manifest.routes) }
 }
 
 export async function startBuiltServer(options: StartServerOptions) {
@@ -555,8 +660,8 @@ export async function startBuiltServer(options: StartServerOptions) {
   const root = await realpath(requestedRoot)
   const host = options.host
   const port = options.port
-  const manifest = JSON.parse(await readFile(join(root, 'manifest.json'), 'utf8')) as BuiltManifest
-  if (manifest.version !== 1) throw new Error(`Unsupported Devjar build version: ${manifest.version}`)
+  const manifest = JSON.parse(await readFile(join(root, 'manifest.json'), 'utf8')) as RouteManifest
+  if (manifest.version !== 2) throw new Error(`Unsupported Devjar build version: ${manifest.version}`)
   const shell = await readFile(join(root, 'index.html'), 'utf8')
 
   const server = createServer(async (request, response) => {
@@ -565,13 +670,6 @@ export async function startBuiltServer(options: StartServerOptions) {
       if (request.method !== 'GET' && request.method !== 'HEAD') {
         response.writeHead(405, { Allow: 'GET, HEAD' })
         response.end(request.method === 'HEAD' ? undefined : 'Method not allowed')
-        return
-      }
-      if (url.pathname === '/__devjar/project') {
-        const route = normalizeRoute(url.searchParams.get('route') || '/')
-        const project = manifest.routes[route] || manifest.notFound
-        if (project) send(request, response, 200, 'application/json; charset=utf-8', JSON.stringify(project))
-        else send(request, response, 404, 'application/json; charset=utf-8', JSON.stringify({ error: `No page found for ${route}` }))
         return
       }
       if (url.pathname.startsWith('/__devjar/')) {

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,15 +1,32 @@
-import { createEsmShResolver } from './_cdn'
-import { createRenderer, linkModules } from './core'
-import { createModule } from './module'
+import React, { Component, type ElementType, type ReactNode } from 'react'
+import { createRoot } from 'react-dom/client'
 
 performance.mark('devjar:client-start')
 
-type Project = {
-  files: Record<string, string>
-  dependencies: Record<string, string>
-  cdn: string
-  liveReload: boolean
+type RouteEntry = {
+  module: string
   page: string
+}
+
+type RouteManifest = {
+  version: 2
+  liveReload: boolean
+  revision: number
+  routes: Record<string, RouteEntry>
+  notFound: RouteEntry | undefined
+}
+
+type RouteModule = {
+  default?: unknown
+}
+
+type ErrorBoundaryProps = {
+  children?: ReactNode
+  revision: number
+}
+
+type ErrorBoundaryState = {
+  error: unknown
 }
 
 function getRoot(id: string) {
@@ -20,22 +37,77 @@ function getRoot(id: string) {
 
 const hostRoot = getRoot('root')
 const errorRoot = getRoot('__devjarError')
-
 const appRoot = document.createElement('div')
 appRoot.id = '__reactRoot'
 hostRoot.appendChild(appRoot)
+const reactRoot = createRoot(appRoot)
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: unknown) {
+    return { error }
+  }
+
+  componentDidUpdate(previousProps: ErrorBoundaryProps) {
+    if (previousProps.revision !== this.props.revision && this.state.error) {
+      this.setState({ error: null })
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      const message = this.state.error instanceof Error
+        ? this.state.error.message
+        : String(this.state.error)
+      return React.createElement('div', null, message)
+    }
+    return this.props.children
+  }
+}
 
 let loadRevision = 0
-let moduleResolver = (_specifier: string): string => {
-  throw new Error('Devjar module resolution is not initialized')
-}
-const render = createRenderer(createModule, specifier => moduleResolver(specifier))
+let renderRevision = 0
+let routeManifest: RouteManifest
+const routeModules = new Map<string, Promise<RouteModule>>()
 
-async function getProject(route: string): Promise<Project> {
-  const response = await fetch('/__devjar/project?route=' + encodeURIComponent(route))
+function normalizeRoute(route: string) {
+  const cleanRoute = route.replace(/^\/+|\/+$/g, '')
+  return cleanRoute ? `/${cleanRoute}` : '/'
+}
+
+async function getRouteManifest(revision: number) {
+  const url = new URL('/__devjar/routes.json', location.origin)
+  if (revision) url.searchParams.set('v', String(revision))
+  const response = await fetch(url)
   const data = await response.json()
-  if (!response.ok) throw new Error(data.error || 'Unable to load project')
-  return data
+  if (!response.ok) throw new Error(data.error || 'Unable to load routes')
+  if (data.version !== 2) throw new Error(`Unsupported Devjar route manifest: ${data.version}`)
+  return data as RouteManifest
+}
+
+function getRouteEntry(route: string) {
+  return routeManifest.routes[normalizeRoute(route)] || routeManifest.notFound
+}
+
+function importRoute(entry: RouteEntry) {
+  let promise = routeModules.get(entry.module)
+  if (!promise) {
+    promise = import(/* webpackIgnore: true */ /* @vite-ignore */ entry.module) as Promise<RouteModule>
+    routeModules.set(entry.module, promise)
+    promise.catch(() => routeModules.delete(entry.module))
+  }
+  return promise
+}
+
+function preloadRoute(route: string) {
+  const entry = getRouteEntry(route)
+  if (!entry || routeModules.has(entry.module)) return
+  const preload = document.createElement('link')
+  preload.rel = 'modulepreload'
+  preload.href = entry.module
+  document.head.appendChild(preload)
+  void importRoute(entry).catch(() => {})
 }
 
 function errorMessage(error: unknown) {
@@ -53,35 +125,56 @@ function hideError() {
   errorRoot.textContent = ''
 }
 
+function isElementType(value: unknown): value is ElementType {
+  return typeof value === 'string'
+    || typeof value === 'function'
+    || (typeof value === 'object' && value !== null)
+}
+
 async function load(route: string) {
   const revision = ++loadRevision
   try {
-    const project = await getProject(route)
-    if (revision !== loadRevision) return project
-
-    moduleResolver = createEsmShResolver(project.dependencies, project.cdn)
-    const linked = await linkModules(project.files, moduleResolver)
-    if (revision !== loadRevision) return project
-
-    await render(linked.files, linked.dependencies)
-    if (revision === loadRevision) {
-      document.title = project.page
-      hideError()
-      if (!performance.getEntriesByName('devjar:first-render').length) {
-        performance.mark('devjar:first-render')
-        performance.measure(
-          'devjar:first-render',
-          'devjar:client-start',
-          'devjar:first-render',
-        )
-      }
-      dispatchEvent(new CustomEvent('devjar:render'))
+    const entry = getRouteEntry(route)
+    if (!entry) throw new Error(`No page found for ${normalizeRoute(route)}`)
+    const module = await importRoute(entry)
+    if (revision !== loadRevision) return
+    if (!isElementType(module.default)) {
+      throw new Error(`Devjar page ${entry.page} must have a default React component export`)
     }
-    return project
+
+    renderRevision++
+    reactRoot.render(React.createElement(
+      ErrorBoundary,
+      { revision: renderRevision },
+      React.createElement(module.default),
+    ))
+    document.title = entry.page
+    hideError()
+    if (!performance.getEntriesByName('devjar:first-render').length) {
+      performance.mark('devjar:first-render')
+      performance.measure(
+        'devjar:first-render',
+        'devjar:client-start',
+        'devjar:first-render',
+      )
+    }
+    dispatchEvent(new CustomEvent('devjar:render'))
   } catch (error) {
     if (revision === loadRevision) showError(error)
     throw error
   }
+}
+
+function routeAnchor(target: EventTarget | null) {
+  const anchor = target instanceof Element
+    ? target.closest<HTMLAnchorElement>('a[href]')
+    : null
+  if (!anchor) return
+  const url = new URL(anchor.href, location.href)
+  if (url.origin !== location.origin) return
+  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/__devjar/')) return
+  if (/\.[^/]+$/.test(url.pathname)) return
+  return { anchor, url }
 }
 
 function shouldNavigate(event: MouseEvent, anchor: HTMLAnchorElement) {
@@ -92,36 +185,43 @@ function shouldNavigate(event: MouseEvent, anchor: HTMLAnchorElement) {
 }
 
 function navigate(event: MouseEvent) {
-  const target = event.target
-  const anchor = target instanceof Element
-    ? target.closest<HTMLAnchorElement>('a[href]')
-    : null
-  if (!anchor || !shouldNavigate(event, anchor)) return
-
-  const url = new URL(anchor.href, location.href)
-  if (url.origin !== location.origin) return
-  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/__devjar/')) return
-  if (/\.[^/]+$/.test(url.pathname)) return
-  if (url.pathname === location.pathname && url.search === location.search && url.hash) return
+  const route = routeAnchor(event.target)
+  if (!route || !shouldNavigate(event, route.anchor)) return
+  if (route.url.pathname === location.pathname
+    && route.url.search === location.search
+    && route.url.hash) return
 
   event.preventDefault()
-  history.pushState(null, '', url.pathname + url.search + url.hash)
-  void load(url.pathname).catch(() => {})
+  history.pushState(null, '', route.url.pathname + route.url.search + route.url.hash)
+  void load(route.url.pathname).catch(() => {})
+}
+
+function preloadNavigation(event: Event) {
+  const route = routeAnchor(event.target)
+  if (route) preloadRoute(route.url.pathname)
 }
 
 async function start() {
+  routeManifest = await getRouteManifest(0)
   document.addEventListener('click', navigate)
+  document.addEventListener('pointerover', preloadNavigation)
+  document.addEventListener('focusin', preloadNavigation)
   addEventListener('popstate', () => {
     void load(location.pathname).catch(() => {})
   })
 
-  const project = await load(location.pathname)
-  if (project.liveReload) {
+  await load(location.pathname)
+  if (routeManifest.liveReload) {
     const events = new EventSource('/__devjar/events')
-    events.addEventListener('change', () => {
-      void load(location.pathname).catch(() => {})
+    events.addEventListener('change', event => {
+      void (async () => {
+        const change = JSON.parse((event as MessageEvent).data) as { revision: number }
+        routeModules.clear()
+        routeManifest = await getRouteManifest(change.revision)
+        await load(location.pathname)
+      })().catch(showError)
     })
   }
 }
 
-void start().catch(() => {})
+void start().catch(showError)

--- a/src/transform-worker.ts
+++ b/src/transform-worker.ts
@@ -43,7 +43,7 @@ self.onmessage = async ({ data }: MessageEvent<{
 
     const transformed: Record<string, string> = {}
     for (const [filename, source] of Object.entries(files)) {
-      const output = oxc.transformSync(filename, source, getTransformOptions(filename))
+      const output = oxc.transformSync(filename, source, getTransformOptions(filename, true))
 
       const errorMessage = getTransformErrorMessage(output.errors)
       if (errorMessage) throw new Error(errorMessage)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,16 +1,32 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
-import { cp, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { cp, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { init, parse } from 'es-module-lexer'
-import { buildProject, loadProject, startBuiltServer, startDevServer } from '../src/cli'
+import {
+  buildProject,
+  compileProjectModule,
+  loadRouteManifest,
+  startBuiltServer,
+  startDevServer,
+} from '../src/cli'
 import { CDN_HOST, createEsmShResolver } from '../src/_cdn'
 import { replaceImports } from '../src/core'
 import { getTailwindBrowserUrl } from '../src/tailwind'
 
 const root = resolve(import.meta.dir, '../examples/basic')
 const dashboardRoot = resolve(import.meta.dir, '../examples/dashboard')
-const liveProjectOptions = { cdn: undefined, liveReload: true }
+function testModuleUrl(projectPath: string) {
+  return `/modules/${projectPath}`
+}
+
+function loadTestRouteManifest(projectRoot: string) {
+  return loadRouteManifest(projectRoot, {
+    liveReload: true,
+    revision: 7,
+    moduleUrl: testModuleUrl,
+  })
+}
 
 describe('project loading', () => {
   test('keeps parent-directory imports in the local module graph', async () => {
@@ -35,44 +51,36 @@ describe('project loading', () => {
     expect(resolveModule('@scope/pkg/subpath')).toBe('https://esm.sh/@scope/pkg@%5E2.0.0/subpath')
   })
 
-  test('loads a page and its local dependency graph', async () => {
-    const project = await loadProject(root, '/', liveProjectOptions)
-    expect(project.page).toBe('pages/index.tsx')
-    expect(Object.keys(project.files).sort()).toEqual([
-      './components/shell.tsx',
-      './pages/index.tsx',
-      './styles.css',
-      'index.tsx',
-    ])
-    expect(project.tailwind).toBe(true)
-    expect(project.files['index.tsx']).toContain('./pages/index.tsx')
-    expect(project.files['./components/shell.tsx']).not.toContain('ReactNode')
-  })
-
-  test('loads a second page route', async () => {
-    const project = await loadProject(root, '/about', liveProjectOptions)
-    expect(project.page).toBe('pages/about.tsx')
+  test('loads a route manifest with module entries', async () => {
+    const manifest = await loadTestRouteManifest(root)
+    expect(manifest.version).toBe(2)
+    expect(manifest.revision).toBe(7)
+    expect(manifest.routes['/']).toEqual({
+      module: '/modules/pages/index.tsx',
+      page: 'pages/index.tsx',
+    })
+    expect(manifest.routes['/about']).toEqual({
+      module: '/modules/pages/about.tsx',
+      page: 'pages/about.tsx',
+    })
+    expect(manifest.notFound).toBeUndefined()
   })
 
   test('uses a custom module CDN', async () => {
-    const project = await loadProject(root, '/', {
-      cdn: 'https://modules.example.test/',
-      liveReload: true,
-    })
-    expect(project.cdn).toBe('https://modules.example.test')
-    expect(createEsmShResolver(project.dependencies, project.cdn)('react')).toBe(
-      'https://modules.example.test/react@19.2.0?dev',
+    const code = await compileProjectModule(
+      root,
+      'pages/about.tsx',
+      { react: '19.2.0' },
+      'https://modules.example.test/',
+      testModuleUrl,
     )
+    expect(code).toContain('https://modules.example.test/react@19.2.0/jsx-dev-runtime?dev')
   })
 
   test('loads the hosted dashboard example and its 404 page', async () => {
-    const project = await loadProject(dashboardRoot, '/', liveProjectOptions)
-    expect(project.dependencies['lucide-react']).toBe('0.542.0')
-    expect(project.files['./components/project-card.tsx']).toBeDefined()
-    expect(project.files['./lib/projects.ts']).toBeDefined()
-
-    const notFound = await loadProject(dashboardRoot, '/missing', liveProjectOptions)
-    expect(notFound.page).toBe('pages/404.tsx')
+    const manifest = await loadTestRouteManifest(dashboardRoot)
+    expect(manifest.routes['/projects'].page).toBe('pages/projects.tsx')
+    expect(manifest.notFound?.page).toBe('pages/404.tsx')
   })
 
   test('uses the project Tailwind version for the cached browser runtime', () => {
@@ -83,6 +91,29 @@ describe('project loading', () => {
       'https://modules.example.test/@tailwindcss/browser@%5E4.1.0',
     )
     expect(getTailwindBrowserUrl({}, CDN_HOST)).toBeUndefined()
+  })
+
+  test('rewrites dynamic local imports as module URLs', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'devjar-dynamic-import-'))
+    try {
+      await mkdir(join(projectRoot, 'pages'))
+      await mkdir(join(projectRoot, 'components'))
+      await writeFile(
+        join(projectRoot, 'pages/index.tsx'),
+        `export const loadCard = () => import('../components/card')`,
+      )
+      await writeFile(join(projectRoot, 'components/card.tsx'), 'export default function Card() {}')
+      const code = await compileProjectModule(
+        await realpath(projectRoot),
+        'pages/index.tsx',
+        {},
+        CDN_HOST,
+        testModuleUrl,
+      )
+      expect(code).toContain(`import("/modules/components/card.tsx")`)
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
+    }
   })
 })
 
@@ -113,18 +144,25 @@ describe('dev server', () => {
     const bootstrap = shellSource.match(/<script>\n([\s\S]+?)<\/script>/)?.[1]
     expect(() => new Function(bootstrap || '')).not.toThrow()
 
-    const project = await fetch(`${base}/__devjar/project?route=%2Fabout`)
-    expect((await project.json()).page).toBe('pages/about.tsx')
+    const routes = await (await fetch(`${base}/__devjar/routes.json`)).json()
+    expect(routes.routes['/about'].page).toBe('pages/about.tsx')
+    const pageModule = await (await fetch(`${base}${routes.routes['/about'].module}`)).text()
+    expect(pageModule).toContain('/__devjar/module?path=components%2Fshell.tsx')
+    expect(pageModule).toContain('/__devjar/module?path=styles.css')
+    expect(pageModule).toContain('https://esm.sh/react@19.2.0/jsx-dev-runtime?dev')
+    const sharedModule = await (await fetch(`${base}/__devjar/module?path=components%2Fshell.tsx`)).text()
+    expect(sharedModule).not.toContain('ReactNode')
     const client = await (await fetch(`${base}/__devjar/client.js`)).text()
     await init
     expect(() => parse(client)).not.toThrow()
-    expect(client).not.toContain('function dependencyUrl')
-    expect(client).toContain('createEsmShResolver(project.dependencies, project.cdn)')
-    expect(client).toContain('createRenderer(createModule')
-    expect(client).toContain('linkModules(project.files, moduleResolver)')
+    expect(client).toContain('/__devjar/routes.json')
+    expect(client).toContain('modulepreload')
+    expect(client).toContain('pointerover')
+    expect(client).not.toContain('/__devjar/project')
+    expect(client).not.toContain('linkModules')
     expect(client).not.toContain('createElement("iframe")')
     expect(client).not.toContain('@tailwindcss/browser')
-    expect(client).toContain('project.liveReload')
+    expect(client).toContain('routeManifest.liveReload')
     expect(client).toContain('popstate')
     expect(client).toContain('history.pushState')
 
@@ -171,9 +209,13 @@ describe('production build', () => {
   test('writes routes, runtime assets, public files, and static APIs', async () => {
     const manifest = JSON.parse(await readFile(join(buildRoot, 'manifest.json'), 'utf8'))
     expect(Object.keys(manifest.routes).sort()).toEqual(['/', '/404', '/projects', '/settings'])
-    expect(manifest.routes['/'].liveReload).toBe(false)
-    expect(manifest.cdn).toBe('https://modules.example.test')
-    expect(await readFile(join(buildRoot, '__devjar/client.js'), 'utf8')).toContain('__devjar/project')
+    expect(manifest.version).toBe(2)
+    expect(manifest.liveReload).toBe(false)
+    expect(manifest.routes['/'].module).toMatch(/^\/__devjar\/modules\/.+\.js$/)
+    expect(await readFile(join(buildRoot, '__devjar/client.js'), 'utf8')).toContain('__devjar/routes.json')
+    expect(await readFile(join(buildRoot, '__devjar/routes.json'), 'utf8')).toBe(JSON.stringify(manifest))
+    const entryModule = await readFile(join(buildRoot, manifest.routes['/'].module), 'utf8')
+    expect(entryModule).toContain('https://modules.example.test/react@19.2.0/jsx-dev-runtime?dev')
     expect(await readFile(join(buildRoot, 'index.html'), 'utf8')).toContain('data-devjar-tailwind')
     expect(await readFile(join(buildRoot, '__devjar/_cdn.js'), 'utf8')).toContain('createEsmShResolver')
     expect(await readFile(join(buildRoot, 'api/projects.json'), 'utf8')).toContain('Mobile refresh')
@@ -196,11 +238,13 @@ describe('production build', () => {
 
     const shell = await (await fetch(`${base}/projects`)).text()
     expect(shell).toContain('https://modules.example.test/react@19.2.0?dev')
-    const project = await (await fetch(`${base}/__devjar/project?route=%2Fprojects`)).json()
-    expect(project.page).toBe('pages/projects.tsx')
-    expect(project.liveReload).toBe(false)
-    const notFound = await (await fetch(`${base}/__devjar/project?route=%2Fmissing`)).json()
-    expect(notFound.page).toBe('pages/404.tsx')
+    const routes = await (await fetch(`${base}/__devjar/routes.json`)).json()
+    expect(routes.routes['/projects'].page).toBe('pages/projects.tsx')
+    expect(routes.liveReload).toBe(false)
+    expect(routes.notFound.page).toBe('pages/404.tsx')
+    const projectModule = await fetch(`${base}${routes.routes['/projects'].module}`)
+    expect(projectModule.status).toBe(200)
+    expect(projectModule.headers.get('content-type')).toContain('text/javascript')
     expect((await fetch(`${base}/__devjar/events`)).status).toBe(404)
     expect(await (await fetch(`${base}/api/projects.json`)).json()).toHaveLength(4)
     expect(await (await fetch(`${base}/mark.svg`)).text()).toContain('<svg')


### PR DESCRIPTION
## Summary
- replace per-navigation project graph downloads with a compact route manifest and native browser module entries
- serve local source files as individually transformed modules so shared imports stay loaded across routes
- preload route entries on pointer and keyboard navigation intent
- emit deduplicated production module assets and preserve history, 404 routes, custom CDNs, and live reload
- mark module routing complete and module-level HMR next in the performance roadmap

## Performance
- dashboard production manifest: 42,692 bytes -> 508 bytes
- deduplicated production graph: 8 modules, 18,155 bytes
- hover on /projects fetched only its unique page entry
- clicking the prefetched route made zero requests and scheduled the local render in 0.4 ms

## Validation
- pnpm build
- pnpm exec tsc --noEmit
- pnpm test (11 passing)
- pnpm test:package
- real-browser development and production navigation
- real-browser back/forward, direct 404, custom CDN, dynamic import, and live-reload checks