### PR TITLE
Statically render CLI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@
 
 devjar is a library that enables you to live test and share your code snippets and examples with others. devjar will generate a live code editor where you can run your code snippets and view the results in real-time based on the provided code content of your React app.
 
-**Notice:** devjar requires React 19 and only renders in the browser. Projects
-use the same `pages/` convention in the iframe runtime and CLI.
+**Notice:** devjar requires React 19. The iframe runtime and development server
+render in the browser; CLI production builds statically render each page.
+Projects use the same `pages/` convention in the iframe runtime and CLI.
 
 ## Install
 
@@ -196,18 +197,26 @@ The CLI applies dependency versions to CDN URLs using the
 
 ### Build and host
 
-Create a static client-rendered build, then serve it without source-file
-watching or on-request transforms:
+Create a static build, then serve it without source-file watching or on-request
+transforms:
 
 ```sh
 devjar build
 devjar start dist
 ```
 
-The generated HTML is an application shell; React page content still renders in
-the browser and is not server-rendered. The build contains the transformed local
-route graph, runtime assets, public files, and static API data. Package imports
-and Tailwind continue to load from the selected CDN.
+The build writes the initial React content and imported CSS into an HTML file for
+each route, then hydrates that content in the browser. Opening or hosting the
+HTML therefore shows page content before client JavaScript runs. Package imports
+are loaded from the selected CDN during static rendering and in the browser, so
+the project does not need a local `node_modules` directory.
+
+Files from `public/` are copied to the root of the output directory. For example,
+`public/logo.svg` becomes `dist/logo.svg` and remains available at `/logo.svg`.
+
+Static rendering executes every page once during the build. Browser APIs can be
+used in effects and event handlers, but using `window` or `document` directly
+during render will fail the build with the affected route.
 
 Use `--out-dir <directory>` to change the build location. The output directory
 must remain inside the project root.

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   ],
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "pnpm run build:lib && pnpm run build:client && pnpm run build:worker",
+    "build": "pnpm run build:lib && pnpm run build:client && pnpm run build:cli-assets && pnpm run build:worker",
     "build:lib": "bunchee",
     "build:client": "bun scripts/build-client.ts",
+    "build:cli-assets": "bun scripts/build-cli-assets.ts",
     "build:worker": "bun scripts/build-workers.ts",
     "prepublishOnly": "pnpm run build",
     "build:site": "pnpm run build && next build ./site",

