### PR TITLE
Add pages-based website example

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,15 +223,18 @@ during render will fail the build with the affected route.
 Use `--out-dir <directory>` to change the build location. The output directory
 must remain inside the project root.
 
-The repository includes two runnable examples:
+The repository includes three runnable examples:
 
 ```sh
 devjar dev examples/basic
 devjar dev examples/dashboard
+devjar dev examples/website
 ```
 
 The dashboard demonstrates page navigation, shared components, a CDN-loaded
 icon package, Tailwind, static API data, and a public SVG asset.
+The website example runs Devjar's own editor and live preview as a pages-based
+Devjar project.
 
 ```sh
 devjar dev [root] --host localhost --port 3000
@@ -239,12 +242,13 @@ devjar dev [root] --host localhost --port 3000
 
 ## Notice: iframe cross-origin isolation
 
-This notice applies to the `<DevJar>` iframe runtime, not the Devjar CLI.
-
 The iframe transforms code in the browser using Oxc and shared WebAssembly
 memory, so its host page must be cross-origin isolated. Devjar packages the
 browser transformer, WASM binary, and helper worker as lazy runtime assets;
 compatible bundlers emit these files without requiring a manual copy step.
+The `devjar dev` and `devjar start` servers send the required headers
+automatically. Static deployments must configure equivalent headers on their
+hosting platform.
 
 <details>
 <summary>Next.js headers example</summary>

--- a/examples/website/components/codesandbox.css
+++ b/examples/website/components/codesandbox.css
@@ -1,0 +1,483 @@
+textarea:focus,
+textarea:focus-visible {
+  outline: none;
+}
+.preview {
+  position: relative;
+  border-top: 1px solid #dfe0e5;
+  background-color: #fff;
+  container-type: inline-size;
+  overflow: hidden;
+  min-height: 320px;
+}
+.preview--result {
+  font-family: Consolas, Monaco, monospace;
+  border: none;
+  font-size: 16px;
+  line-height: 1.25em;
+  width: 100%;
+  height: 100%;
+  min-height: 320px;
+  display: block;
+  overflow: hidden;
+  opacity: 0;
+  position: relative;
+  z-index: 1;
+  transition: opacity 0.32s ease;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.preview--result.is-ready {
+  opacity: 1;
+}
+
+.preview--result::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+.preview--loading {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: minmax(0, 0.82fr) minmax(240px, 1.18fr);
+  align-items: center;
+  gap: 20px;
+  padding: 18px;
+  background: #f7f7f7;
+  color: #171717;
+  pointer-events: none;
+  opacity: 1;
+  transition: opacity 0.32s ease, visibility 0.32s ease;
+}
+
+.preview--loading.is-hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.preview--loading-copy {
+  max-width: 360px;
+  min-width: 0;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  color: #171717;
+}
+
+.preview--loading-kicker {
+  position: relative;
+  margin: 0;
+  color: transparent;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1.45;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.preview--loading-copy h1 {
+  margin: 0 0 10px;
+  color: #171717;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-size: clamp(2.25rem, 7cqw, 4.25rem);
+  font-weight: 700;
+  line-height: 0.92;
+}
+
+.preview--loading-button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 18px;
+  border: 1px solid #d4d4d4;
+  border-radius: 999px;
+  padding: 10px 16px;
+  background: #ffffff;
+  color: transparent;
+  font: inherit;
+  font-weight: 700;
+  line-height: 1.25;
+  height: calc(1.25em + 22px);
+  cursor: default;
+}
+
+.preview--loading-noise {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #a3a3a3;
+  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  font-variant-ligatures: none;
+  letter-spacing: 0;
+  opacity: 0.72;
+  white-space: pre;
+  pointer-events: none;
+}
+
+.preview--loading-measure {
+  position: relative;
+  display: inline-block;
+  color: transparent;
+}
+
+.preview--loading-cell {
+  flex: 0 0 1ch;
+  overflow: hidden;
+  text-align: center;
+}
+
+.preview--loading-cell.is-space {
+  opacity: 0;
+}
+
+.preview--loading-kicker .preview--loading-noise {
+  color: #737373;
+  opacity: 0.68;
+}
+
+.preview--loading-button .preview--loading-noise {
+  inset: 0;
+  color: #a3a3a3;
+  opacity: 0.72;
+  overflow: hidden;
+}
+
+.preview--loading-art {
+  position: relative;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  background: #fbfbfb;
+  color: #737373;
+  overflow: hidden;
+  opacity: 0.7;
+  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: clamp(0.72rem, 1.45cqw, 1rem);
+  font-weight: 300;
+  line-height: 1.34;
+  letter-spacing: 0;
+  white-space: pre;
+  text-align: left;
+  font-variant-ligatures: none;
+}
+
+.preview--loading-art::after {
+  content: '';
+  position: absolute;
+  inset: 18px;
+  background:
+    linear-gradient(90deg, transparent 0 7px, rgba(212, 212, 212, 0.42) 7px 8px),
+    linear-gradient(0deg, transparent 0 7px, rgba(212, 212, 212, 0.28) 7px 8px);
+  background-size: 8px 8px;
+  opacity: 0.16;
+  pointer-events: none;
+}
+
+.preview--loading-art span {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: max-content;
+  white-space: pre;
+}
+
+.preview--loading-art span:nth-child(7),
+.preview--loading-art span:nth-child(8),
+.preview--loading-art span:nth-child(11),
+.preview--loading-art span:nth-child(12) {
+  opacity: 0.62;
+}
+
+.preview--loading-art span:nth-child(3),
+.preview--loading-art span:nth-child(5),
+.preview--loading-art span:nth-child(7),
+.preview--loading-art span:nth-child(8),
+.preview--loading-art span:nth-child(12) {
+  color: #a3a3a3;
+}
+
+.codesandbox-layout {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  min-height: 0;
+}
+
+.filetree {
+  display: flex;
+  flex-direction: column;
+  width: 210px;
+  min-width: 210px;
+  border-right: 1px solid #e5e7eb;
+  background-color: #fafafa;
+  flex-shrink: 0;
+}
+
+.filetree-root {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #1f2937;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.react-icon {
+  flex-shrink: 0;
+  color: #6b7280;
+}
+
+.root-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.root-action-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #6b7280;
+  transition: all 0.15s ease;
+  border-radius: 3px;
+}
+
+.root-action-button:hover {
+  background-color: #f3f4f6;
+  color: #6b7280;
+}
+
+.root-action-input {
+  width: 100px;
+  outline: none;
+  border: 1px solid #d1d5db;
+  border-radius: 3px;
+  padding: 2px 6px;
+  margin: 0;
+  background-color: #fff;
+  font-size: 12px;
+  color: #374151;
+}
+
+.root-action-input:focus {
+  border-color: #6b7280;
+}
+
+.filetree-files {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+  padding: 6px 0;
+}
+
+.filetree-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  padding: 4px 10px;
+  cursor: pointer;
+  color: #374151;
+  font-size: 13px;
+  transition: background-color 0.15s ease, opacity 0.2s ease-out, transform 0.2s ease-out;
+  border: none;
+  background: none;
+  text-align: left;
+  width: 100%;
+}
+
+.filetree-item:hover {
+  background-color: #f3f4f6;
+}
+
+.filetree-item.active {
+  color: #171717;
+  background-color: #e7e7e7;
+}
+
+.filetree-item.active:hover {
+  background-color: #e7e7e7;
+}
+
+.file-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: #6b7280;
+}
+
+.filetree-item-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+}
+
+.filetree-item--folder {
+  font-weight: 600;
+  color: #262626;
+}
+
+.filetree-children {
+  position: relative;
+}
+
+.filetree-children::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 17px;
+  border-left: 1px solid #dedede;
+  pointer-events: none;
+}
+
+.filetree-item--nested {
+  padding-left: 26px;
+}
+
+.filetree-item--editing {
+  background-color: #f9fafb;
+}
+
+.filetree-item--deleting {
+  opacity: 0;
+  transform: translateX(-10px);
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+  pointer-events: none;
+}
+
+.filetree-item-input {
+  flex: 1;
+  outline: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 3px;
+  padding: 2px 0;
+  margin: 0;
+  background-color: transparent;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: normal;
+  color: #374151;
+  font-family: inherit;
+  caret-color: #9ca3af;
+  letter-spacing: normal;
+  vertical-align: baseline;
+}
+
+.filetree-item-input:focus {
+  border-color: #d1d5db;
+  outline: none;
+}
+
+.editor {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+}
+
+.editor[data-active-extension="css"] .sh__token--identifier {
+  color: var(--sh-property) !important;
+}
+
+.editor[data-active-extension="css"] .sh__token--class {
+  color: var(--sh-string) !important;
+}
+
+.editor[data-active-extension="css"] .sh__token--sign {
+  color: var(--sh-sign) !important;
+}
+
+.editor [data-codice-code-line-number] {
+  opacity: 0.4;
+  color: #9ca3af;
+}
+
+
+[data-codesandbox] {
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 12px 36px 4px rgb(200 200 200 / 50%);
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  height: 660px;
+  min-height: 620px;
+}
+
+[data-codesandbox="react"] {
+  width: 100%;
+  height: auto;
+  min-height: 0;
+  gap: 1.25rem;
+  border-radius: 0;
+  overflow: visible;
+  box-shadow: none;
+  background: transparent;
+}
+
+[data-codesandbox="react"] .preview {
+  width: 100%;
+  min-height: 440px;
+  border-top: 0;
+  background: #f5f5f4;
+}
+
+[data-codesandbox="react"] .preview--result {
+  height: 100%;
+  min-height: 100%;
+}
+
+[data-codesandbox="react"] .codesandbox-layout {
+  width: min(960px, calc(100% - 1rem));
+  height: 360px;
+  margin: 0 auto;
+  flex: none;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: 0 12px 36px 4px rgb(200 200 200 / 45%);
+}
+
+@media (max-width: 760px) {
+  .preview--loading {
+    grid-template-columns: 1fr;
+    gap: 18px;
+    padding: 16px;
+  }
+
+  .preview--loading-art {
+    height: auto;
+    min-height: 220px;
+    font-size: clamp(0.68rem, 2.85cqw, 0.9rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .preview--loading,
+  .preview--result {
+    transition: none;
+  }
+}

--- a/examples/website/components/codesandbox.tsx
+++ b/examples/website/components/codesandbox.tsx
@@ -1,0 +1,556 @@
+'use client'
+
+import './codesandbox.css'
+
+const CDN_HOST = 'https://esm.sh'
+const REACT_DEV_MODULES = new Set([
+  'react',
+  'react-dom',
+  'react-dom/client',
+  'react/jsx-runtime',
+  'react/jsx-dev-runtime',
+])
+const editorTextareaProps = { style: { caretColor: '#171717' } }
+
+function resolveModule(specifier: string) {
+  const url = `${CDN_HOST}/${specifier}`
+  return REACT_DEV_MODULES.has(specifier) ? `${url}?dev` : url
+}
+
+import { Editor } from '@sugar-high/react'
+import { DevJar } from 'devjar'
+import FileIcon from './file-icon'
+import RootActions from './root-actions'
+import { useEffect, useRef, useState } from 'react'
+
+const kebabCase = (str: string) => str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase()
+const removeExtension = (str: string) => str.replace(/\.[^/.]+$/, '')
+
+// Normalize filename - remove leading ./ and ensure proper extension
+function normalizeFilename(filename: string): string {
+  return filename.startsWith('./') ? filename.slice(2) : filename
+}
+
+// Get display name for file tree (just the filename without path)
+function getDisplayName(filename: string): string {
+  const normalized = normalizeFilename(filename)
+  // If it already has an extension, return as is, otherwise add .js
+  if (normalized.includes('.')) {
+    return normalized
+  }
+  return normalized + '.js'
+}
+
+const loaderChars = '░▒▓█▄▀■□▪▫'
+
+function loaderChar(index: number, frame: number) {
+  return loaderChars[(index * 17 + frame * 11) % loaderChars.length]
+}
+
+function scrambleText(text: string, frame: number) {
+  let index = 0
+  return text.replace(/\S/g, () => loaderChar(index++, frame))
+}
+
+function scrambleTemplate(template: string, frame: number) {
+  let index = 0
+  return template.replace(/x/g, () => loaderChar(index++, frame))
+}
+
+function renderLoaderCells(text: string, frame: number) {
+  return Array.from(scrambleText(text, frame), (char, index) => (
+    <span className={char === ' ' ? 'preview--loading-cell is-space' : 'preview--loading-cell'} key={index}>
+      {char === ' ' ? '\u00a0' : char}
+    </span>
+  ))
+}
+
+const previewFallbackArtTemplate = [
+  '           DEVJAR             ',
+  '  .------------------------.  ',
+  ' /  xxxxxx        xxxxxxx  /| ',
+  '+------------------------+  | ',
+  '| xxxxxxxx               |  | ',
+  '|                        |  | ',
+  '|  xxxxxxxxxxxxxxxxxx    |  | ',
+  '|  xxxxxxxxxxxxxx        |  | ',
+  '|                        |  | ',
+  '|  .------------------.  |  | ',
+  '|  |                  |  |  | ',
+  '|  |    xxxxxxxxxx    |  |  | ',
+  '|  |                  |  |  | ',
+  '|  +------------------+  | /  ',
+  '+------------------------+    ',
+]
+
+export function Codesandbox({
+  files: initialFiles
+}: {
+  files: Record<string, string>
+}) {
+  // Initialize activeFile with the root page when available.
+  const getInitialActiveFile = (files: Record<string, string>) => {
+    const rootPage = ['pages/index.tsx', 'pages/index.ts', 'pages/index.jsx', 'pages/index.js']
+      .find(filename => filename in files)
+    if (rootPage) return rootPage
+    const firstKey = Object.keys(files)[0]
+    return firstKey || 'pages/index.tsx'
+  }
+
+  const [activeFile, setActiveFile] = useState<string | null>(() => getInitialActiveFile(initialFiles))
+  const [activeFolder, setActiveFolder] = useState<string | null>(null)
+  const [files, setFiles] = useState(initialFiles)
+  const [folders, setFolders] = useState<string[]>([])
+  const [editingNewItem, setEditingNewItem] = useState<{ type: 'file' | 'folder'; tempId: string } | null>(null)
+  const [newItemName, setNewItemName] = useState('')
+  const [deletingItems, setDeletingItems] = useState<Set<string>>(new Set())
+  const previewRef = useRef<HTMLDivElement>(null)
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const [previewHeight, setPreviewHeight] = useState(440)
+  const [previewReady, setPreviewReady] = useState(false)
+  const [loaderFrame, setLoaderFrame] = useState(0)
+  const activeExtension = activeFile?.split('.').pop() || ''
+  const projectFolders = [...new Set([
+    ...folders,
+    ...Object.keys(files).flatMap((filename) => {
+      const path = normalizeFilename(filename)
+      const separator = path.indexOf('/')
+      return separator === -1 ? [] : [path.slice(0, separator)]
+    }),
+  ])]
+
+  useEffect(() => {
+    if (previewReady) return
+    const interval = window.setInterval(() => {
+      setLoaderFrame((frame) => (frame + 1) % 997)
+    }, 120)
+
+    return () => window.clearInterval(interval)
+  }, [previewReady])
+
+  useEffect(() => {
+    const iframe = iframeRef.current
+    const preview = previewRef.current
+    if (!iframe || !preview) return
+
+    let resizeObserver: ResizeObserver | undefined
+    let frame = 0
+    let probeFrame = 0
+    let rendered = false
+
+    const updateHeight = () => {
+      frame = 0
+      const doc = iframe.contentDocument
+      if (!doc) return
+
+      const nextHeight = Math.ceil(Math.max(
+        doc.body?.scrollHeight || 0,
+        doc.body?.offsetHeight || 0,
+        doc.documentElement?.scrollHeight || 0,
+        doc.documentElement?.offsetHeight || 0,
+        440
+      ))
+
+      setPreviewHeight(nextHeight)
+    }
+
+    const scheduleUpdate = () => {
+      if (frame) cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(updateHeight)
+    }
+
+    const markReady = () => {
+      rendered = true
+      setPreviewReady(true)
+      scheduleUpdate()
+    }
+
+    const detectRenderedContent = () => {
+      if (rendered) return true
+
+      const doc = iframe.contentDocument
+      const root = doc?.getElementById('__reactRoot')
+      if (!root) return false
+
+      if (root.childElementCount > 0 || root.textContent?.trim()) {
+        markReady()
+        return true
+      }
+
+      return false
+    }
+
+    const probeReady = () => {
+      probeFrame = 0
+      if (detectRenderedContent()) return
+      probeFrame = requestAnimationFrame(probeReady)
+    }
+
+    const scheduleReadyProbe = () => {
+      if (!rendered && !probeFrame) {
+        probeFrame = requestAnimationFrame(probeReady)
+      }
+    }
+
+    const setupObserver = () => {
+      scheduleUpdate()
+      scheduleReadyProbe()
+      const doc = iframe.contentDocument
+      if (!doc || typeof ResizeObserver === 'undefined') return
+      resizeObserver?.disconnect()
+      resizeObserver = new ResizeObserver(scheduleUpdate)
+      resizeObserver.observe(doc.documentElement)
+      if (doc.body) resizeObserver.observe(doc.body)
+    }
+
+    iframe.addEventListener('load', setupObserver)
+    iframe.addEventListener('devjar:render', markReady)
+    window.addEventListener('resize', scheduleUpdate)
+    setupObserver()
+
+    return () => {
+      iframe.removeEventListener('load', setupObserver)
+      iframe.removeEventListener('devjar:render', markReady)
+      window.removeEventListener('resize', scheduleUpdate)
+      resizeObserver?.disconnect()
+      if (frame) cancelAnimationFrame(frame)
+      if (probeFrame) cancelAnimationFrame(probeFrame)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (initialFiles !== files) {
+      setFiles(initialFiles)
+      // Update activeFile if current one doesn't exist in new files
+      if (activeFile && !initialFiles[activeFile]) {
+        setActiveFile(getInitialActiveFile(initialFiles))
+      }
+    }
+  }, [initialFiles])
+
+  // Handle Cmd+Delete or Cmd+Backspace to delete files/folders
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Check for Cmd+Delete or Cmd+Backspace (Mac) or Ctrl+Delete/Backspace (Windows/Linux)
+      const isDelete = (e.metaKey || e.ctrlKey) && (e.key === 'Delete' || e.key === 'Backspace')
+
+      if (isDelete && !editingNewItem) {
+        e.preventDefault()
+
+        if (activeFolder) {
+          // Delete folder and all its files
+          const folderFiles = Object.keys(files).filter(f => f.startsWith(activeFolder + '/'))
+          const itemsToDelete = [activeFolder, ...folderFiles]
+
+          setDeletingItems(new Set(itemsToDelete))
+
+          setTimeout(() => {
+            const newFiles = { ...files }
+            folderFiles.forEach(f => delete newFiles[f])
+            setFiles(newFiles)
+            setFolders(folders.filter(f => f !== activeFolder))
+            setActiveFolder(null)
+            setActiveFile(getInitialActiveFile(newFiles))
+            setDeletingItems(new Set())
+          }, 200) // Match animation duration
+        } else if (activeFile) {
+          // Delete file
+          setDeletingItems(new Set([activeFile]))
+
+          setTimeout(() => {
+            const newFiles = { ...files }
+            delete newFiles[activeFile]
+            setFiles(newFiles)
+            setActiveFile(getInitialActiveFile(newFiles))
+            setDeletingItems(new Set())
+          }, 200) // Match animation duration
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [activeFile, activeFolder, files, folders, editingNewItem])
+
+  return (
+    <div data-codesandbox="react">
+      <div className="preview" ref={previewRef} style={{ height: previewHeight }}>
+        <div className={previewReady ? 'preview--loading is-hidden' : 'preview--loading'} aria-hidden="true">
+          <div className="preview--loading-copy">
+            <h1>DEVJAR</h1>
+            <p className="preview--loading-kicker">
+              <span className="preview--loading-measure">
+                React Live Preview in browser
+                <span className="preview--loading-noise">{renderLoaderCells('React Live Preview in browser', loaderFrame)}</span>
+              </span>
+            </p>
+            <button className="preview--loading-button" type="button" tabIndex={-1}>
+              <span className="preview--loading-measure">
+                WIGGLE
+                <span className="preview--loading-noise">{renderLoaderCells('WIGGLE', loaderFrame + 2)}</span>
+              </span>
+            </button>
+          </div>
+          <pre className="preview--loading-art">
+            {previewFallbackArtTemplate.map((line, index) => (
+              <span key={index}>{scrambleTemplate(line, loaderFrame + index)}</span>
+            ))}
+          </pre>
+        </div>
+        <DevJar
+          className={'preview--result ' + (previewReady ? 'is-ready' : '')}
+          files={files}
+          ref={iframeRef}
+          scrolling="no"
+          onError={(err) => {
+            if (err) console.error(err)
+          }}
+          resolveModule={resolveModule}
+        />
+      </div>
+      <div className="codesandbox-layout">
+        <div className="filetree">
+          <div className="filetree-root">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="react-icon">
+              <circle cx="12" cy="12" r="2" stroke="currentColor" strokeWidth="1" fill="none"/>
+              <ellipse cx="12" cy="12" rx="11" ry="4.2" stroke="currentColor" strokeWidth="1" fill="none"/>
+              <ellipse cx="12" cy="12" rx="11" ry="4.2" stroke="currentColor" strokeWidth="1" fill="none" transform="rotate(60 12 12)"/>
+              <ellipse cx="12" cy="12" rx="11" ry="4.2" stroke="currentColor" strokeWidth="1" fill="none" transform="rotate(-60 12 12)"/>
+            </svg>
+            <RootActions
+              onNewFile={() => {
+                const tempId = `__new_file_${Date.now()}__`
+                setEditingNewItem({ type: 'file', tempId })
+                setNewItemName('')
+                // Keep activeFolder if one is selected, so file is created under it
+              }}
+              onNewFolder={() => {
+                const tempId = `__new_folder_${Date.now()}__`
+                setEditingNewItem({ type: 'folder', tempId })
+                setNewItemName('')
+                setActiveFolder(null)
+              }}
+            />
+          </div>
+          <div className="filetree-files">
+            {projectFolders.map((folderName) => {
+              const folderFiles = Object.keys(files).filter(f => normalizeFilename(f).startsWith(folderName + '/'))
+              const isActiveFolder = activeFolder === folderName
+              return (
+                <div key={folderName}>
+                  <div
+                    role="button"
+                    className={'filetree-item filetree-item--folder ' + (isActiveFolder ? 'active' : '') + (deletingItems.has(folderName) ? ' filetree-item--deleting' : '')}
+                    onClick={() => {
+                      setActiveFolder(folderName)
+                      setActiveFile(null)
+                    }}
+                  >
+                    <svg width="16" height="18" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" className="file-icon">
+                      <path d="M2.5 3.5C2.5 3.22 2.72 3 3 3H5.5L7 4.5H10.5C10.78 4.5 11 4.72 11 5V11.5C11 11.78 10.78 12 10.5 12H3C2.72 12 2.5 11.78 2.5 11.5V3.5Z" stroke="currentColor" strokeWidth="1" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                    <span className="filetree-item-name">{folderName}</span>
+                  </div>
+                  <div className="filetree-children">
+                    {folderFiles.map((filename) => {
+                      const path = normalizeFilename(filename)
+                      const displayName = getDisplayName(path.slice(folderName.length + 1))
+                      return (
+                        <div
+                          role="button"
+                          key={filename}
+                          className={'filetree-item filetree-item--nested ' + (filename === activeFile ? 'active' : '') + (deletingItems.has(filename) ? ' filetree-item--deleting' : '')}
+                          onClick={() => {
+                            setActiveFile(filename)
+                            setActiveFolder(null)
+                          }}
+                        >
+                          <FileIcon />
+                          <span className="filetree-item-name">{displayName}</span>
+                        </div>
+                      )
+                    })}
+                    {isActiveFolder && editingNewItem && editingNewItem.type === 'file' && (
+                      <div className="filetree-item filetree-item--editing filetree-item--nested">
+                        <FileIcon />
+                        <input
+                          type="text"
+                          className="filetree-item-input"
+                          value={newItemName}
+                          placeholder=""
+                          autoFocus
+                          onChange={(e) => setNewItemName(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') {
+                              const trimmed = newItemName.trim()
+                              if (!trimmed) {
+                                setEditingNewItem(null)
+                                setNewItemName('')
+                                return
+                              }
+
+                              const baseFilename = trimmed.includes('.') ? trimmed : trimmed + '.js'
+                              const filename = `${folderName}/${baseFilename}`
+                              const fileBaseName = removeExtension(baseFilename)
+                              setFiles({
+                                ...files,
+                                [filename]: `export default function ${kebabCase(fileBaseName)}() {}`,
+                              })
+                              setActiveFile(filename)
+                              setActiveFolder(null)
+                              setEditingNewItem(null)
+                              setNewItemName('')
+                            } else if (e.key === 'Escape') {
+                              setEditingNewItem(null)
+                              setNewItemName('')
+                            }
+                          }}
+                          onBlur={() => {
+                            const trimmed = newItemName.trim()
+                            if (!trimmed) {
+                              setEditingNewItem(null)
+                              setNewItemName('')
+                              return
+                            }
+
+                            const baseFilename = trimmed.includes('.') ? trimmed : trimmed + '.js'
+                            const filename = `${folderName}/${baseFilename}`
+                            const fileBaseName = removeExtension(baseFilename)
+                            setFiles({
+                              ...files,
+                              [filename]: `export default function ${kebabCase(fileBaseName)}() {}`,
+                            })
+                            setActiveFile(filename)
+                            setActiveFolder(null)
+                            setEditingNewItem(null)
+                            setNewItemName('')
+                          }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+            {Object.keys(files).filter(f => !projectFolders.some(folder => normalizeFilename(f).startsWith(folder + '/'))).map((filename) => {
+              const displayName = getDisplayName(filename)
+              return (
+                <div
+                  role="button"
+                  key={filename}
+                  className={'filetree-item ' + (filename === activeFile ? 'active' : '') + (deletingItems.has(filename) ? ' filetree-item--deleting' : '')}
+                  onClick={() => {
+                    setActiveFile(filename)
+                    setActiveFolder(null)
+                  }}
+                >
+                  <FileIcon />
+                  <span className="filetree-item-name">{displayName}</span>
+                </div>
+              )
+            })}
+            {editingNewItem && !(activeFolder && editingNewItem.type === 'file') && (
+              <div className="filetree-item filetree-item--editing">
+                {editingNewItem.type === 'folder' ? (
+                  <svg width="16" height="18" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" className="file-icon">
+                    <path d="M2.5 3.5C2.5 3.22 2.72 3 3 3H5.5L7 4.5H10.5C10.78 4.5 11 4.72 11 5V11.5C11 11.78 10.78 12 10.5 12H3C2.72 12 2.5 11.78 2.5 11.5V3.5Z" stroke="currentColor" strokeWidth="1" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+                  </svg>
+                ) : (
+                  <FileIcon />
+                )}
+                <input
+                  type="text"
+                  className="filetree-item-input"
+                  value={newItemName}
+                  placeholder=""
+                  autoFocus
+                  onChange={(e) => setNewItemName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      const trimmed = newItemName.trim()
+                      if (!trimmed) {
+                        setEditingNewItem(null)
+                        setNewItemName('')
+                        return
+                      }
+
+                      if (editingNewItem.type === 'file') {
+                        const baseFilename = trimmed.includes('.') ? trimmed : trimmed + '.js'
+                        const filename = activeFolder ? `${activeFolder}/${baseFilename}` : baseFilename
+                        const fileBaseName = removeExtension(baseFilename)
+                        setFiles({
+                          ...files,
+                          [filename]: `export default function ${kebabCase(fileBaseName)}() {}`,
+                        })
+                        setActiveFile(filename)
+                        setActiveFolder(null)
+                      } else {
+                        // Create folder
+                        if (!folders.includes(trimmed)) {
+                          setFolders([...folders, trimmed])
+                        }
+                      }
+
+                      setEditingNewItem(null)
+                      setNewItemName('')
+                    } else if (e.key === 'Escape') {
+                      setEditingNewItem(null)
+                      setNewItemName('')
+                    }
+                  }}
+                  onBlur={() => {
+                    const trimmed = newItemName.trim()
+                    if (!trimmed) {
+                      setEditingNewItem(null)
+                      setNewItemName('')
+                      return
+                    }
+
+                    if (editingNewItem.type === 'file') {
+                      const baseFilename = trimmed.includes('.') ? trimmed : trimmed + '.js'
+                      const filename = activeFolder ? `${activeFolder}/${baseFilename}` : baseFilename
+                      const fileBaseName = removeExtension(baseFilename)
+                      setFiles({
+                        ...files,
+                        [filename]: `export default function ${kebabCase(fileBaseName)}() {}`,
+                      })
+                      setActiveFile(filename)
+                      setActiveFolder(null)
+                    } else {
+                      // Create folder
+                      if (!folders.includes(trimmed)) {
+                        setFolders([...folders, trimmed])
+                      }
+                    }
+
+                    setEditingNewItem(null)
+                    setNewItemName('')
+                  }}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+          <Editor
+            className="editor"
+            controls={false}
+            title={null}
+            lineNumbers={true}
+            fontSize={13}
+            textareaProps={editorTextareaProps}
+            extension={activeExtension}
+            data-active-extension={activeExtension}
+            value={activeFile ? files[activeFile] || '' : ''}
+            onChange={(code) => {
+              if (activeFile) {
+                setFiles((currentFiles) => ({
+                  ...currentFiles,
+                  [activeFile]: code,
+                }))
+              }
+            }}
+          />
+      </div>
+    </div>
+  )
+}

--- a/examples/website/components/file-icon.tsx
+++ b/examples/website/components/file-icon.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+function FileIcon() {
+  return (
+    <span className="file-icon">
+      <svg width="16" height="18" viewBox="0 0 12 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M3 2.5C3 2.22 3.22 2 3.5 2H8L9.5 3.5V11.5C9.5 11.78 9.28 12 9 12H3.5C3.22 12 3 11.78 3 11.5V2.5Z" stroke="currentColor" strokeWidth="1" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+      </svg>
+    </span>
+  )
+}
+
+export default FileIcon

--- a/examples/website/components/root-actions.tsx
+++ b/examples/website/components/root-actions.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+function RootActions({ onNewFile, onNewFolder }: { onNewFile: () => void; onNewFolder: () => void }) {
+  return (
+    <div className="root-actions">
+      <button
+        className="root-action-button"
+        aria-label="New file"
+        onClick={onNewFile}
+        title="New file"
+      >
+        <svg width="16" height="18" viewBox="0 0 12 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M3 2.5C3 2.22 3.22 2 3.5 2H8L9.5 3.5V11.5C9.5 11.78 9.28 12 9 12H3.5C3.22 12 3 11.78 3 11.5V2.5Z" stroke="currentColor" strokeWidth="1" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+          <circle cx="8.5" cy="10.25" r="2.5" fill="#fafafa" stroke="none"/>
+          <line x1="8.5" y1="9" x2="8.5" y2="11.5" stroke="currentColor" strokeWidth="1" strokeLinecap="round"/>
+          <line x1="7" y1="10.25" x2="10" y2="10.25" stroke="currentColor" strokeWidth="1" strokeLinecap="round"/>
+        </svg>
+      </button>
+      <button
+        className="root-action-button"
+        aria-label="New folder"
+        onClick={onNewFolder}
+        title="New folder"
+      >
+        <svg width="18" height="18" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M2.5 3.5C2.5 3.22 2.72 3 3 3H5.5L7 4.5H10.5C10.78 4.5 11 4.72 11 5V11.5C11 11.78 10.78 12 10.5 12H3C2.72 12 2.5 11.78 2.5 11.5V3.5Z" stroke="currentColor" strokeWidth="1" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+          <circle cx="9.5" cy="10.25" r="2.5" fill="#fafafa" stroke="none"/>
+          <line x1="9.5" y1="9" x2="9.5" y2="11.5" stroke="currentColor" strokeWidth="1" strokeLinecap="round"/>
+          <line x1="8" y1="10.25" x2="11" y2="10.25" stroke="currentColor" strokeWidth="1" strokeLinecap="round"/>
+        </svg>
+      </button>
+    </div>
+  )
+}
+
+export default RootActions

--- a/examples/website/lib/demo-files.ts
+++ b/examples/website/lib/demo-files.ts
@@ -1,0 +1,306 @@
+function source(parts: TemplateStringsArray) {
+  const lines = parts[0].split('\n')
+  const contentLines = lines.filter((line) => line.trim())
+  const indentation = Math.min(
+    ...contentLines.map((line) => line.match(/^ */)?.[0].length || 0),
+  )
+
+  return lines.map((line) => line.slice(indentation)).join('\n').trimEnd()
+}
+export const demoFiles = {
+  'pages/index.jsx': source`\
+  import { useState } from 'react'
+  import { art } from '../components/ascii'
+  import '../styles.css'
+
+  const site = {
+    name: 'DEVJAR',
+    cta: 'WIGGLE',
+    accent: '#525252',
+  }
+
+  export default function App() {
+    const [refreshes, setRefreshes] = useState(0)
+
+    return (
+      <div className="page" style={{ '--accent': site.accent }}>
+        <main>
+          <section className="copy">
+            <h1>{site.name}</h1>
+            <p className="eyebrow">React Live Preview in browser</p>
+            <button type="button" onClick={() => setRefreshes((count) => count + 1)}>
+              {site.cta}
+            </button>
+          </section>
+
+          <pre className={refreshes > 0 ? 'ascii is-shuffling' : 'ascii'} aria-label="Devjar preview">
+            <code key={refreshes}>
+              {art.map((line, index) => (
+                <span className="ascii-line" key={index}>{line}</span>
+              ))}
+            </code>
+          </pre>
+        </main>
+      </div>
+    )
+  }`,
+  'components/ascii.js': source`\
+  const copy = {
+    title: 'DEVJAR',
+    editorLabel: 'editor',
+    previewLabel: 'preview',
+    filename: 'pages/index.jsx',
+    codeLine: 'const title = "Ship"',
+    renderLine: 'return <Demo />',
+    resultLabel: 'live result',
+    actionLabel: '[ Button ]',
+  }
+
+  function fit(value, width) {
+    return String(value).slice(0, width)
+  }
+
+  function left(value, width) {
+    return fit(value, width).padEnd(width, ' ')
+  }
+
+  function center(value, width) {
+    const text = fit(value, width)
+    const before = Math.floor((width - text.length) / 2)
+    const after = width - text.length - before
+    return ' '.repeat(before) + text + ' '.repeat(after)
+  }
+
+  function codeLine(value) {
+    return '|  ' + left(value, 22) + '|  | '
+  }
+
+  function previewLine(value) {
+    return '|  |' + center(value, 18) + '|  |  | '
+  }
+
+  const art = [
+    center(copy.title, 30),
+    '  .------------------------.  ',
+    ' /  ' + left(copy.editorLabel, 6) + '        ' + left(copy.previewLabel, 7) + '  /| ',
+    '+------------------------+  | ',
+    '| ' + left(copy.filename, 23) + '|  | ',
+    '|                        |  | ',
+    codeLine(copy.codeLine),
+    codeLine(copy.renderLine),
+    '|                        |  | ',
+    '|  .------------------.  |  | ',
+    previewLine(copy.resultLabel),
+    previewLine(copy.actionLabel),
+    '|  |                  |  |  | ',
+    '|  +------------------+  | /  ',
+    '+------------------------+    ',
+  ]
+
+  export { art }`,
+  'styles.css': source`\
+  * {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    margin: 0;
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+    color: #171717;
+    background: #f7f7f7;
+    overflow-x: hidden;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  html::-webkit-scrollbar,
+  body::-webkit-scrollbar {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
+  .page {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    padding: 18px;
+    overflow-x: hidden;
+    background: #f7f7f7;
+  }
+
+  main {
+    flex: 1;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: minmax(0, 0.82fr) minmax(240px, 1.18fr);
+    gap: 20px;
+    align-items: center;
+  }
+
+  .copy {
+    max-width: 360px;
+    min-width: 0;
+  }
+
+  .eyebrow {
+    margin: 0;
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin: 0 0 10px;
+    font-size: clamp(2.25rem, 7vw, 4.25rem);
+    font-weight: 700;
+    line-height: 0.92;
+  }
+
+  p {
+    margin: 0;
+    color: #57534e;
+    font-size: 0.95rem;
+    line-height: 1.45;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 18px;
+    border: 1px solid #d4d4d4;
+    border-radius: 999px;
+    padding: 10px 16px;
+    background: #ffffff;
+    color: #171717;
+    font: inherit;
+    font-weight: 700;
+    line-height: 1.25;
+    height: calc(1.25em + 22px);
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+
+  button:hover,
+  button:focus-visible {
+    border-color: #a3a3a3;
+    background: #f5f5f5;
+  }
+
+  button:active {
+    border-color: #a3a3a3;
+    background: #eeeeee;
+  }
+
+  .ascii {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 18px;
+    border: 1px solid #e5e5e5;
+    border-radius: 8px;
+    background: #fbfbfb;
+    color: #404040;
+    overflow: hidden;
+  }
+
+  .ascii code {
+    display: block;
+    max-width: 100%;
+    max-height: 100%;
+    font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
+    font-size: clamp(0.72rem, 1.45vw, 1rem);
+    font-weight: 400;
+    line-height: 1.34;
+    letter-spacing: 0;
+    white-space: pre;
+    tab-size: 2;
+    text-align: left;
+    font-variant-ligatures: none;
+    overflow: visible;
+  }
+
+  .ascii-line {
+    display: block;
+    white-space: pre;
+    font: inherit;
+  }
+
+  .ascii.is-shuffling .ascii-line:nth-child(7),
+  .ascii.is-shuffling .ascii-line:nth-child(8),
+  .ascii.is-shuffling .ascii-line:nth-child(11),
+  .ascii.is-shuffling .ascii-line:nth-child(12) {
+    animation: shuffle-line 0.58s cubic-bezier(0.22, 1, 0.36, 1);
+    will-change: transform, opacity;
+  }
+
+  .ascii.is-shuffling .ascii-line:nth-child(8),
+  .ascii.is-shuffling .ascii-line:nth-child(12) {
+    animation-delay: 0.06s;
+  }
+
+  @keyframes shuffle-line {
+    0% {
+      opacity: 1;
+      transform: translateX(0);
+    }
+
+    22% {
+      opacity: 0.58;
+      transform: translateX(1ch);
+    }
+
+    44% {
+      opacity: 0.86;
+      transform: translateX(-0.72ch);
+    }
+
+    66% {
+      opacity: 0.7;
+      transform: translateX(0.38ch);
+    }
+
+    100% {
+      opacity: 1;
+      transform: translateX(0);
+    }
+  }
+
+  .ascii::selection,
+  .ascii code::selection {
+    background: #e5e5e5;
+    color: #171717;
+  }
+
+  @media (max-width: 760px) {
+    .page {
+      min-height: 100vh;
+      height: auto;
+      overflow: auto;
+      padding: 16px;
+    }
+
+    main {
+      grid-template-columns: 1fr;
+      gap: 18px;
+    }
+
+    .ascii {
+      height: auto;
+      min-height: 220px;
+    }
+
+    .ascii code {
+      font-size: clamp(0.68rem, 2.85vw, 0.9rem);
+    }
+  }
+  `,
+}

--- a/examples/website/package.json
+++ b/examples/website/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "dependencies": {
+    "@sugar-high/react": "2.2.0",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
+    "sugar-high": "2.2.1"
+  }
+}

--- a/examples/website/pages/index.tsx
+++ b/examples/website/pages/index.tsx
@@ -1,0 +1,32 @@
+import { Codesandbox } from '../components/codesandbox'
+import { demoFiles } from '../lib/demo-files'
+import '../styles.css'
+
+export default function Page() {
+  return (
+    <>
+      <main>
+        <div className="playground-container">
+          <div className="playground-wrapper">
+            <Codesandbox files={demoFiles} />
+          </div>
+        </div>
+      </main>
+      <footer>
+        <nav className="site-footer" aria-label="Footer links">
+          <div className="footer-links">
+            <a href="https://github.com/huozhi/devjar" target="_blank" rel="noopener noreferrer">
+              GitHub
+            </a>
+            <a href="https://github.com/huozhi/devjar/blob/main/API.md" target="_blank" rel="noopener noreferrer">
+              API.md
+            </a>
+            <a href="https://x.com/huozhi" target="_blank" rel="noopener noreferrer">
+              X
+            </a>
+          </div>
+        </nav>
+      </footer>
+    </>
+  )
+}

--- a/examples/website/styles.css
+++ b/examples/website/styles.css
@@ -1,0 +1,324 @@
+* {
+  box-sizing: border-box;
+}
+html {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
+  overflow-x: hidden;
+}
+html, body {
+  margin: 0;
+  padding: 0;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  max-width: 100%;
+}
+
+html::-webkit-scrollbar,
+body::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
+:root {
+  --sh-class: #24292e;
+  --sh-identifier: #354150;
+  --sh-sign: #24292e;
+  --sh-string: #57a3a7;
+  --sh-keyword: #d73a49;
+  --sh-comment: #6a737d;
+  --sh-jsxliterals: #24292e;
+  --sh-entity: #424d5b;
+  --sh-property: #83898f;
+}
+
+a, a:focus, a:visited {
+  color: inherit;
+}
+a:hover {
+  color: #424d5b;
+}
+
+main {
+  padding: 0;
+}
+
+footer {
+  margin-top: 4rem;
+  padding: 0 1rem 2.25rem;
+  display: flex;
+  justify-content: center;
+}
+
+.site-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  max-width: 960px;
+  width: 100%;
+  padding-top: 1.125rem;
+  border-top: 1px solid #e7e5e4;
+  color: #737373;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.footer-links {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.875rem;
+  flex-wrap: wrap;
+}
+
+.site-footer a {
+  text-decoration: none;
+}
+
+.footer-links a:hover {
+  color: #171717;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.text-center {
+  text-align: center;
+}
+
+.editor {
+  position: relative;
+  display: flex;
+  overflow-y: scroll;
+  justify-content: stretch;
+  flex-direction: column;
+}
+
+.executor {
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  border: none;
+  background: #333;
+  border-radius: 4px;
+  color: #fff;
+}
+
+
+.playground-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  padding: 0 0 2rem;
+}
+
+.playground-wrapper {
+  width: 100%;
+  max-width: none;
+  margin: 0 auto;
+}
+
+.playground-wrapper:has([data-codesandbox="gl"]) {
+  max-width: 760px;
+}
+
+.usage-section {
+  width: 100%;
+  max-width: 680px;
+  margin: 3rem auto;
+  padding: 0 0.5rem;
+}
+
+.usage-content h2 {
+  font-size: 24px;
+  font-weight: 500;
+  color: #404756;
+  margin: 0 0 1rem 0;
+}
+
+.usage-example h3 {
+  font-size: 18px;
+  font-weight: 500;
+  color: #404756;
+  margin: 0 0 0.75rem 0;
+}
+
+.usage-example h4 {
+  font-size: 16px;
+  font-weight: 500;
+  color: #404756;
+  margin: 1.5rem 0 0.75rem 0;
+}
+
+.usage-example p {
+  color: #6b7280;
+  margin: 0 0 1rem 0;
+}
+
+.code-block {
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: #fff;
+  box-shadow:
+    -1px -1px 2px rgba(0, 0, 0, 0.03),
+    1px 1px 2px rgba(0, 0, 0, 0.03);
+  transition: box-shadow 0.2s ease-in-out;
+}
+
+.code-block:hover {
+  box-shadow:
+    -2px -2px 4px rgba(0, 0, 0, 0.05),
+    2px 2px 4px rgba(0, 0, 0, 0.05);
+}
+.code-block pre {
+  margin: 0;
+  padding: 16px;
+  max-height: 400px;
+  overflow-y: auto;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.code-block code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  user-select: text;
+}
+
+.code-block .sh__line {
+  display: block;
+}
+
+.playground {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  line-height: 1.4;
+  width: 100%;
+  max-width: 680px;
+}
+
+.showcase {
+  justify-content: center;
+  line-height: 1.4;
+  margin: 2rem 0;
+}
+
+.section {
+  max-width: 680px;
+  border-bottom: 1px dashed #e5e7eb;
+  padding: 32px 0;
+}
+
+@media (max-width: 640px) {
+  main {
+    padding: 0 0.5rem;
+  }
+  footer {
+    padding: 0 0.5rem 2rem;
+  }
+  .site-footer {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .footer-links {
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+  [data-codesandbox] .codesandbox-layout {
+    flex-direction: column;
+    min-height: auto;
+    height: auto;
+    flex: 0 0 auto;
+  }
+  [data-codesandbox] .codesandbox-layout > .filetree {
+    order: 1;
+    width: auto;
+    min-width: auto;
+    max-width: 100%;
+  }
+  [data-codesandbox] .codesandbox-layout > .editor {
+    order: 2;
+    width: auto;
+    flex: 0 0 auto;
+  }
+  [data-codesandbox] .filetree {
+    width: auto;
+    min-width: auto;
+    max-width: 100%;
+    border-right: none;
+    border-bottom: 1px solid #e5e7eb;
+    height: auto;
+    max-height: 180px;
+    flex-shrink: 0;
+    flex-grow: 1;
+    flex-basis: auto;
+  }
+  .filetree-root {
+    display: flex;
+    padding: 8px 12px;
+    flex-shrink: 0;
+  }
+  [data-codesandbox] .filetree-files {
+    display: flex;
+    flex-direction: column;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding: 0;
+    gap: 0;
+    -webkit-overflow-scrolling: touch;
+    height: auto;
+    flex: 0 0 auto;
+    flex-grow: 0;
+    min-height: 0;
+    max-height: 140px;
+  }
+  .filetree-item {
+    padding: 4px 12px;
+    white-space: nowrap;
+    flex-shrink: 0;
+    width: 100%;
+    border-radius: 0;
+  }
+  .filetree-item--nested {
+    padding-left: 10px;
+  }
+  .filetree-item-name {
+    max-width: none;
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+  .filetree-item--editing {
+    min-width: 150px;
+  }
+  .filetree-item-input {
+    min-width: 120px;
+  }
+  [data-codesandbox] .editor {
+    min-height: 300px;
+    max-height: 400px;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    width: auto;
+    flex: 0 0 auto;
+  }
+  [data-codesandbox] {
+    height: auto;
+    min-height: auto;
+  }
+  [data-codesandbox] .codesandbox-layout {
+    height: auto;
+  }
+  .preview {
+    min-height: 260px;
+    padding: 1rem 0.75rem;
+  }
+  .playground-wrapper {
+    padding: 0 0.5rem;
+  }
+}

--- a/src/cdn.ts
+++ b/src/cdn.ts
@@ -33,6 +33,12 @@ export function createEsmShResolver(
     }
     const subpath = specifier.slice(name.length)
     const dev = name === 'react' || name === 'react-dom' || name === 'react-refresh'
-    return `${host}/${name}@${encodeURIComponent(version)}${subpath}${dev ? '?dev' : ''}`
+    const externalizeReact = host === CDN_HOST && name !== 'react'
+    const parameters = [
+      ...(dev ? ['dev'] : []),
+      ...(externalizeReact ? ['external=react'] : []),
+    ]
+    const query = parameters.length ? `?${parameters.join('&')}` : ''
+    return `${host}/${name}@${encodeURIComponent(version)}${subpath}${query}`
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -138,6 +138,11 @@ export async function loadRouteManifest(
   }
 }
 
+const isolationHeaders = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'credentialless',
+}
+
 function send(
   request: IncomingMessage,
   response: ServerResponse,
@@ -148,6 +153,7 @@ function send(
   response.writeHead(status, {
     'Content-Type': type,
     'Cache-Control': 'no-store',
+    ...isolationHeaders,
   })
   response.end(request.method === 'HEAD' ? undefined : body)
 }
@@ -249,6 +255,7 @@ async function serveFile(
     'Content-Type': contentTypes[extname(path)] || 'application/octet-stream',
     'Content-Length': info.size,
     'Cache-Control': 'no-store',
+    ...isolationHeaders,
   })
   if (request.method === 'HEAD') response.end()
   else createReadStream(canonicalPath).pipe(response)

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -57,10 +57,23 @@ async function findSourceFile(path: string) {
   }
 }
 
-function localImports(source: string) {
+async function localImports(projectPath: string, source: string) {
+  const output = transformSync(
+    projectPath,
+    source,
+    getTransformOptions(projectPath, false),
+  )
+  const error = getTransformErrorMessage(output.errors)
+  if (error) throw new Error(error)
+
+  await init
+  const [parsedImports] = parse(output.code)
   const imports = new Set<string>()
-  const pattern = /(?:import\s+(?:[^'";]*?\s+from\s*)?|export\s+[^'";]*?\s+from\s*|import\s*\()(['"])(\.{1,2}\/[^'"]+)\1/g
-  for (const match of source.matchAll(pattern)) imports.add(match[2])
+  for (const imported of parsedImports) {
+    if (imported.n?.startsWith('./') || imported.n?.startsWith('../')) {
+      imports.add(imported.n)
+    }
+  }
   return imports
 }
 
@@ -83,7 +96,7 @@ export async function collectProjectFiles(root: string, entry: string) {
     if (extname(canonicalPath) === '.css') continue
 
     const source = await readFile(canonicalPath, 'utf8')
-    for (const specifier of localImports(source)) {
+    for (const specifier of await localImports(projectPath, source)) {
       const imported = await findSourceFile(resolve(canonicalPath, '..', specifier))
       if (!imported) {
         throw new Error(`Cannot resolve ${specifier} imported by ${projectPath}`)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -12,12 +12,13 @@ import {
 } from '../src/cli/index'
 import { CDN_HOST, createEsmShResolver } from '../src/cdn'
 import { createIframeRouteManifest, linkModules } from '../src/core'
-import { compileProjectModule } from '../src/cli/modules'
+import { collectProjectFiles, compileProjectModule } from '../src/cli/modules'
 import { getTailwindBrowserUrl } from '../src/tailwind'
 import { testCdnModule } from '../scripts/test-cdn'
 
 const root = resolve(import.meta.dir, '../examples/basic')
 const dashboardRoot = resolve(import.meta.dir, '../examples/dashboard')
+const websiteRoot = resolve(import.meta.dir, '../examples/website')
 
 function testModuleUrl(projectPath: string) {
   return `/modules/${projectPath}`
@@ -97,7 +98,8 @@ describe('project loading', () => {
       CDN_HOST,
     )
     expect(resolveModule('react/jsx-runtime')).toBe('https://esm.sh/react@19.1.0/jsx-runtime?dev')
-    expect(resolveModule('@scope/pkg/subpath')).toBe('https://esm.sh/@scope/pkg@%5E2.0.0/subpath')
+    expect(resolveModule('react-dom/client')).toBe('https://esm.sh/react-dom@19.2.0/client?dev&external=react')
+    expect(resolveModule('@scope/pkg/subpath')).toBe('https://esm.sh/@scope/pkg@%5E2.0.0/subpath?external=react')
   })
 
   test('loads a route manifest with module entries', async () => {
@@ -167,6 +169,25 @@ describe('project loading', () => {
     expect(manifest.notFound?.page).toBe('pages/404.tsx')
   })
 
+  test('loads the website example and its editable source files', async () => {
+    const manifest = await loadTestRouteManifest(websiteRoot)
+    expect(manifest.routes['/'].page).toBe('pages/index.tsx')
+
+    const files = await collectProjectFiles(
+      await realpath(websiteRoot),
+      join(websiteRoot, 'pages/index.tsx'),
+    )
+    expect([...files].sort()).toEqual([
+      'components/codesandbox.css',
+      'components/codesandbox.tsx',
+      'components/file-icon.tsx',
+      'components/root-actions.tsx',
+      'lib/demo-files.ts',
+      'pages/index.tsx',
+      'styles.css',
+    ])
+  })
+
   test('uses the project Tailwind version for the cached browser runtime', () => {
     expect(getTailwindBrowserUrl(
       { tailwindcss: '^4.1.0' },
@@ -202,6 +223,34 @@ describe('project loading', () => {
       await rm(projectRoot, { recursive: true, force: true })
     }
   })
+
+  test('ignores import-like text inside project source strings', async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), 'devjar-source-strings-'))
+    try {
+      await mkdir(join(projectRoot, 'pages'))
+      await mkdir(join(projectRoot, 'lib'))
+      await writeFile(
+        join(projectRoot, 'pages/index.tsx'),
+        `import { example } from '../lib/example'
+export default function Page() { return <pre>{example}</pre> }`,
+      )
+      await writeFile(
+        join(projectRoot, 'lib/example.ts'),
+        "export const example = `import Missing from '../components/missing'`",
+      )
+
+      const files = await collectProjectFiles(
+        await realpath(projectRoot),
+        join(projectRoot, 'pages/index.tsx'),
+      )
+      expect([...files].sort()).toEqual([
+        'lib/example.ts',
+        'pages/index.tsx',
+      ])
+    } finally {
+      await rm(projectRoot, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('dev server', () => {
@@ -219,7 +268,8 @@ describe('dev server', () => {
 
     const shell = await fetch(`${base}/about`)
     expect(shell.status).toBe(200)
-    expect(shell.headers.get('cross-origin-embedder-policy')).toBeNull()
+    expect(shell.headers.get('cross-origin-opener-policy')).toBe('same-origin')
+    expect(shell.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
     const shellSource = await shell.text()
     expect(shellSource).toContain('/__devjar/client.js')
     expect(shellSource).toContain("import * as RefreshModule from 'react-refresh/runtime'")
@@ -267,6 +317,7 @@ describe('dev server', () => {
 
     const worker = await fetch(`${base}/__devjar/transform-worker.js`)
     expect(worker.headers.get('content-type')).toContain('text/javascript')
+    expect(worker.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
     const wasm = await fetch(`${base}/__devjar/transform.wasm32-wasi.wasm`)
     expect(wasm.headers.get('content-type')).toBe('application/wasm')
 
@@ -389,6 +440,9 @@ describe('production build', () => {
   test('serves prebuilt projects without development events', async () => {
     server = await startBuiltServer({ root: buildRoot, host: '127.0.0.1', port: 0 })
     const base = `http://${server.host}:${server.port}`
+    const document = await fetch(base)
+    expect(document.headers.get('cross-origin-opener-policy')).toBe('same-origin')
+    expect(document.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
 
     const shell = await (await fetch(`${base}/projects`)).text()
     expect(shell).toContain('https://modules.example.test/react@19.2.0?dev')


### PR DESCRIPTION
## Summary

- add the current Devjar website as a standalone `pages/` example with its editor and live preview
- parse transformed modules when discovering local imports so editable source strings are not treated as project dependencies
- reuse the import-mapped React instance for packages loaded from the default esm.sh CDN
- serve cross-origin isolation headers from `devjar dev` and `devjar start` so nested Devjar previews can run their transformer
- document the new example and static-host header requirement

## Validation

- `pnpm test` (20 passing)
- `pnpm build`
- `node ./dist/bin.js build examples/website`
- browser-verified the dev example, iframe render, editor update, and absence of runtime errors

Refs #69
