### PR TITLE
Self-host the Devjar runtime in CLI projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ the project does not need a local `node_modules` directory.
 
 Files from `public/` are copied to the root of the output directory. For example,
 `public/logo.svg` becomes `dist/logo.svg` and remains available at `/logo.svg`.
+Imports from `devjar` use the runtime and worker assets included in the build
+instead of loading another copy of Devjar from the package CDN.
 
 Static rendering executes every page once during the build. Browser APIs can be
 used in effects and event handlers, but using `window` or `document` directly

--- a/scripts/test-cdn.ts
+++ b/scripts/test-cdn.ts
@@ -1,7 +1,13 @@
 export function testCdnModule(pathname: string) {
-  if (pathname.includes('/jsx-dev-runtime')) {
+  if (pathname.includes('/es-module-lexer@')) {
+    return `export const init = Promise.resolve()
+export function parse() { return [[], []] }`
+  }
+  if (pathname.includes('/jsx-runtime') || pathname.includes('/jsx-dev-runtime')) {
     return `export const Fragment = Symbol.for('react.fragment')
-export function jsxDEV(type, props) { return { type, props: props || {} } }`
+export function jsx(type, props) { return { type, props: props || {} } }
+export const jsxs = jsx
+export const jsxDEV = jsx`
   }
   if (pathname.includes('/react-dom@') && pathname.includes('/server')) {
     return `function escape(value) {
@@ -23,6 +29,13 @@ export function renderToString(node) { return render(node) }`
   }
   if (pathname.includes('/react@')) {
     return `export function createElement(type, props) { return { type, props: props || {} } }
+export function useCallback(callback) { return callback }
+export function useEffect() {}
+export function useId() { return 'test-id' }
+export function useImperativeHandle() {}
+export function useMemo(factory) { return factory() }
+export function useRef(value) { return { current: value } }
+export function useState(value) { return [typeof value === 'function' ? value() : value, () => {}] }
 export default { createElement }`
   }
   return `throw new Error('Unknown test CDN module: ${pathname}')`

--- a/src/cli/http-loader.mjs
+++ b/src/cli/http-loader.mjs
@@ -1,4 +1,13 @@
+let imports = {}
+
+export function initialize(data) {
+  imports = data.imports
+}
+
 export async function resolve(specifier, context, nextResolve) {
+  if (imports[specifier]) {
+    return { url: imports[specifier], shortCircuit: true }
+  }
   if (specifier.startsWith('http://') || specifier.startsWith('https://')) {
     return { url: specifier, shortCircuit: true }
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -98,6 +98,15 @@ function packageDependencies(packageJson: PackageJson) {
   }
 }
 
+async function readDevjarDependencies(assetsRoot: string) {
+  const packageJson = await readPackage(dirname(assetsRoot))
+  const esModuleLexer = packageJson.dependencies?.['es-module-lexer']
+  if (!esModuleLexer) {
+    throw new Error('Devjar is missing its es-module-lexer dependency')
+  }
+  return { 'es-module-lexer': esModuleLexer }
+}
+
 function resolveCdn(override: string | undefined) {
   return normalizeCdnHost(override || CDN_HOST)
 }
@@ -145,6 +154,7 @@ function send(
 
 type HtmlOptions = {
   dependencies: Record<string, string>
+  devjarDependencies: Record<string, string>
   cdn: string
   liveReload: boolean
   content: string
@@ -155,7 +165,7 @@ function html(options: HtmlOptions) {
   const resolveModule = createEsmShResolver(options.dependencies, options.cdn)
   const resolveRuntimeModule = createEsmShResolver({
     ...options.dependencies,
-    'es-module-lexer': '1.6.0',
+    ...options.devjarDependencies,
   }, options.cdn)
   const imports = {
     react: resolveModule('react'),
@@ -251,6 +261,7 @@ export async function startDevServer(options: DevServerOptions) {
   const port = options.port
   const events = new Set<ServerResponse>()
   const assetsRoot = await runtimeRoot()
+  const devjarDependencies = await readDevjarDependencies(assetsRoot)
   const modules = new DevModuleGraph()
   let revision = 0
 
@@ -348,6 +359,7 @@ export async function startDevServer(options: DevServerOptions) {
         html(
           {
             dependencies: packageDependencies(packageJson),
+            devjarDependencies,
             cdn: resolveCdn(options.cdn),
             liveReload: true,
             content: '',
@@ -523,12 +535,13 @@ async function writeRouteHtml(
   outDir: string,
   route: string,
   rendered: PrerenderedRoute,
-  options: Pick<HtmlOptions, 'dependencies' | 'cdn'>,
+  options: Pick<HtmlOptions, 'dependencies' | 'devjarDependencies' | 'cdn'>,
 ) {
   const outputPath = routeHtmlPath(outDir, route)
   await mkdir(dirname(outputPath), { recursive: true })
   const document = html({
     dependencies: options.dependencies,
+    devjarDependencies: options.devjarDependencies,
     cdn: options.cdn,
     liveReload: false,
     content: rendered.markup,
@@ -548,6 +561,8 @@ export async function buildProject(options: BuildOptions) {
 
   const packageJson = await readPackage(root)
   const dependencies = packageDependencies(packageJson)
+  const runtime = await runtimeRoot()
+  const devjarDependencies = await readDevjarDependencies(runtime)
   const cdn = resolveCdn(options.cdn)
   const discovered = await discoverRoutes(root)
   const manifest = await loadRouteManifest(root, {
@@ -560,8 +575,9 @@ export async function buildProject(options: BuildOptions) {
         root,
         routes: discovered.routes,
         dependencies,
+        devjarDependencies,
         cdn,
-        runtimeModulePath: join(await runtimeRoot(), 'index.js'),
+        runtimeModulePath: join(runtime, 'index.js'),
       })
     : Object.fromEntries([...discovered.routes.keys()].map(route => (
         [route, { markup: '', styles: '' }]
@@ -577,7 +593,11 @@ export async function buildProject(options: BuildOptions) {
   await copyPublicFiles(join(root, 'public'), outDir)
   await writeFile(join(outDir, 'manifest.json'), JSON.stringify(manifest))
   for (const route of Object.keys(manifest.routes)) {
-    await writeRouteHtml(outDir, route, renderedRoutes[route], { dependencies, cdn })
+    await writeRouteHtml(outDir, route, renderedRoutes[route], {
+      dependencies,
+      devjarDependencies,
+      cdn,
+    })
   }
   await copyRuntimeAssets(join(outDir, '__devjar'))
   const modulesRoot = join(outDir, '__devjar/modules')

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -313,6 +313,7 @@ export async function startDevServer(options: DevServerOptions) {
             dependencies,
             cdn,
             moduleUrl: modules.moduleUrl,
+            runtimeModuleUrl: '/__devjar/runtime.js',
             refresh: true,
             platform: 'browser',
           })
@@ -555,7 +556,13 @@ export async function buildProject(options: BuildOptions) {
     moduleUrl: builtModuleUrl,
   })
   const renderedRoutes = options.prerender
-    ? await prerender({ root, routes: discovered.routes, dependencies, cdn })
+    ? await prerender({
+        root,
+        routes: discovered.routes,
+        dependencies,
+        cdn,
+        runtimeModulePath: join(await runtimeRoot(), 'index.js'),
+      })
     : Object.fromEntries([...discovered.routes.keys()].map(route => (
         [route, { markup: '', styles: '' }]
       )))
@@ -582,6 +589,7 @@ export async function buildProject(options: BuildOptions) {
       dependencies,
       cdn,
       moduleUrl: builtModuleUrl,
+      runtimeModuleUrl: '/__devjar/runtime.js',
       refresh: false,
       platform: 'browser',
     })

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -26,6 +26,7 @@ export type CompileProjectModuleOptions = {
   dependencies: Record<string, string>
   cdn: string
   moduleUrl: (projectPath: string) => string
+  runtimeModuleUrl: string
   refresh: boolean
   platform: 'browser' | 'server'
 }
@@ -172,7 +173,9 @@ export async function compileProjectModule(
   for (const imported of imports) {
     if (!imported.n) continue
     let value: string
-    if (imported.n.startsWith('./') || imported.n.startsWith('../')) {
+    if (imported.n === 'devjar') {
+      value = options.runtimeModuleUrl
+    } else if (imported.n.startsWith('./') || imported.n.startsWith('../')) {
       const importedPath = await resolveProjectSource(
         options.root,
         relative(options.root, resolve(sourcePath, '..', imported.n)),

--- a/src/cli/prerender-runner.mjs
+++ b/src/cli/prerender-runner.mjs
@@ -1,9 +1,10 @@
 import { readFile, writeFile } from 'node:fs/promises'
 import { register } from 'node:module'
 
-register(new URL('./http-loader.mjs', import.meta.url))
-
 const input = JSON.parse(await readFile(process.argv[2], 'utf8'))
+register(new URL('./http-loader.mjs', import.meta.url), {
+  data: { imports: input.imports },
+})
 const reactModule = await import(input.react)
 const serverModule = await import(input.reactDomServer)
 const React = reactModule.default || reactModule

--- a/src/cli/prerender.ts
+++ b/src/cli/prerender.ts
@@ -11,6 +11,7 @@ type PrerenderOptions = {
   root: string
   routes: Map<string, string>
   dependencies: Record<string, string>
+  devjarDependencies: Record<string, string>
   cdn: string
   runtimeModulePath: string
 }
@@ -72,6 +73,10 @@ export async function prerender(options: PrerenderOptions) {
 
     const outputPath = join(temporaryRoot, 'rendered.json')
     const resolveModule = createEsmShResolver(options.dependencies, options.cdn)
+    const resolveRuntimeModule = createEsmShResolver({
+      ...options.dependencies,
+      ...options.devjarDependencies,
+    }, options.cdn)
     const input: RenderInput = {
       routes: Object.fromEntries([...options.routes].map(([route, entry]) => {
         const projectPath = relative(options.root, entry).split(sep).join('/')
@@ -83,10 +88,7 @@ export async function prerender(options: PrerenderOptions) {
         react: resolveModule('react'),
         'react/jsx-runtime': resolveModule('react/jsx-runtime'),
         'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
-        'es-module-lexer': createEsmShResolver({
-          ...options.dependencies,
-          'es-module-lexer': '1.6.0',
-        }, options.cdn)('es-module-lexer'),
+        'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
       },
       outputPath,
     }

--- a/src/cli/prerender.ts
+++ b/src/cli/prerender.ts
@@ -12,6 +12,7 @@ type PrerenderOptions = {
   routes: Map<string, string>
   dependencies: Record<string, string>
   cdn: string
+  runtimeModulePath: string
 }
 
 export type PrerenderedRoute = {
@@ -23,6 +24,7 @@ type RenderInput = {
   routes: Record<string, string>
   react: string
   reactDomServer: string
+  imports: Record<string, string>
   outputPath: string
 }
 
@@ -61,6 +63,7 @@ export async function prerender(options: PrerenderOptions) {
         dependencies: options.dependencies,
         cdn: options.cdn,
         moduleUrl: importedPath => `./${serverModuleName(importedPath)}`,
+        runtimeModuleUrl: pathToFileURL(options.runtimeModulePath).href,
         refresh: false,
         platform: 'server',
       })
@@ -76,6 +79,15 @@ export async function prerender(options: PrerenderOptions) {
       })),
       react: resolveModule('react'),
       reactDomServer: resolveModule('react-dom/server'),
+      imports: {
+        react: resolveModule('react'),
+        'react/jsx-runtime': resolveModule('react/jsx-runtime'),
+        'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
+        'es-module-lexer': createEsmShResolver({
+          ...options.dependencies,
+          'es-module-lexer': '1.6.0',
+        }, options.cdn)('es-module-lexer'),
+      },
       outputPath,
     }
     const inputPath = join(temporaryRoot, 'input.json')

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -122,6 +122,7 @@ describe('project loading', () => {
       dependencies: { react: '19.2.0' },
       cdn: 'https://modules.example.test/',
       moduleUrl: testModuleUrl,
+      runtimeModuleUrl: '/__devjar/runtime.js',
       refresh: false,
       platform: 'browser',
     })
@@ -184,6 +185,7 @@ describe('project loading', () => {
         dependencies: {},
         cdn: CDN_HOST,
         moduleUrl: testModuleUrl,
+        runtimeModuleUrl: '/__devjar/runtime.js',
         refresh: false,
         platform: 'browser',
       })
@@ -418,7 +420,10 @@ describe('static export', () => {
       await writeFile(
         join(projectRoot, 'pages/index.tsx'),
         `import '../styles.css'
-export default function Page() { return <main className="page"><h1>Static now</h1></main> }`,
+import { DevJar } from 'devjar'
+export default function Page() {
+  return <main className="page"><h1>Static now</h1><DevJar files={{ 'pages/index.jsx': 'export default function Page() {}' }} /></main>
+}`,
       )
       await writeFile(
         join(projectRoot, 'pages/guides/about.tsx'),
@@ -437,7 +442,8 @@ export default function Page() { return <main className="page"><h1>Static now</h
         prerender: true,
       })
       const document = await readFile(join(result.outDir, 'index.html'), 'utf8')
-      expect(document).toContain('<main class="page"><h1>Static now</h1></main>')
+      expect(document).toContain('<main class="page"><h1>Static now</h1>')
+      expect(document).toContain('<iframe')
       expect(document).toContain('<style data-devjar-static>.page { color: black; }</style>')
       expect(document).toContain('<div id="__reactRoot">')
       expect(await readFile(join(result.outDir, 'guides/about/index.html'), 'utf8'))
@@ -448,6 +454,10 @@ export default function Page() { return <main className="page"><h1>Static now</h
         .toContain('<h1>Static not found</h1>')
       expect(await readFile(join(result.outDir, '__devjar/client.js'), 'utf8'))
         .toContain('hydrateRoot')
+      const manifest = JSON.parse(await readFile(join(result.outDir, 'manifest.json'), 'utf8'))
+      const pageModule = await readFile(join(result.outDir, manifest.routes['/'].module), 'utf8')
+      expect(pageModule).toContain('/__devjar/runtime.js')
+      expect(pageModule).not.toContain(`${address.port}/devjar`)
     } finally {
       await new Promise<void>(resolvePromise => cdn.close(() => resolvePromise()))
       await rm(projectRoot, { recursive: true, force: true })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -129,13 +129,14 @@ describe('project loading', () => {
     expect(compiled.code).toContain('https://modules.example.test/react@19.2.0/jsx-dev-runtime?dev')
   })
 
-  test('ignores package configuration outside dependency versions', async () => {
+  test('uses project dependencies for the app and Devjar dependencies for its runtime', async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), 'devjar-zero-config-'))
     try {
       await cp(root, projectRoot, { recursive: true })
       const packageJsonPath = join(projectRoot, 'package.json')
       const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
       packageJson.devjar = { cdn: 'https://modules.example.test/' }
+      packageJson.dependencies['es-module-lexer'] = '9.9.9'
       await writeFile(packageJsonPath, JSON.stringify(packageJson))
 
       const result = await buildProject({
@@ -146,8 +147,15 @@ describe('project loading', () => {
       })
       const manifest = JSON.parse(await readFile(join(result.outDir, 'manifest.json'), 'utf8'))
       const entry = await readFile(join(result.outDir, manifest.routes['/'].module), 'utf8')
+      const document = await readFile(join(result.outDir, 'index.html'), 'utf8')
+      const devjarPackage = JSON.parse(
+        await readFile(resolve(import.meta.dir, '../package.json'), 'utf8'),
+      )
+      const lexerVersion = encodeURIComponent(devjarPackage.dependencies['es-module-lexer'])
       expect(entry).toContain('https://esm.sh/react@19.2.0/jsx-dev-runtime?dev')
       expect(entry).not.toContain('modules.example.test')
+      expect(document).toContain(`https://esm.sh/es-module-lexer@${lexerVersion}`)
+      expect(document).not.toContain('es-module-lexer@9.9.9')
     } finally {
       await rm(projectRoot, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary

- resolve project imports from devjar to the runtime emitted under /__devjar
- use that same local runtime while prerendering pages
- teach the isolated CDN loader to resolve the local runtime external imports
- verify a statically exported page can render a nested DevJar iframe without a second CDN copy of Devjar

## Validation

- pnpm build
- pnpm test
- pnpm test:package

Tracks #69.