### PR TITLE
Fix the editor cursor and rapid-update HMR

### DIFF
--- a/site/ui/codesandbox.tsx
+++ b/site/ui/codesandbox.tsx
@@ -10,6 +10,7 @@ const REACT_DEV_MODULES = new Set([
   'react/jsx-runtime',
   'react/jsx-dev-runtime',
 ])
+const editorTextareaProps = { style: { caretColor: '#171717' } }
 
 function resolveModule(specifier: string) {
   const url = `${CDN_HOST}/${specifier}`
@@ -536,15 +537,16 @@ export function Codesandbox({
             title={null}
             lineNumbers={true}
             fontSize={13}
+            textareaProps={editorTextareaProps}
             extension={activeExtension}
             data-active-extension={activeExtension}
             value={activeFile ? files[activeFile] || '' : ''}
             onChange={(code) => {
               if (activeFile) {
-                setFiles({
-                  ...files,
+                setFiles((currentFiles) => ({
+                  ...currentFiles,
                   [activeFile]: code,
-                })
+                }))
               }
             }}
           />

--- a/src/core.ts
+++ b/src/core.ts
@@ -299,6 +299,8 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     typeof import('react'),
     typeof import('react-dom/client'),
   ]> | undefined
+  let renderRequestId = 0
+  let renderQueue = Promise.resolve()
   let revision = 0
   const moduleRuntime: ModuleRuntime = {}
   let currentFiles: Record<string, string> = {}
@@ -310,14 +312,12 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     errorBoundary = value
   }
 
-  async function render(
+  async function renderCurrent(
     files: Record<string, string>,
     dependencies: Record<string, string[]>,
     manifest: IframeRouteManifest,
+    requestId: number,
   ) {
-    currentFiles = files
-    currentDependencies = dependencies
-    currentManifest = manifest
     const cleanRoute = currentRoute.replace(/^\/+|\/+$/g, '')
     const route = cleanRoute ? `/${cleanRoute}` : '/'
     const entry = manifest.routes[route] || manifest.notFound
@@ -342,6 +342,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
       ])
     }
     const [ReactMod, ReactDOMMod] = await rendererModules
+    if (requestId !== renderRequestId) return
 
     const _jsx = ReactMod.createElement
     const root = document.getElementById('__reactRoot')
@@ -434,6 +435,23 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
         ))
       }
     }
