### PR TITLE
Align iframe projects with CLI page conventions

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,6 +1,7 @@
 # Devjar API
 
-Devjar runs editable React code in a browser iframe. The runtime renders the default export from `index.js`.
+Devjar runs editable React code in a browser iframe. Projects use the same
+file-based `pages/` convention as the Devjar CLI.
 
 Devjar requires React 19.
 
@@ -18,7 +19,7 @@ pnpm add devjar
 import { DevJar } from 'devjar'
 
 const files = {
-  'index.js': `export default function App() {
+  'pages/index.tsx': `export default function Page() {
     return <h1>Hello world</h1>
   }`,
 }
@@ -35,22 +36,30 @@ export function Preview() {
 
 Props:
 
-- `files: Record<string, string>`: files available to the runtime. `index.js` is the entry file.
+- `files: Record<string, string>`: project files available to the runtime. `pages/index.*` is the root page.
 - `dependencies?: Record<string, string>`: package versions loaded from esm.sh when no custom resolver is supplied.
 - `resolveModule?: (specifier: string) => string`: overrides the default CDN resolver for bare imports.
 - `onError?: (...data: any[]) => void`: receives runtime or transform errors.
 
-File keys can include relative modules and CSS:
+Page files, shared modules, and CSS use project-relative paths:
 
 ```ts
 const files = {
-  'index.js': `import './styles.css'
-export default function App() {
-  return <button className="button">Save</button>
+  'pages/index.tsx': `import '../styles.css'
+import { Button } from '../components/button'
+export default function Page() {
+  return <Button>Save</Button>
 }`,
-  './styles.css': `.button { font: inherit; }`,
+  'components/button.tsx': `export function Button({ children }) {
+  return <button className="button">{children}</button>
+}`,
+  'styles.css': `.button { font: inherit; }`,
 }
 ```
+
+`pages/index.*` maps to `/`, nested page files map to nested routes, and
+`pages/404.*` handles unmatched links inside the iframe. Relative page links
+navigate without leaving the iframe.
 
 ### `useLiveCode(options)`
 

--- a/API.md
+++ b/API.md
@@ -58,8 +58,8 @@ export default function Page() {
 ```
 
 `pages/index.*` maps to `/`, nested page files map to nested routes, and
-`pages/404.*` handles unmatched links inside the iframe. Relative page links
-navigate without leaving the iframe.
+relative page links navigate without leaving the iframe. Unmatched links render
+a built-in 404 page unless the project provides `pages/404.*`.
 
 ### `useLiveCode(options)`
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ pnpm add devjar
 * `transformWorkerUrl`: Optional custom URL for the packaged transform worker.
 
 `pages/index.*` maps to `/`, nested page files map to nested routes, and
-`pages/404.*` handles unmatched links inside the iframe. Relative page links
-navigate without leaving the iframe.
+relative page links navigate without leaving the iframe. Unmatched links render
+a built-in 404 page unless the project provides `pages/404.*`.
 
 **Example**
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 
 devjar is a library that enables you to live test and share your code snippets and examples with others. devjar will generate a live code editor where you can run your code snippets and view the results in real-time based on the provided code content of your React app.
 
-**Notice:** devjar requires React 19 and only works for browser runtime at the moment. It will always render the default export component in `index.js` as the app entry.
+**Notice:** devjar requires React 19 and only renders in the browser. Projects
+use the same `pages/` convention in the iframe runtime and CLI.
 
 ## Install
 
@@ -31,11 +32,15 @@ pnpm add devjar
 
 **Props**
 
-* `files`: An object that specifies the files you want to include in your development environment.
+* `files`: Project files using the same `pages/` convention as the CLI.
 * `dependencies`: Optional package name/version map. Packages load from esm.sh.
 * `resolveModule`: Optional override that maps module specifiers to browser-loadable module URLs.
 * `onError`: Callback function of error event from the iframe sandbox. By default `console.log`.
 * `transformWorkerUrl`: Optional custom URL for the packaged transform worker.
+
+`pages/index.*` maps to `/`, nested page files map to nested routes, and
+`pages/404.*` handles unmatched links inside the iframe. Relative page links
+navigate without leaving the iframe.
 
 **Example**
 
@@ -45,7 +50,7 @@ import { DevJar } from 'devjar'
 const CDN_HOST = 'https://esm.sh'
 
 const files = {
-  'index.js': `export default function App() { return 'hello world' }`
+  'pages/index.jsx': `export default function Page() { return 'hello world' }`
 }
 
 function App() {
@@ -99,11 +104,11 @@ function Playground() {
   // load code files and execute them as live code
   function run() {
     load({
-      // `index.js` is the entry of every project
-      'index.js': `export default function App() { return 'hello world' }`,
-
-      // other relative modules can be used in the live coding
-      './mod': `export default function Mod() { return 'mod' }`,
+      'pages/index.jsx': `import Message from '../components/message'
+export default function Page() { return <Message /> }`,
+      'components/message.jsx': `export default function Message() {
+  return 'hello world'
+}`,
     })
   }
 

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -31,10 +31,10 @@ const required = [
   'dist/transform.wasm32-wasi.wasm',
 ]
 const missing = required.filter(file => !files.has(file))
-const hasCdnChunk = [...files].some(file => /^dist\/cdn-.+\.js$/.test(file))
+const hasRuntimeChunk = [...files].some(file => /^dist\/.+-[a-z0-9]+\.js$/.test(file))
 
-if (missing.length || !hasCdnChunk) {
-  if (!hasCdnChunk) missing.push('dist/cdn-<hash>.js')
+if (missing.length || !hasRuntimeChunk) {
+  if (!hasRuntimeChunk) missing.push('dist/<runtime>-<hash>.js')
   throw new Error(`Package is missing required files: ${missing.join(', ')}`)
 }
 

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -2,10 +2,10 @@ import PlaygroundSection from './playground-section'
 import dedent from 'dedent'
 
 const codeSample = {
-  'index.js': dedent`\
+  'pages/index.jsx': dedent`\
   import { useState } from 'react'
-  import { art } from './ascii'
-  import './styles.css'
+  import { art } from '../components/ascii'
+  import '../styles.css'
 
   const site = {
     name: 'DEVJAR',
@@ -38,12 +38,12 @@ const codeSample = {
       </div>
     )
   }`,
-  './ascii.js': dedent`\
+  'components/ascii.js': dedent`\
   const copy = {
     title: 'DEVJAR',
     editorLabel: 'editor',
     previewLabel: 'preview',
-    filename: 'index.js',
+    filename: 'pages/index.jsx',
     codeLine: 'const title = "Ship"',
     renderLine: 'return <Demo />',
     resultLabel: 'live result',
@@ -92,7 +92,7 @@ const codeSample = {
   ]
 
   export { art }`,
-  './styles.css': dedent`\
+  'styles.css': dedent`\
   * {
     box-sizing: border-box;
   }

--- a/site/ui/codesandbox.tsx
+++ b/site/ui/codesandbox.tsx
@@ -87,11 +87,13 @@ export function Codesandbox({
 }: {
   files: Record<string, string>
 }) {
-  // Initialize activeFile with first available file, preferring index.js
+  // Initialize activeFile with the root page when available.
   const getInitialActiveFile = (files: Record<string, string>) => {
-    if (files['index.js']) return 'index.js'
+    const rootPage = ['pages/index.tsx', 'pages/index.ts', 'pages/index.jsx', 'pages/index.js']
+      .find(filename => filename in files)
+    if (rootPage) return rootPage
     const firstKey = Object.keys(files)[0]
-    return firstKey || 'index.js'
+    return firstKey || 'pages/index.tsx'
   }
   
   const [activeFile, setActiveFile] = useState<string | null>(() => getInitialActiveFile(initialFiles))

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,9 +10,9 @@ import {
   compileProjectModule,
   DevModuleGraph,
   moduleAssetName,
-  sourceExtensions,
 } from './modules'
 import type { HmrChange, RouteEntry, RouteManifest } from './protocol'
+import { normalizeRoute, routeFromPagePath, sourceExtensions } from '../project'
 import { getTailwindBrowserUrl } from '../tailwind'
 
 type PackageJson = {
@@ -78,11 +78,6 @@ async function runtimeRoot() {
   return await fileExists(join(moduleRoot, 'index.js'))
     ? moduleRoot
     : resolve(moduleRoot, '../../dist')
-}
-
-function normalizeRoute(route: string) {
-  const cleanRoute = route.replace(/^\/+|\/+$/g, '')
-  return cleanRoute ? `/${cleanRoute}` : '/'
 }
 
 async function readPackage(root: string): Promise<PackageJson> {
@@ -442,10 +437,9 @@ async function discoverRoutes(root: string) {
   const routes = new Map<string, string>()
   let notFound: string | undefined
   for (const path of files.sort()) {
-    let pagePath = relative(pagesRoot, path).split(sep).join('/')
-    pagePath = pagePath.slice(0, -extname(pagePath).length)
-    if (pagePath === '404') notFound = path
-    const route = normalizeRoute(pagePath.replace(/(?:^|\/)index$/, ''))
+    const pagePath = relative(pagesRoot, path).split(sep).join('/')
+    if (pagePath.slice(0, -extname(pagePath).length) === '404') notFound = path
+    const route = routeFromPagePath(pagePath)!
     if (routes.has(route)) {
       throw new Error(`Multiple pages resolve to ${route}: ${relative(root, routes.get(route)!)} and ${relative(root, path)}`)
     }

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -3,10 +3,10 @@ import { extname, relative, resolve, sep } from 'node:path'
 import { init, parse } from 'es-module-lexer'
 import { transformSync } from 'oxc-transform'
 import { createEsmShResolver } from '../cdn'
+import { sourceExtensions } from '../project'
 import { getTransformErrorMessage, getTransformOptions } from '../transform'
 import type { HmrUpdate } from './protocol'
 
-export const sourceExtensions = ['.tsx', '.ts', '.jsx', '.js']
 export const localExtensions = [...sourceExtensions, '.css']
 
 type ModuleGraphEntry = {

--- a/src/core.ts
+++ b/src/core.ts
@@ -3,11 +3,17 @@ import { createModule } from './module'
 import type { ModuleRuntime } from './module'
 import { init, parse } from 'es-module-lexer'
 import { CDN_HOST, createEsmShResolver } from './cdn'
+import { routeFromPagePath, sourceExtensions } from './project'
 
 type ResolveModule = (specifier: string) => string
+export type IframeRouteManifest = {
+  routes: Record<string, string>
+  notFound: string | undefined
+}
 type RenderFunction = (
   files: Record<string, string>,
-  dependencies: Record<string, string[]>
+  dependencies: Record<string, string[]>,
+  manifest: IframeRouteManifest,
 ) => Promise<void>
 
 declare global {
@@ -29,12 +35,26 @@ type TransformWorkerResponse = {
 
 let esModuleLexerInit = false
 const isRelative = (specifier: string) => specifier.startsWith('./') || specifier.startsWith('../')
-const removeExtension = (str: string) => str.replace(/\.[^/.]+$/, '')
 const localImportPrefix = '__DEVJAR_LOCAL_IMPORT__'
 const tailwindSrc = 'https://unpkg.com/@tailwindcss/browser@4'
+const localExtensions = [...sourceExtensions, '.css']
 
 function createLocalImportPlaceholder(moduleKey: string) {
   return `${localImportPrefix}${encodeURIComponent(moduleKey)}__`
+}
+
+function normalizeProjectPath(filename: string) {
+  const parts: string[] = []
+  for (const part of filename.replace(/\\/g, '/').split('/')) {
+    if (!part || part === '.') continue
+    if (part === '..') {
+      if (!parts.length) throw new Error(`devjar: File escapes the project root: ${filename}`)
+      parts.pop()
+    } else {
+      parts.push(part)
+    }
+  }
+  return parts.join('/')
 }
 
 function createTransformWorker(transformWorkerUrl?: string | URL) {
@@ -62,23 +82,44 @@ function createTransformWorker(transformWorkerUrl?: string | URL) {
 }
 
 function getModuleKey(filename: string) {
-  const key = isRelative(filename) ? '@' + filename.slice(2) : filename
-  return filename.endsWith('.css') ? key : removeExtension(key)
+  return `@${normalizeProjectPath(filename)}`
 }
 
-function resolveRelativeModule(importer: string, imported: string) {
-  const importerPath = importer.startsWith('./') ? importer.slice(2) : importer
-  const parts = importerPath.split('/')
+function resolveRelativePath(importer: string, imported: string) {
+  const parts = normalizeProjectPath(importer).split('/')
   parts.pop()
 
   for (const part of imported.split('/')) {
     if (!part || part === '.') continue
-    if (part === '..') parts.pop()
-    else parts.push(part)
+    if (part === '..') {
+      if (!parts.length) {
+        throw new Error(`devjar: Local import escapes the project root: ${imported}`)
+      }
+      parts.pop()
+    } else {
+      parts.push(part)
+    }
   }
+  return parts.join('/')
+}
 
-  const path = parts.join('/')
-  return imported.endsWith('.css') ? '@' + path : removeExtension('@' + path)
+function resolveRelativeModule(
+  importer: string,
+  imported: string,
+  localFiles: ReadonlyMap<string, string>,
+) {
+  const requestedPath = resolveRelativePath(importer, imported)
+  const candidates = /\.[^/]+$/.test(requestedPath)
+    ? [requestedPath]
+    : [
+        ...localExtensions.map(extension => requestedPath + extension),
+        ...localExtensions.map(extension => `${requestedPath}/index${extension}`),
+      ]
+  for (const candidate of candidates) {
+    const moduleKey = localFiles.get(candidate)
+    if (moduleKey) return moduleKey
+  }
+  throw new Error(`devjar: Cannot resolve ${imported} imported by ${importer}`)
 }
 
 function replaceImports(
@@ -86,7 +127,7 @@ function replaceImports(
   filename: string,
   moduleKey: string,
   resolveModule: ResolveModule,
-  localModules: ReadonlySet<string>
+  localFiles: ReadonlyMap<string, string>,
 ) {
   let code = ''
   let lastIndex = 0
@@ -94,15 +135,15 @@ function replaceImports(
   const [imports] = parse(source)
   const cssImports: string[] = []
   const dependencies: string[] = []
-  
+
   // start, end, statementStart, statementEnd, assertion, name
-  imports.forEach(({ s, e, ss, se, a, n }) => {
+  imports.forEach(({ s, e, ss, se, n }) => {
     if (!n) return
-    code += source.slice(lastIndex, ss) // content from last import to beginning of this line 
+    code += source.slice(lastIndex, ss) // content from last import to beginning of this line
 
     const localModuleKey = isRelative(n)
-      ? resolveRelativeModule(filename, n)
-      : localModules.has(n) ? n : undefined
+      ? resolveRelativeModule(filename, n, localFiles)
+      : undefined
 
     // handle imports
     if (localModuleKey && localModuleKey.endsWith('.css')) {
@@ -164,7 +205,9 @@ async function linkModules(
     esModuleLexerInit = true
   }
 
-  const localModules = new Set(Object.keys(files).map(getModuleKey))
+  const localFiles = new Map(
+    Object.keys(files).map(filename => [normalizeProjectPath(filename), getModuleKey(filename)]),
+  )
   const dependencies: Record<string, string[]> = {}
   const linkedFiles: Record<string, string> = {}
 
@@ -181,7 +224,7 @@ async function linkModules(
       filename,
       moduleKey,
       resolveModule,
-      localModules,
+      localFiles,
     )
     linkedFiles[moduleKey] = linked.code
     dependencies[moduleKey] = linked.dependencies
@@ -190,7 +233,38 @@ async function linkModules(
   return { files: linkedFiles, dependencies }
 }
 
-// This is used directly by the CLI client and stringified for the iframe runtime.
+function createIframeRouteManifest(files: Record<string, string>): IframeRouteManifest {
+  const routes: Record<string, string> = {}
+  let notFound: string | undefined
+
+  for (const filename of Object.keys(files).sort()) {
+    const projectPath = normalizeProjectPath(filename)
+    if (!projectPath.startsWith('pages/')) continue
+    const pagePath = projectPath.slice('pages/'.length)
+    const route = routeFromPagePath(pagePath)
+    if (!route) continue
+    if (routes[route]) {
+      throw new Error(`devjar: Multiple pages resolve to ${route}`)
+    }
+    routes[route] = getModuleKey(projectPath)
+    if (route === '/404' && !pagePath.includes('/')) {
+      notFound = routes[route]
+    }
+  }
+
+  if (!routes['/']) {
+    // Keep existing single-file projects working while pages/ is canonical.
+    const legacyEntry = sourceExtensions
+      .map(extension => `index${extension}`)
+      .find(filename => filename in files || `./${filename}` in files)
+    if (legacyEntry) routes['/'] = getModuleKey(legacyEntry)
+    else throw new Error('devjar: Expected an index page in pages/')
+  }
+
+  return { routes, notFound }
+}
+
+// This function is stringified into the iframe runtime.
 function createRenderer(createModule_: typeof createModule, resolveModule: ResolveModule) {
   function isElementType(value: unknown): value is React.ElementType {
     return typeof value === 'string'
@@ -227,12 +301,34 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
   ]> | undefined
   let revision = 0
   const moduleRuntime: ModuleRuntime = {}
+  let currentFiles: Record<string, string> = {}
+  let currentDependencies: Record<string, string[]> = {}
+  let currentManifest: IframeRouteManifest | undefined
+  let currentRoute = '/'
+  let renderedEntry = ''
   const setErrorBoundaryRef = (value: ErrorBoundaryInstance | null) => {
     errorBoundary = value
   }
 
-  async function render(files: Record<string, string>, dependencies: Record<string, string[]>) {
-    const result = await createModule_(files, { resolveModule, dependencies, runtime: moduleRuntime })
+  async function render(
+    files: Record<string, string>,
+    dependencies: Record<string, string[]>,
+    manifest: IframeRouteManifest,
+  ) {
+    currentFiles = files
+    currentDependencies = dependencies
+    currentManifest = manifest
+    const cleanRoute = currentRoute.replace(/^\/+|\/+$/g, '')
+    const route = cleanRoute ? `/${cleanRoute}` : '/'
+    const entry = manifest.routes[route] || manifest.notFound
+    if (!entry) throw new Error(`devjar: No page found for ${route}`)
+
+    const result = await createModule_(files, {
+      resolveModule,
+      dependencies,
+      runtime: moduleRuntime,
+      entry,
+    })
     const nextReactModuleUrl = resolveModule('react')
     const nextReactDomModuleUrl = resolveModule('react-dom/client')
     if (!rendererModules
@@ -251,7 +347,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     const root = document.getElementById('__reactRoot')
     if (!root) throw new Error('devjar: render root was not found')
     if (!isElementType(result.module.default)) {
-      throw new Error('devjar: index must have a default React component export')
+      throw new Error(`devjar: Page ${entry.slice(1)} must have a default React component export`)
     }
     const App = result.module.default
 
@@ -292,7 +388,20 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
         { revision, ref: setErrorBoundaryRef },
         _jsx(App)
       ))
+      renderedEntry = entry
       moduleRuntime.hasRendered = true
+      return
+    }
+
+    if (renderedEntry !== entry) {
+      revision++
+      renderedEntry = entry
+      errorBoundary?.reset()
+      reactRoot.render(_jsx(
+        ErrorBoundary,
+        { revision, ref: setErrorBoundaryRef },
+        _jsx(App)
+      ))
       return
     }
 
@@ -315,6 +424,28 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
       }
     }
   }
+
+  document.addEventListener('click', (event) => {
+    if (event.defaultPrevented || event.button !== 0) return
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+    const anchor = event.target instanceof Element
+      ? event.target.closest<HTMLAnchorElement>('a[href]')
+      : null
+    if (!anchor || anchor.hasAttribute('download')) return
+    if (anchor.target && anchor.target !== '_self') return
+    const href = anchor.getAttribute('href')
+    if (!href || href.startsWith('#')) return
+    const url = new URL(href, `https://devjar.local${currentRoute}`)
+    if (url.origin !== 'https://devjar.local') return
+    if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/__devjar/')) return
+    if (/\.[^/]+$/.test(url.pathname)) return
+
+    event.preventDefault()
+    currentRoute = url.pathname
+    if (currentManifest) {
+      void render(currentFiles, currentDependencies, currentManifest)
+    }
+  })
 
   return render
 }
@@ -494,103 +625,74 @@ function useLiveCode({
 
   const load = useCallback(async (files: Record<string, string>) => {
     const loadId = ++loadIdRef.current
-    if (!esModuleLexerInit) {
-      await init
-      esModuleLexerInit = true
-    }
 
-    if (files) {
+    try {
       const resolveModuleForLoad = resolveModule
-      const localModules = new Set(Object.keys(files).map(getModuleKey))
+      const manifest = createIframeRouteManifest(files)
 
-      try {
-        const filesToTransform = Object.fromEntries(
-          Object.entries(files).filter(([filename, source]) => {
-            return !filename.endsWith('.css') && transformCacheRef.current.get(filename)?.source !== source
-          })
-        )
-        const newTransforms = Object.keys(filesToTransform).length
-          ? transform ? await transformFiles(filesToTransform) : filesToTransform
-          : {}
+      const filesToTransform = Object.fromEntries(
+        Object.entries(files).filter(([filename, source]) => {
+          return !filename.endsWith('.css') && transformCacheRef.current.get(filename)?.source !== source
+        })
+      )
+      const newTransforms = Object.keys(filesToTransform).length
+        ? transform ? await transformFiles(filesToTransform) : filesToTransform
+        : {}
 
-        if (loadId !== loadIdRef.current) return
-        for (const [filename, code] of Object.entries(newTransforms)) {
-          transformCacheRef.current.set(filename, { source: files[filename], code })
-        }
-        for (const filename of transformCacheRef.current.keys()) {
-          if (!(filename in files)) transformCacheRef.current.delete(filename)
-        }
-
-        /**
-         * transformedFiles
-         * {
-         *  'index.js': '...',
-         *  '@mod1': '...',
-         *  '@mod2': '...',
-         */
-        const dependencies: Record<string, string[]> = {}
-        const transformedFiles: Record<string, string> = {}
-        for (const filename of Object.keys(files)) {
-          // 1. Remove ./
-          // 2. For non css files, remove extension
-          // e.g. './styles.css' -> '@styles.css'
-          // e.g. './foo.js' -> '@foo'
-          const moduleKey = getModuleKey(filename)
-          
-          if (filename.endsWith('.css')) {
-            transformedFiles[moduleKey] = files[filename]
-            dependencies[moduleKey] = []
-          } else {
-            // JS or TS files
-            const cachedTransform = transformCacheRef.current.get(filename)
-            if (!cachedTransform) {
-              throw new Error(`devjar: Missing transform for ${filename}`)
-            }
-            const transformed = replaceImports(
-              cachedTransform.code,
-              filename,
-              moduleKey,
-              resolveModuleForLoad,
-              localModules
-            )
-            transformedFiles[moduleKey] = transformed.code
-            dependencies[moduleKey] = transformed.dependencies
-          }
-        }
-
-        const iframe = iframeRef.current
-        const script = appScriptRef.current
-        if (iframe) {
-          const contentWindow = iframe.contentWindow
-          if (!contentWindow) throw new Error('devjar: iframe window is unavailable')
-          const renderFiles = async () => {
-            await tailwindReadyRef.current
-            const render = contentWindow.__render__
-            if (!render) throw new Error('devjar: renderer was not initialized')
-            await render(transformedFiles, dependencies)
-            if (loadId === loadIdRef.current) {
-              iframe.dispatchEvent(new CustomEvent('devjar:render'))
-            }
-          }
-
-          const render = contentWindow.__render__
-          if (render) {
-            await renderFiles()
-          } else {
-            // if render is not loaded yet, wait until it's loaded
-            if (!script) throw new Error('devjar: application script was not initialized')
-            script.onload = () => {
-              renderFiles().catch((err) => {
-                setError(err)
-              })
-            }
-          }
-        }
-        setError(undefined)
-      } catch (e) {
-        console.warn(e)
-        setError(e)
+      if (loadId !== loadIdRef.current) return
+      for (const [filename, code] of Object.entries(newTransforms)) {
+        transformCacheRef.current.set(filename, { source: files[filename], code })
       }
+      for (const filename of transformCacheRef.current.keys()) {
+        if (!(filename in files)) transformCacheRef.current.delete(filename)
+      }
+
+      const transformedSources: Record<string, string> = {}
+      for (const filename of Object.keys(files)) {
+        if (filename.endsWith('.css')) {
+          transformedSources[filename] = files[filename]
+        } else {
+          const cachedTransform = transformCacheRef.current.get(filename)
+          if (!cachedTransform) {
+            throw new Error(`devjar: Missing transform for ${filename}`)
+          }
+          transformedSources[filename] = cachedTransform.code
+        }
+      }
+      const linked = await linkModules(transformedSources, resolveModuleForLoad)
+
+      const iframe = iframeRef.current
+      const script = appScriptRef.current
+      if (iframe) {
+        const contentWindow = iframe.contentWindow
+        if (!contentWindow) throw new Error('devjar: iframe window is unavailable')
+        const renderFiles = async () => {
+          await tailwindReadyRef.current
+          const render = contentWindow.__render__
+          if (!render) throw new Error('devjar: renderer was not initialized')
+          await render(linked.files, linked.dependencies, manifest)
+          if (loadId === loadIdRef.current) {
+            iframe.dispatchEvent(new CustomEvent('devjar:render'))
+          }
+        }
+
+        const render = contentWindow.__render__
+        if (render) {
+          await renderFiles()
+        } else {
+          // if render is not loaded yet, wait until it's loaded
+          if (!script) throw new Error('devjar: application script was not initialized')
+          script.onload = () => {
+            renderFiles().catch((err) => {
+              setError(err)
+            })
+          }
+        }
+      }
+      setError(undefined)
+    } catch (e) {
+      console.warn(e)
+      setError(e)
     }
     rerender({})
   }, [resolveModule, transform, transformFiles])
@@ -600,6 +702,7 @@ function useLiveCode({
 
 export { 
   createModule,
+  createIframeRouteManifest,
   createRenderer,
   linkModules,
   replaceImports,

--- a/src/core.ts
+++ b/src/core.ts
@@ -321,14 +321,14 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     const cleanRoute = currentRoute.replace(/^\/+|\/+$/g, '')
     const route = cleanRoute ? `/${cleanRoute}` : '/'
     const entry = manifest.routes[route] || manifest.notFound
-    if (!entry) throw new Error(`devjar: No page found for ${route}`)
-
-    const result = await createModule_(files, {
-      resolveModule,
-      dependencies,
-      runtime: moduleRuntime,
-      entry,
-    })
+    const result = entry
+      ? await createModule_(files, {
+          resolveModule,
+          dependencies,
+          runtime: moduleRuntime,
+          entry,
+        })
+      : undefined
     const nextReactModuleUrl = resolveModule('react')
     const nextReactDomModuleUrl = resolveModule('react-dom/client')
     if (!rendererModules
@@ -346,10 +346,21 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     const _jsx = ReactMod.createElement
     const root = document.getElementById('__reactRoot')
     if (!root) throw new Error('devjar: render root was not found')
-    if (!isElementType(result.module.default)) {
-      throw new Error(`devjar: Page ${entry.slice(1)} must have a default React component export`)
+    let App: React.ElementType
+    if (entry) {
+      if (!isElementType(result?.module.default)) {
+        throw new Error(`devjar: Page ${entry.slice(1)} must have a default React component export`)
+      }
+      App = result.module.default
+    } else {
+      App = function NotFound() {
+        return _jsx('main', null,
+          _jsx('h1', null, '404'),
+          _jsx('p', null, `No page found for ${route}`),
+        )
+      }
     }
-    const App = result.module.default
+    const renderedPage = entry || `__devjar_not_found__${route}`
 
     if (!ErrorBoundary) {
       ErrorBoundary = class extends ReactMod.Component<ErrorBoundaryProps, ErrorBoundaryState> {
@@ -388,14 +399,14 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
         { revision, ref: setErrorBoundaryRef },
         _jsx(App)
       ))
-      renderedEntry = entry
+      renderedEntry = renderedPage
       moduleRuntime.hasRendered = true
       return
     }
 
-    if (renderedEntry !== entry) {
+    if (renderedEntry !== renderedPage) {
       revision++
-      renderedEntry = entry
+      renderedEntry = renderedPage
       errorBoundary?.reset()
       reactRoot.render(_jsx(
         ErrorBoundary,
@@ -405,7 +416,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
       return
     }
 
-    if (result.changed) {
+    if (result?.changed) {
       errorBoundary?.reset()
       const refreshRuntime = moduleRuntime.refreshRuntime
       if (!refreshRuntime) throw new Error('devjar: refresh runtime was not initialized')

--- a/src/module.ts
+++ b/src/module.ts
@@ -19,10 +19,11 @@ export interface ModuleNamespace {
 
 async function createModule(
   files: Record<string, string>,
-  { resolveModule, dependencies = {}, runtime = {} }: {
+  { resolveModule, dependencies, runtime, entry }: {
     resolveModule: (specifier: string) => string
-    dependencies?: Record<string, string[]>
-    runtime?: ModuleRuntime
+    dependencies: Record<string, string[]>
+    runtime: ModuleRuntime
+    entry: string
   }
 ): Promise<{ module: ModuleNamespace, changed: boolean }> {
   function isRefreshRuntime(value: unknown): value is RefreshRuntime {
@@ -151,11 +152,11 @@ export default sheet;`
     })
   }
 
-  if (!runtimeUrls['index']) {
-    throw new Error('devjar: Module not found: index')
+  if (!runtimeUrls[entry]) {
+    throw new Error(`devjar: Module not found: ${entry}`)
   }
 
-  const module: ModuleNamespace = await import(/* webpackIgnore: true */ /* @vite-ignore */ /* turbopackIgnore: true */ runtimeUrls['index'])
+  const module: ModuleNamespace = await import(/* webpackIgnore: true */ /* @vite-ignore */ /* turbopackIgnore: true */ runtimeUrls[entry])
   runtime.files = { ...files }
   return { module, changed: changedModules.size > 0 }
 }

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,0 +1,13 @@
+export const sourceExtensions = ['.tsx', '.ts', '.jsx', '.js']
+
+export function normalizeRoute(route: string) {
+  const cleanRoute = route.replace(/^\/+|\/+$/g, '')
+  return cleanRoute ? `/${cleanRoute}` : '/'
+}
+
+export function routeFromPagePath(pagePath: string) {
+  const extension = sourceExtensions.find(extension => pagePath.endsWith(extension))
+  if (!extension) return
+  const pathWithoutExtension = pagePath.slice(0, -extension.length)
+  return normalizeRoute(pathWithoutExtension.replace(/(?:^|\/)index$/, ''))
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,7 +10,7 @@ import {
   startDevServer,
 } from '../src/cli/index'
 import { CDN_HOST, createEsmShResolver } from '../src/cdn'
-import { replaceImports } from '../src/core'
+import { createIframeRouteManifest, linkModules } from '../src/core'
 import { compileProjectModule } from '../src/cli/modules'
 import { getTailwindBrowserUrl } from '../src/tailwind'
 
@@ -48,15 +48,44 @@ async function readChangeEvent(
 describe('project loading', () => {
   test('keeps parent-directory imports in the local module graph', async () => {
     await init
-    const transformed = replaceImports(
-      `import { Card } from '../components/card'; import '../styles.css'`,
-      './pages/index.tsx',
-      '@pages/index',
+    const linked = await linkModules(
+      {
+        'pages/index.tsx': `import { Card } from '../components/card'; import '../styles.css'`,
+        'components/card.tsx': 'export function Card() {}',
+        'styles.css': 'body {}',
+      },
       specifier => `https://esm.sh/${specifier}`,
-      new Set(['@components/card', '@styles.css'])
     )
-    expect(transformed.dependencies).toEqual(['@components/card', '@styles.css'])
-    expect(transformed.code).not.toContain('https://esm.sh/../')
+    expect(linked.dependencies['@pages/index.tsx']).toEqual([
+      '@components/card.tsx',
+      '@styles.css',
+    ])
+    expect(linked.files['@pages/index.tsx']).not.toContain('https://esm.sh/../')
+  })
+
+  test('uses CLI page conventions for iframe projects', () => {
+    expect(createIframeRouteManifest({
+      'pages/index.tsx': '',
+      'pages/about.tsx': '',
+      'pages/docs/index.jsx': '',
+      'pages/404.tsx': '',
+      'components/card.tsx': '',
+    })).toEqual({
+      routes: {
+        '/': '@pages/index.tsx',
+        '/404': '@pages/404.tsx',
+        '/about': '@pages/about.tsx',
+        '/docs': '@pages/docs/index.jsx',
+      },
+      notFound: '@pages/404.tsx',
+    })
+  })
+
+  test('keeps single-file iframe projects compatible', () => {
+    expect(createIframeRouteManifest({ 'index.js': '' })).toEqual({
+      routes: { '/': '@index.js' },
+      notFound: undefined,
+    })
   })
 
   test('shares the runtime CDN resolver', () => {
@@ -324,7 +353,7 @@ describe('production build', () => {
     expect(builtHtml).toContain('data-devjar-tailwind')
     expect(builtHtml).not.toContain('react-refresh')
     const runtimeFiles = await readdir(join(buildRoot, '__devjar'))
-    expect(runtimeFiles.some(file => /^cdn-.+\.js$/.test(file))).toBe(true)
+    expect(runtimeFiles.some(file => /^.+-[a-z0-9]+\.js$/.test(file))).toBe(true)
     expect(await readFile(join(buildRoot, 'api/projects.json'), 'utf8')).toContain('Mobile refresh')
     expect(await readFile(join(buildRoot, 'public/mark.svg'), 'utf8')).toContain('<svg')
   })


### PR DESCRIPTION
## Summary

- share page extension and route normalization rules between the iframe runtime and CLI
- support `pages/index.*`, nested routes, `pages/404.*`, and internal iframe navigation
- resolve local modules by canonical project paths while keeping legacy single-file `index.*` projects working
- update the hosted playground and docs to use the CLI-shaped file layout

## Verification

- `pnpm test` (15 passing)
- `pnpm exec tsc --noEmit`
- `pnpm build:site`
- browser smoke test against the production demo build