--- a/scripts/build-cli-assets.ts
+++ b/scripts/build-cli-assets.ts
@@ -1,0 +1,9 @@
+import { cp } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const root = join(import.meta.dir, '..')
+
+await Promise.all([
+  cp(join(root, 'src/cli/http-loader.mjs'), join(root, 'dist/http-loader.mjs')),
+  cp(join(root, 'src/cli/prerender-runner.mjs'), join(root, 'dist/prerender-runner.mjs')),
+])

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -2,6 +2,7 @@ import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { testCdnModule } from './test-cdn'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const packageJson = await Bun.file(join(root, 'package.json')).json()
@@ -26,7 +27,9 @@ const files = new Set<string>(pack.files.map((file: { path: string }) => file.pa
 const required = [
   'dist/bin.js',
   'dist/client.js',
+  'dist/http-loader.mjs',
   'dist/index.js',
+  'dist/prerender-runner.mjs',
   'dist/transform-worker.js',
   'dist/transform.wasm32-wasi.wasm',
 ]
@@ -50,21 +53,44 @@ if (help.exitCode !== 0 || !help.stdout.toString().includes('default: localhost'
 
 const cliProject = mkdtempSync(join(tmpdir(), 'devjar-cli-'))
 cpSync(join(root, 'examples/basic'), cliProject, { recursive: true })
-const build = Bun.spawnSync(['node', 'dist/bin.js', 'build', cliProject], {
-  cwd: root,
-  stderr: 'inherit',
+const cdn = Bun.serve({
+  hostname: '127.0.0.1',
+  port: 0,
+  fetch(request) {
+    return new Response(testCdnModule(new URL(request.url).pathname), {
+      headers: { 'Content-Type': 'text/javascript' },
+    })
+  },
 })
+const build = Bun.spawn([
+  'node',
+  'dist/bin.js',
+  'build',
+  cliProject,
+  '--cdn',
+  `http://127.0.0.1:${cdn.port}`,
+], {
+  cwd: root,
+  stdout: 'pipe',
+  stderr: 'pipe',
+})
+const [buildOutput, buildError, buildExitCode] = await Promise.all([
+  new Response(build.stdout).text(),
+  new Response(build.stderr).text(),
+  build.exited,
+])
+cdn.stop(true)
 const usedDefaultOutput = existsSync(join(cliProject, 'dist', 'manifest.json'))
-const buildOutput = build.stdout.toString()
 rmSync(cliProject, { recursive: true, force: true })
 
 if (
-  build.exitCode !== 0
+  buildExitCode !== 0
   || !usedDefaultOutput
   || !buildOutput.includes('Devjar build complete')
   || !buildOutput.includes('Output  ')
   || !buildOutput.includes('Routes  2')
 ) {
+  if (buildError) console.error(buildError)
   throw new Error('The packaged CLI did not report a completed build in dist')
 }
 

--- a/scripts/test-cdn.ts
+++ b/scripts/test-cdn.ts
@@ -1,0 +1,29 @@
+export function testCdnModule(pathname: string) {
+  if (pathname.includes('/jsx-dev-runtime')) {
+    return `export const Fragment = Symbol.for('react.fragment')
+export function jsxDEV(type, props) { return { type, props: props || {} } }`
+  }
+  if (pathname.includes('/react-dom@') && pathname.includes('/server')) {
+    return `function escape(value) {
+  return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+}
+function render(node) {
+  if (node == null || typeof node === 'boolean') return ''
+  if (Array.isArray(node)) return node.map(render).join('')
+  if (typeof node === 'string' || typeof node === 'number') return escape(node)
+  if (typeof node.type === 'function') return render(node.type(node.props))
+  if (node.type === Symbol.for('react.fragment')) return render(node.props.children)
+  const attributes = Object.entries(node.props || {})
+    .filter(([name]) => name !== 'children')
+    .map(([name, value]) => ' ' + (name === 'className' ? 'class' : name) + '="' + escape(value) + '"')
+    .join('')
+  return '<' + node.type + attributes + '>' + render(node.props?.children) + '</' + node.type + '>'
+}
+export function renderToString(node) { return render(node) }`
+  }
+  if (pathname.includes('/react@')) {
+    return `export function createElement(type, props) { return { type, props: props || {} } }
+export default { createElement }`
+  }
+  return `throw new Error('Unknown test CDN module: ${pathname}')`
+}

--- a/src/bin/devjar.ts
+++ b/src/bin/devjar.ts
@@ -109,6 +109,7 @@ async function run() {
       root: root || process.cwd(),
       outDir: outDir || 'dist',
       cdn,
+      prerender: true,
     })
     console.log(style(1, 'Devjar build complete'))
     console.log('')

--- a/src/cli/client.tsx
+++ b/src/cli/client.tsx
@@ -1,5 +1,5 @@
 import React, { Component, type ElementType, type ReactNode } from 'react'
-import { createRoot } from 'react-dom/client'
+import { createRoot, hydrateRoot, type Root } from 'react-dom/client'
 import { createHotUpdater } from './hmr'
 import type { HmrChange, RouteEntry, RouteManifest } from './protocol'
 
@@ -26,10 +26,13 @@ function getRoot(id: string) {
 
 const hostRoot = getRoot('root')
 const errorRoot = getRoot('__devjarError')
-const appRoot = document.createElement('div')
-appRoot.id = '__reactRoot'
-hostRoot.appendChild(appRoot)
-const reactRoot = createRoot(appRoot)
+let appRoot = document.getElementById('__reactRoot')
+if (!appRoot) {
+  appRoot = document.createElement('div')
+  appRoot.id = '__reactRoot'
+  hostRoot.appendChild(appRoot)
+}
+let reactRoot: Root | undefined
 
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
@@ -132,11 +135,17 @@ async function load(route: string) {
     }
 
     renderRevision++
-    reactRoot.render(React.createElement(
+    const page = React.createElement(
       ErrorBoundary,
       { revision: renderRevision },
       React.createElement(module.default),
-    ))
+    )
+    if (!reactRoot && !routeManifest.liveReload && appRoot.hasChildNodes()) {
+      reactRoot = hydrateRoot(appRoot, page, { onRecoverableError: showError })
+    } else {
+      if (!reactRoot) reactRoot = createRoot(appRoot)
+      reactRoot.render(page)
+    }
     document.title = entry.page
     hideError()
     if (!performance.getEntriesByName('devjar:first-render').length) {

--- a/src/cli/http-loader.mjs
+++ b/src/cli/http-loader.mjs
@@ -1,0 +1,19 @@
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('http://') || specifier.startsWith('https://')) {
+    return { url: specifier, shortCircuit: true }
+  }
+  if ((context.parentURL?.startsWith('http://') || context.parentURL?.startsWith('https://'))
+    && (specifier.startsWith('/') || specifier.startsWith('.'))) {
+    return { url: new URL(specifier, context.parentURL).href, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}
+
+export async function load(url, context, nextLoad) {
+  if (url.startsWith('http://') || url.startsWith('https://')) {
+    const response = await fetch(url)
+    if (!response.ok) throw new Error(`Unable to load ${url}: ${response.status}`)
+    return { format: 'module', source: await response.text(), shortCircuit: true }
+  }
+  return nextLoad(url, context)
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@ import {
 import type { HmrChange, RouteEntry, RouteManifest } from './protocol'
 import { normalizeRoute, routeFromPagePath, sourceExtensions } from '../project'
 import { getTailwindBrowserUrl } from '../tailwind'
+import { prerender, type PrerenderedRoute } from './prerender'
 
 type PackageJson = {
   dependencies?: Record<string, string>
@@ -31,6 +32,7 @@ export type BuildOptions = {
   root: string
   outDir: string
   cdn: string | undefined
+  prerender: boolean
 }
 
 export type StartServerOptions = {
@@ -141,16 +143,20 @@ function send(
   response.end(request.method === 'HEAD' ? undefined : body)
 }
 
-function html(
-  dependencies: Record<string, string>,
-  cdn: string,
-  liveReload: boolean,
-) {
-  const resolveModule = createEsmShResolver(dependencies, cdn)
+type HtmlOptions = {
+  dependencies: Record<string, string>
+  cdn: string
+  liveReload: boolean
+  content: string
+  styles: string
+}
+
+function html(options: HtmlOptions) {
+  const resolveModule = createEsmShResolver(options.dependencies, options.cdn)
   const resolveRuntimeModule = createEsmShResolver({
-    ...dependencies,
+    ...options.dependencies,
     'es-module-lexer': '1.6.0',
-  }, cdn)
+  }, options.cdn)
   const imports = {
     react: resolveModule('react'),
     'react-dom': resolveModule('react-dom'),
@@ -159,18 +165,18 @@ function html(
     'react-dom/client': resolveModule('react-dom/client'),
     'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
     devjar: '/__devjar/runtime.js',
-    ...(liveReload
+    ...(options.liveReload
       ? { 'react-refresh/runtime': resolveRuntimeModule('react-refresh/runtime') }
       : {}),
   }
-  const tailwindUrl = getTailwindBrowserUrl(dependencies, cdn)
+  const tailwindUrl = getTailwindBrowserUrl(options.dependencies, options.cdn)
   const tailwindPreload = tailwindUrl
     ? `<link rel="modulepreload" href="${tailwindUrl}">`
     : ''
   const tailwindScript = tailwindUrl
     ? `<script data-devjar-tailwind type="module" src="${tailwindUrl}"></script>`
     : ''
-  const clientScript = liveReload
+  const clientScript = options.liveReload
     ? `<script type="module">
 import * as RefreshModule from 'react-refresh/runtime'
 const RefreshRuntime = RefreshModule.default || RefreshModule
@@ -179,11 +185,14 @@ globalThis.__devjarRefreshRuntime = RefreshRuntime
 await import('/__devjar/client.js')
 </script>`
     : '<script type="module" src="/__devjar/client.js"></script>'
+  const staticStyles = options.styles
+    ? `<style data-devjar-static>${options.styles.replace(/<\/style/gi, '<\\/style')}</style>`
+    : ''
   return `<!doctype html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Devjar</title>${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
-<style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>
-</head><body><div id="root"></div><pre id="__devjarError" class="devjar-error" hidden></pre><script>
+<style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>${staticStyles}
+</head><body><div id="root"><div id="__reactRoot">${options.content}</div></div><pre id="__devjarError" class="devjar-error" hidden></pre><script>
 const errorRoot = document.getElementById('__devjarError')
 const showBootstrapError = value => {
   errorRoot.hidden = false
@@ -305,6 +314,7 @@ export async function startDevServer(options: DevServerOptions) {
             cdn,
             moduleUrl: modules.moduleUrl,
             refresh: true,
+            platform: 'browser',
           })
           modules.update(projectPath, compiled)
           send(request, response, 200, 'text/javascript; charset=utf-8', compiled.code)
@@ -335,9 +345,13 @@ export async function startDevServer(options: DevServerOptions) {
         200,
         'text/html; charset=utf-8',
         html(
-          packageDependencies(packageJson),
-          resolveCdn(options.cdn),
-          true,
+          {
+            dependencies: packageDependencies(packageJson),
+            cdn: resolveCdn(options.cdn),
+            liveReload: true,
+            content: '',
+            styles: '',
+          },
         ),
       )
     } catch (error) {
@@ -465,6 +479,15 @@ async function copyApiFiles(source: string, destination: string) {
   }
 }
 
+async function copyPublicFiles(source: string, destination: string) {
+  if (!await directoryExists(source)) return
+  for (const entry of await readdir(source, { withFileTypes: true })) {
+    await cp(join(source, entry.name), join(destination, entry.name), {
+      recursive: entry.isDirectory(),
+    })
+  }
+}
+
 async function copyRuntimeAssets(destination: string) {
   const source = await runtimeRoot()
   await mkdir(destination, { recursive: true })
@@ -489,6 +512,31 @@ async function copyRuntimeAssets(destination: string) {
   }
 }
 
+function routeHtmlPath(outDir: string, route: string) {
+  return route === '/'
+    ? join(outDir, 'index.html')
+    : join(outDir, route.slice(1), 'index.html')
+}
+
+async function writeRouteHtml(
+  outDir: string,
+  route: string,
+  rendered: PrerenderedRoute,
+  options: Pick<HtmlOptions, 'dependencies' | 'cdn'>,
+) {
+  const outputPath = routeHtmlPath(outDir, route)
+  await mkdir(dirname(outputPath), { recursive: true })
+  const document = html({
+    dependencies: options.dependencies,
+    cdn: options.cdn,
+    liveReload: false,
+    content: rendered.markup,
+    styles: rendered.styles,
+  })
+  await writeFile(outputPath, document)
+  if (route === '/404') await writeFile(join(outDir, '404.html'), document)
+}
+
 export async function buildProject(options: BuildOptions) {
   const root = await realpath(resolve(options.root))
   const outDir = resolve(root, options.outDir)
@@ -506,6 +554,11 @@ export async function buildProject(options: BuildOptions) {
     revision: 0,
     moduleUrl: builtModuleUrl,
   })
+  const renderedRoutes = options.prerender
+    ? await prerender({ root, routes: discovered.routes, dependencies, cdn })
+    : Object.fromEntries([...discovered.routes.keys()].map(route => (
+        [route, { markup: '', styles: '' }]
+      )))
   const projectPaths = new Set<string>()
   for (const page of discovered.routes.values()) {
     const files = await collectProjectFiles(root, page)
@@ -514,8 +567,11 @@ export async function buildProject(options: BuildOptions) {
 
   await rm(outDir, { recursive: true, force: true })
   await mkdir(outDir, { recursive: true })
+  await copyPublicFiles(join(root, 'public'), outDir)
   await writeFile(join(outDir, 'manifest.json'), JSON.stringify(manifest))
-  await writeFile(join(outDir, 'index.html'), html(dependencies, cdn, false))
+  for (const route of Object.keys(manifest.routes)) {
+    await writeRouteHtml(outDir, route, renderedRoutes[route], { dependencies, cdn })
+  }
   await copyRuntimeAssets(join(outDir, '__devjar'))
   const modulesRoot = join(outDir, '__devjar/modules')
   await mkdir(modulesRoot, { recursive: true })
@@ -527,13 +583,11 @@ export async function buildProject(options: BuildOptions) {
       cdn,
       moduleUrl: builtModuleUrl,
       refresh: false,
+      platform: 'browser',
     })
     await writeFile(join(modulesRoot, moduleAssetName(projectPath)), compiled.code)
   }
   await writeFile(join(outDir, '__devjar/routes.json'), JSON.stringify(manifest))
-  if (await directoryExists(join(root, 'public'))) {
-    await cp(join(root, 'public'), join(outDir, 'public'), { recursive: true })
-  }
   await copyApiFiles(join(root, 'api'), join(outDir, 'api'))
 
   return { root, outDir, routes: Object.keys(manifest.routes) }
@@ -549,7 +603,13 @@ export async function startBuiltServer(options: StartServerOptions) {
   const port = options.port
   const manifest = JSON.parse(await readFile(join(root, 'manifest.json'), 'utf8')) as RouteManifest
   if (manifest.version !== 2) throw new Error(`Unsupported Devjar build version: ${manifest.version}`)
-  const shell = await readFile(join(root, 'index.html'), 'utf8')
+  const fallbackHtml = await readFile(join(root, 'index.html'), 'utf8')
+  const routeHtml = new Map<string, string>()
+  for (const route of Object.keys(manifest.routes)) {
+    const path = routeHtmlPath(root, route)
+    routeHtml.set(route, await fileExists(path) ? await readFile(path, 'utf8') : fallbackHtml)
+  }
+  const notFoundHtml = manifest.notFound ? routeHtml.get('/404') : undefined
 
   const server = createServer(async (request, response) => {
     try {
@@ -571,8 +631,20 @@ export async function startBuiltServer(options: StartServerOptions) {
         }
         return
       }
-      if (await serveFile(request, response, join(root, 'public'), url.pathname.slice(1), undefined)) return
-      send(request, response, 200, 'text/html; charset=utf-8', shell)
+      if (await serveFile(request, response, root, url.pathname.slice(1), undefined)) return
+      const route = normalizeRoute(url.pathname)
+      const routeDocument = routeHtml.get(route)
+      if (routeDocument) {
+        send(request, response, 200, 'text/html; charset=utf-8', routeDocument)
+        return
+      }
+      send(
+        request,
+        response,
+        404,
+        'text/html; charset=utf-8',
+        notFoundHtml || '<!doctype html><title>Not found</title><h1>404 — Not found</h1>',
+      )
     } catch (error) {
       send(request, response, 500, 'text/plain; charset=utf-8', error instanceof Error ? error.stack || error.message : String(error))
     }

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -27,6 +27,7 @@ export type CompileProjectModuleOptions = {
   cdn: string
   moduleUrl: (projectPath: string) => string
   refresh: boolean
+  platform: 'browser' | 'server'
 }
 
 async function fileExists(path: string) {
@@ -106,7 +107,7 @@ export function builtModuleUrl(projectPath: string) {
   return `/__devjar/modules/${moduleAssetName(projectPath)}`
 }
 
-function cssModule(source: string, projectPath: string) {
+function browserCssModule(source: string, projectPath: string) {
   return `const sheet = new CSSStyleSheet()
 sheet.replaceSync(${JSON.stringify(source)})
 globalThis.__devjarStyleSheets ||= new Map()
@@ -119,6 +120,10 @@ document.adoptedStyleSheets = sheets
 globalThis.__devjarStyleSheets.set(${JSON.stringify(projectPath)}, sheet)
 export default sheet
 `
+}
+
+function serverCssModule(source: string) {
+  return `export default ${JSON.stringify(source)}\n`
 }
 
 async function resolveProjectSource(root: string, projectPath: string) {
@@ -143,7 +148,9 @@ export async function compileProjectModule(
   const source = await readFile(sourcePath, 'utf8')
   if (extname(sourcePath) === '.css') {
     return {
-      code: cssModule(source, projectPath),
+      code: options.platform === 'browser'
+        ? browserCssModule(source, projectPath)
+        : serverCssModule(source),
       dependencies: [],
       refreshBoundary: false,
     }

--- a/src/cli/prerender-runner.mjs
+++ b/src/cli/prerender-runner.mjs
@@ -1,0 +1,26 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { register } from 'node:module'
+
+register(new URL('./http-loader.mjs', import.meta.url))
+
+const input = JSON.parse(await readFile(process.argv[2], 'utf8'))
+const reactModule = await import(input.react)
+const serverModule = await import(input.reactDomServer)
+const React = reactModule.default || reactModule
+const rendered = {}
+
+for (const [route, entry] of Object.entries(input.routes)) {
+  try {
+    const pageModule = await import(entry)
+    if (typeof pageModule.default !== 'function'
+      && (typeof pageModule.default !== 'object' || pageModule.default === null)) {
+      throw new Error('page must have a default React component export')
+    }
+    rendered[route] = serverModule.renderToString(React.createElement(pageModule.default))
+  } catch (error) {
+    throw new Error(`Unable to prerender ${route}: ${error?.stack || error}`)
+  }
+}
+
+await writeFile(input.outputPath, JSON.stringify(rendered))
+process.exit(0)

--- a/src/cli/prerender.ts
+++ b/src/cli/prerender.ts
@@ -1,0 +1,108 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { extname, join, relative, sep } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
+import { createEsmShResolver } from '../cdn'
+import { collectProjectFiles, compileProjectModule, moduleAssetName } from './modules'
+
+type PrerenderOptions = {
+  root: string
+  routes: Map<string, string>
+  dependencies: Record<string, string>
+  cdn: string
+}
+
+export type PrerenderedRoute = {
+  markup: string
+  styles: string
+}
+
+type RenderInput = {
+  routes: Record<string, string>
+  react: string
+  reactDomServer: string
+  outputPath: string
+}
+
+const runFile = promisify(execFile)
+
+function serverModuleName(projectPath: string) {
+  return `${moduleAssetName(projectPath)}.mjs`
+}
+
+function nodeExecutable() {
+  const versions = process.versions as NodeJS.ProcessVersions & { bun?: string }
+  return versions.bun ? 'node' : process.execPath
+}
+
+function renderError(error: unknown) {
+  if (!(error instanceof Error)) return String(error)
+  const stderr = (error as Error & { stderr?: string }).stderr?.trim()
+  return stderr || error.message
+}
+
+export async function prerender(options: PrerenderOptions) {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'devjar-prerender-'))
+  try {
+    const projectFiles = new Set<string>()
+    const routeFiles = new Map<string, Set<string>>()
+    for (const [route, entry] of options.routes) {
+      const files = await collectProjectFiles(options.root, entry)
+      routeFiles.set(route, files)
+      for (const projectPath of files) projectFiles.add(projectPath)
+    }
+
+    for (const projectPath of projectFiles) {
+      const compiled = await compileProjectModule({
+        root: options.root,
+        projectPath,
+        dependencies: options.dependencies,
+        cdn: options.cdn,
+        moduleUrl: importedPath => `./${serverModuleName(importedPath)}`,
+        refresh: false,
+        platform: 'server',
+      })
+      await writeFile(join(temporaryRoot, serverModuleName(projectPath)), compiled.code)
+    }
+
+    const outputPath = join(temporaryRoot, 'rendered.json')
+    const resolveModule = createEsmShResolver(options.dependencies, options.cdn)
+    const input: RenderInput = {
+      routes: Object.fromEntries([...options.routes].map(([route, entry]) => {
+        const projectPath = relative(options.root, entry).split(sep).join('/')
+        return [route, pathToFileURL(join(temporaryRoot, serverModuleName(projectPath))).href]
+      })),
+      react: resolveModule('react'),
+      reactDomServer: resolveModule('react-dom/server'),
+      outputPath,
+    }
+    const inputPath = join(temporaryRoot, 'input.json')
+    await writeFile(inputPath, JSON.stringify(input))
+
+    try {
+      const rendererPath = fileURLToPath(new URL('./prerender-runner.mjs', import.meta.url))
+      await runFile(nodeExecutable(), ['--no-warnings', rendererPath, inputPath], {
+        maxBuffer: 10 * 1024 * 1024,
+      })
+    } catch (error) {
+      throw new Error(renderError(error))
+    }
+
+    const markup = JSON.parse(await readFile(outputPath, 'utf8')) as Record<string, string>
+    const result: Record<string, PrerenderedRoute> = {}
+    for (const [route, files] of routeFiles) {
+      const styles: string[] = []
+      for (const projectPath of files) {
+        if (extname(projectPath) === '.css') {
+          styles.push(await readFile(join(options.root, projectPath), 'utf8'))
+        }
+      }
+      result[route] = { markup: markup[route], styles: styles.join('\n') }
+    }
+    return result
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true })
+  }
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
 import { cp, mkdir, mkdtemp, readFile, readdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { createServer as createHttpServer } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { init, parse } from 'es-module-lexer'
@@ -13,9 +14,11 @@ import { CDN_HOST, createEsmShResolver } from '../src/cdn'
 import { createIframeRouteManifest, linkModules } from '../src/core'
 import { compileProjectModule } from '../src/cli/modules'
 import { getTailwindBrowserUrl } from '../src/tailwind'
+import { testCdnModule } from '../scripts/test-cdn'
 
 const root = resolve(import.meta.dir, '../examples/basic')
 const dashboardRoot = resolve(import.meta.dir, '../examples/dashboard')
+
 function testModuleUrl(projectPath: string) {
   return `/modules/${projectPath}`
 }
@@ -120,6 +123,7 @@ describe('project loading', () => {
       cdn: 'https://modules.example.test/',
       moduleUrl: testModuleUrl,
       refresh: false,
+      platform: 'browser',
     })
     expect(compiled.code).toContain('https://modules.example.test/react@19.2.0/jsx-dev-runtime?dev')
   })
@@ -137,6 +141,7 @@ describe('project loading', () => {
         root: projectRoot,
         outDir: 'dist',
         cdn: undefined,
+        prerender: false,
       })
       const manifest = JSON.parse(await readFile(join(result.outDir, 'manifest.json'), 'utf8'))
       const entry = await readFile(join(result.outDir, manifest.routes['/'].module), 'utf8')
@@ -180,6 +185,7 @@ describe('project loading', () => {
         cdn: CDN_HOST,
         moduleUrl: testModuleUrl,
         refresh: false,
+        platform: 'browser',
       })
       expect(compiled.code).toContain(`import("/modules/components/card.tsx")`)
     } finally {
@@ -329,6 +335,7 @@ describe('production build', () => {
       root: projectRoot,
       outDir: 'dist',
       cdn: 'https://modules.example.test/',
+      prerender: false,
     })
     buildRoot = result.outDir
   })
@@ -355,7 +362,7 @@ describe('production build', () => {
     const runtimeFiles = await readdir(join(buildRoot, '__devjar'))
     expect(runtimeFiles.some(file => /^.+-[a-z0-9]+\.js$/.test(file))).toBe(true)
     expect(await readFile(join(buildRoot, 'api/projects.json'), 'utf8')).toContain('Mobile refresh')
-    expect(await readFile(join(buildRoot, 'public/mark.svg'), 'utf8')).toContain('<svg')
+    expect(await readFile(join(buildRoot, 'mark.svg'), 'utf8')).toContain('<svg')
   })
 
   test('refuses to clean an output directory outside the project', async () => {
@@ -363,6 +370,7 @@ describe('production build', () => {
       root: projectRoot,
       outDir: '../outside',
       cdn: undefined,
+      prerender: false,
     })).rejects.toThrow(
       'The build output must be a directory inside the project root',
     )
@@ -386,5 +394,63 @@ describe('production build', () => {
     expect(await (await fetch(`${base}/mark.svg`)).text()).toContain('<svg')
 
     await server.close()
+  })
+})
+
+describe('static export', () => {
+  test('writes rendered page content and styles into route HTML', async () => {
+    const cdn = createHttpServer((request, response) => {
+      response.writeHead(200, { 'Content-Type': 'text/javascript' })
+      response.end(testCdnModule(new URL(request.url || '/', 'http://localhost').pathname))
+    })
+    await new Promise<void>((resolvePromise, reject) => {
+      cdn.once('error', reject)
+      cdn.listen(0, '127.0.0.1', resolvePromise)
+    })
+    const address = cdn.address() as import('node:net').AddressInfo
+    const projectRoot = await mkdtemp(join(tmpdir(), 'devjar-static-export-'))
+    try {
+      await mkdir(join(projectRoot, 'pages'))
+      await mkdir(join(projectRoot, 'pages/guides'))
+      await writeFile(join(projectRoot, 'package.json'), JSON.stringify({
+        dependencies: { react: '19.2.0', 'react-dom': '19.2.0' },
+      }))
+      await writeFile(
+        join(projectRoot, 'pages/index.tsx'),
+        `import '../styles.css'
+export default function Page() { return <main className="page"><h1>Static now</h1></main> }`,
+      )
+      await writeFile(
+        join(projectRoot, 'pages/guides/about.tsx'),
+        `export default function About() { return <h1>About statically rendered</h1> }`,
+      )
+      await writeFile(
+        join(projectRoot, 'pages/404.tsx'),
+        `export default function NotFound() { return <h1>Static not found</h1> }`,
+      )
+      await writeFile(join(projectRoot, 'styles.css'), '.page { color: black; }')
+
+      const result = await buildProject({
+        root: projectRoot,
+        outDir: 'dist',
+        cdn: `http://127.0.0.1:${address.port}`,
+        prerender: true,
+      })
+      const document = await readFile(join(result.outDir, 'index.html'), 'utf8')
+      expect(document).toContain('<main class="page"><h1>Static now</h1></main>')
+      expect(document).toContain('<style data-devjar-static>.page { color: black; }</style>')
+      expect(document).toContain('<div id="__reactRoot">')
+      expect(await readFile(join(result.outDir, 'guides/about/index.html'), 'utf8'))
+        .toContain('<h1>About statically rendered</h1>')
+      expect(await readFile(join(result.outDir, '404.html'), 'utf8'))
+        .toContain('<h1>Static not found</h1>')
+      expect(await readFile(join(result.outDir, '404/index.html'), 'utf8'))
+        .toContain('<h1>Static not found</h1>')
+      expect(await readFile(join(result.outDir, '__devjar/client.js'), 'utf8'))
+        .toContain('hydrateRoot')
+    } finally {
+      await new Promise<void>(resolvePromise => cdn.close(() => resolvePromise()))
+      await rm(projectRoot, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
## Summary

- prerender every static page into route-specific HTML during devjar build
- hydrate existing markup while keeping development browser-rendered
- support nested static route documents and custom 404.html output
- inline imported CSS and copy public assets to the output root
- load build-time React dependencies from the configured CDN without project-local node_modules

## Validation

- pnpm build
- pnpm test
- pnpm test:package
- real esm.sh builds for the basic and dashboard examples
- browser hydration check with no console errors

Tracks #69. Dynamic and catch-all routes remain out of scope.