+  }
+
+  function render(
+    files: Record<string, string>,
+    dependencies: Record<string, string[]>,
+    manifest: IframeRouteManifest,
+  ) {
+    const requestId = ++renderRequestId
+    currentFiles = files
+    currentDependencies = dependencies
+    currentManifest = manifest
+    const pendingRender = renderQueue.then(() => {
+      if (requestId !== renderRequestId) return
+      return renderCurrent(files, dependencies, manifest, requestId)
+    })
+    renderQueue = pendingRender.catch(() => {})
+    return pendingRender
   }
 
   document.addEventListener('click', (event) => {
@@ -672,6 +690,7 @@ function useLiveCode({
         }
       }
       const linked = await linkModules(transformedSources, resolveModuleForLoad)
+      if (loadId !== loadIdRef.current) return
 
       const iframe = iframeRef.current
       const script = appScriptRef.current
@@ -680,6 +699,7 @@ function useLiveCode({
         if (!contentWindow) throw new Error('devjar: iframe window is unavailable')
         const renderFiles = async () => {
           await tailwindReadyRef.current
+          if (loadId !== loadIdRef.current) return
           const render = contentWindow.__render__
           if (!render) throw new Error('devjar: renderer was not initialized')
           await render(linked.files, linked.dependencies, manifest)

--- a/src/module.ts
+++ b/src/module.ts
@@ -40,8 +40,9 @@ async function createModule(
     return `${localImportPrefix}${encodeURIComponent(moduleKey)}__`
   }
 
-  function createInlinedModule(code: string) {
-    return `data:text/javascript;utf-8,${encodeURIComponent(code)}`
+  function createInlinedModule(code: string, moduleKey: string, revision: number) {
+    const versionedCode = `${code}\n// devjar:${revision}:${encodeURIComponent(moduleKey)}`
+    return `data:text/javascript;utf-8,${encodeURIComponent(versionedCode)}`
   }
 
   function createCssModule(code: string) {
@@ -64,6 +65,7 @@ export default sheet;`
   runtime.files ||= {}
   runtime.urls ||= {}
   runtime.revision = (runtime.revision || 0) + 1
+  const revision = runtime.revision
   const runtimeFiles = runtime.files
   const runtimeUrls = runtime.urls
 
@@ -128,7 +130,7 @@ export default sheet;`
       ? moduleSources[moduleKey]
       : rewriteLocalImports(moduleSources[moduleKey], specifiers)
 
-    runtimeUrls[moduleKey] = createInlinedModule(moduleCode)
+    runtimeUrls[moduleKey] = createInlinedModule(moduleCode, moduleKey, revision)
     buildingUrls.delete(moduleKey)
     return runtimeUrls[moduleKey]
   }
@@ -157,7 +159,7 @@ export default sheet;`
   }
 
   const module: ModuleNamespace = await import(/* webpackIgnore: true */ /* @vite-ignore */ /* turbopackIgnore: true */ runtimeUrls[entry])
-  runtime.files = { ...files }
+  if (runtime.revision === revision) runtime.files = { ...files }
   return { module, changed: changedModules.size > 0 }
 }
 

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from 'bun:test'
+import { createModule, type ModuleRuntime } from '../src/module'
+
+const refreshRuntimeUrl = `data:text/javascript;utf-8,${encodeURIComponent(`
+export default {
+  injectIntoGlobalHook() {},
+  performReactRefresh() {},
+}
+`)}`
+
+test('keeps the latest files when module updates finish out of order', async () => {
+  const runtime: ModuleRuntime = {}
+  const options = {
+    resolveModule: () => refreshRuntimeUrl,
+    dependencies: { '@index.js': [] },
+    runtime,
+    entry: '@index.js',
+  }
+  const oldSource = `
+await new Promise(resolve => setTimeout(resolve, 30))
+export default 'old'
+`
+  const newSource = `export default 'new'`
+
+  const oldUpdate = createModule({ '@index.js': oldSource }, options)
+  await new Promise(resolve => setTimeout(resolve, 5))
+  const newUpdate = createModule({ '@index.js': newSource }, options)
+  await Promise.all([oldUpdate, newUpdate])
+
+  expect(runtime.files?.['@index.js']).toBe(newSource)
+})
+
+test('evaluates a module again when its source returns to an earlier value', async () => {
+  const runtime: ModuleRuntime = {}
+  const options = {
+    resolveModule: () => refreshRuntimeUrl,
+    dependencies: { '@index.js': [] },
+    runtime,
+    entry: '@index.js',
+  }
+  const testGlobal = globalThis as typeof globalThis & {
+    __devjarTestExecutions?: number
+  }
+  const source = (value: string) => `
+globalThis.__devjarTestExecutions = (globalThis.__devjarTestExecutions || 0) + 1
+export default '${value}'
+`
+
+  delete testGlobal.__devjarTestExecutions
+  try {
+    await createModule({ '@index.js': source('a') }, options)
+    const firstUrl = runtime.urls?.['@index.js']
+    await createModule({ '@index.js': source('b') }, options)
+    await createModule({ '@index.js': source('a') }, options)
+
+    expect(testGlobal.__devjarTestExecutions).toBe(3)
+    expect(runtime.urls?.['@index.js']).not.toBe(firstUrl)
+  } finally {
+    delete testGlobal.__devjarTestExecutions
+  }
+})


### PR DESCRIPTION
## Summary

- give the layered Sugar High textarea an explicit visible caret color
- use functional editor state updates so rapid input cannot overwrite newer file state
- serialize iframe renders and prevent older module loads from restoring outdated runtime files
- revision invalidated data-module URLs so deleting and retyping a previous value executes it again instead of reusing the browser import cache
- cover out-of-order completion and `A → B → A` source revisits with regression tests

## Verification

- `pnpm test` (18 passing)
- `pnpm test:package`
- `pnpm build:site`
- browser-tested 40 consecutive `A ↔ B` transitions after reproducing 49 failures in 50 transitions before the fix
- browser-tested page JSX, CSS, and imported-module deletion bursts