### PR TITLE
Preserve page metadata in static output

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,22 @@ Files from `public/` are copied to the root of the output directory. For example
 Imports from `devjar` use the runtime and worker assets included in the build
 instead of loading another copy of Devjar from the package CDN.
 
+Pages can render React 19 document metadata directly. Devjar preserves these
+elements in each route's `<head>` during static export:
+
+```jsx
+export default function Page() {
+  return (
+    <>
+      <title>My prototype</title>
+      <meta name="description" content="A small React prototype" />
+      <link rel="icon" href="/icon.svg" />
+      <main>...</main>
+    </>
+  )
+}
+```
+
 Static rendering executes every page once during the build. Browser APIs can be
 used in effects and event handlers, but using `window` or `document` directly
 during render will fail the build with the affected route.

--- a/examples/website/pages/index.tsx
+++ b/examples/website/pages/index.tsx
@@ -2,9 +2,22 @@ import { Codesandbox } from '../components/codesandbox'
 import { demoFiles } from '../lib/demo-files'
 import '../styles.css'
 
+const description = 'React Live Preview in Browser'
+const socialImage =
+  'https://repository-images.githubusercontent.com/483779830/28347c03-774a-4766-b113-54041fad1e72'
+
 export default function Page() {
   return (
     <>
+      <title>devjar</title>
+      <meta name="description" content={description} />
+      <meta name="author" content="@huozhi" />
+      <meta property="og:title" content="devjar" />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={socialImage} />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:image" content={socialImage} />
+      <link rel="icon" href="/icon.svg" type="image/svg+xml" />
       <main>
         <div className="playground-container">
           <div className="playground-wrapper">

--- a/examples/website/public/icon.svg
+++ b/examples/website/public/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title id="title">devjar</title>
+  <rect width="64" height="64" rx="8" fill="#fafafa"/>
+  <g fill="none" stroke="#262626" stroke-linecap="square" stroke-linejoin="miter">
+    <path d="M22 12h20m-22 5h24" stroke-width="3"/>
+    <path d="M22 18v7l-6 6v19l4 4h24l4-4V31l-6-6v-7" stroke-width="3"/>
+    <path d="M48 33h3v19l-5 5H23v-3" stroke-width="2" stroke-dasharray="5 4"/>
+    <path d="m24 35 5 5-5 5m10 0h7" stroke-width="3"/>
+  </g>
+</svg>

--- a/scripts/test-cdn.ts
+++ b/scripts/test-cdn.ts
@@ -13,22 +13,41 @@ export const jsxDEV = jsx`
     return `function escape(value) {
   return String(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
 }
-function render(node) {
+let metadata = ''
+function render(node, hoistMetadata) {
   if (node == null || typeof node === 'boolean') return ''
-  if (Array.isArray(node)) return node.map(render).join('')
+  if (Array.isArray(node)) return node.map(child => render(child, hoistMetadata)).join('')
   if (typeof node === 'string' || typeof node === 'number') return escape(node)
-  if (typeof node.type === 'function') return render(node.type(node.props))
-  if (node.type === Symbol.for('react.fragment')) return render(node.props.children)
+  if (typeof node.type === 'function') return render(node.type(node.props), hoistMetadata)
+  if (node.type === Symbol.for('react.fragment')) return render(node.props.children, hoistMetadata)
   const attributes = Object.entries(node.props || {})
     .filter(([name]) => name !== 'children')
     .map(([name, value]) => ' ' + (name === 'className' ? 'class' : name) + '="' + escape(value) + '"')
     .join('')
-  return '<' + node.type + attributes + '>' + render(node.props?.children) + '</' + node.type + '>'
+  const isVoid = node.type === 'meta' || node.type === 'link'
+  const element = '<' + node.type + attributes + '>'
+    + (isVoid ? '' : render(node.props?.children, hoistMetadata) + '</' + node.type + '>')
+  if (hoistMetadata && (node.type === 'title' || isVoid)) {
+    metadata += element
+    return ''
+  }
+  return element
 }
-export function renderToString(node) { return render(node) }`
+export function renderToString(node) {
+  metadata = ''
+  return render(node, true).replace('</head>', metadata + '</head>')
+}`
   }
   if (pathname.includes('/react@')) {
-    return `export function createElement(type, props) { return { type, props: props || {} } }
+    return `export function createElement(type, props, ...children) {
+  return {
+    type,
+    props: {
+      ...(props || {}),
+      ...(children.length ? { children: children.length === 1 ? children[0] : children } : {}),
+    },
+  }
+}
 export function useCallback(callback) { return callback }
 export function useEffect() {}
 export function useId() { return 'test-id' }

--- a/src/cli/client.tsx
+++ b/src/cli/client.tsx
@@ -117,6 +117,23 @@ function hideError() {
   errorRoot.textContent = ''
 }
 
+function syncDefaultTitle() {
+  requestAnimationFrame(() => {
+    const defaultTitle = document.head.querySelector('title[data-devjar-default]')
+    const pageTitle = document.head.querySelector('title:not([data-devjar-default])')
+    if (pageTitle) {
+      defaultTitle?.remove()
+      return
+    }
+    if (defaultTitle) return
+
+    const title = document.createElement('title')
+    title.dataset.devjarDefault = ''
+    title.textContent = 'Devjar'
+    document.head.appendChild(title)
+  })
+}
+
 function isElementType(value: unknown): value is ElementType {
   return typeof value === 'string'
     || typeof value === 'function'
@@ -146,7 +163,7 @@ async function load(route: string) {
       if (!reactRoot) reactRoot = createRoot(appRoot)
       reactRoot.render(page)
     }
-    document.title = entry.page
+    syncDefaultTitle()
     hideError()
     if (!performance.getEntriesByName('devjar:first-render').length) {
       performance.mark('devjar:first-render')
@@ -208,6 +225,7 @@ async function start() {
           routeManifest = await getRouteManifest(revision)
         },
         onRefresh: detail => {
+          syncDefaultTitle()
           hideError()
           dispatchEvent(new CustomEvent('devjar:render', { detail }))
         },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -163,6 +163,7 @@ type HtmlOptions = {
   devjarDependencies: Record<string, string>
   cdn: string
   liveReload: boolean
+  head: string
   content: string
   styles: string
 }
@@ -204,9 +205,12 @@ await import('/__devjar/client.js')
   const staticStyles = options.styles
     ? `<style data-devjar-static>${options.styles.replace(/<\/style/gi, '<\\/style')}</style>`
     : ''
+  const documentHead = /<title(?:\s|>)/i.test(options.head)
+    ? options.head
+    : `<title data-devjar-default>Devjar</title>${options.head}`
   return `<!doctype html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Devjar</title>${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
+${documentHead}${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
 <style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>${staticStyles}
 </head><body><div id="root"><div id="__reactRoot">${options.content}</div></div><pre id="__devjarError" class="devjar-error" hidden></pre><script>
 const errorRoot = document.getElementById('__devjarError')
@@ -369,6 +373,7 @@ export async function startDevServer(options: DevServerOptions) {
             devjarDependencies,
             cdn: resolveCdn(options.cdn),
             liveReload: true,
+            head: '',
             content: '',
             styles: '',
           },
@@ -551,6 +556,7 @@ async function writeRouteHtml(
     devjarDependencies: options.devjarDependencies,
     cdn: options.cdn,
     liveReload: false,
+    head: rendered.head,
     content: rendered.markup,
     styles: rendered.styles,
   })
@@ -587,7 +593,7 @@ export async function buildProject(options: BuildOptions) {
         runtimeModulePath: join(runtime, 'index.js'),
       })
     : Object.fromEntries([...discovered.routes.keys()].map(route => (
-        [route, { markup: '', styles: '' }]
+        [route, { head: '', markup: '', styles: '' }]
       )))
   const projectPaths = new Set<string>()
   for (const page of discovered.routes.values()) {

--- a/src/cli/prerender-runner.mjs
+++ b/src/cli/prerender-runner.mjs
@@ -9,6 +9,24 @@ const reactModule = await import(input.react)
 const serverModule = await import(input.reactDomServer)
 const React = reactModule.default || reactModule
 const rendered = {}
+const startBoundary = '<template data-devjar-prerender="start"></template>'
+const endBoundary = '<template data-devjar-prerender="end"></template>'
+
+function contentBetween(document, start, end) {
+  const startIndex = document.indexOf(start)
+  const endIndex = document.indexOf(end, startIndex + start.length)
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error('Devjar could not read the prerendered document')
+  }
+  return document.slice(startIndex + start.length, endIndex)
+}
+
+function renderedRoute(document) {
+  return {
+    head: contentBetween(document, '<head>', '</head>'),
+    markup: contentBetween(document, startBoundary, endBoundary),
+  }
+}
 
 for (const [route, entry] of Object.entries(input.routes)) {
   try {
@@ -17,7 +35,21 @@ for (const [route, entry] of Object.entries(input.routes)) {
       && (typeof pageModule.default !== 'object' || pageModule.default === null)) {
       throw new Error('page must have a default React component export')
     }
-    rendered[route] = serverModule.renderToString(React.createElement(pageModule.default))
+    const document = serverModule.renderToString(
+      React.createElement(
+        'html',
+        null,
+        React.createElement('head'),
+        React.createElement(
+          'body',
+          null,
+          React.createElement('template', { 'data-devjar-prerender': 'start' }),
+          React.createElement(pageModule.default),
+          React.createElement('template', { 'data-devjar-prerender': 'end' }),
+        ),
+      ),
+    )
+    rendered[route] = renderedRoute(document)
   } catch (error) {
     throw new Error(`Unable to prerender ${route}: ${error?.stack || error}`)
   }

--- a/src/cli/prerender.ts
+++ b/src/cli/prerender.ts
@@ -17,9 +17,12 @@ type PrerenderOptions = {
 }
 
 export type PrerenderedRoute = {
+  head: string
   markup: string
   styles: string
 }
+
+type RenderedRoute = Pick<PrerenderedRoute, 'head' | 'markup'>
 
 type RenderInput = {
   routes: Record<string, string>
@@ -104,7 +107,7 @@ export async function prerender(options: PrerenderOptions) {
       throw new Error(renderError(error))
     }
 
-    const markup = JSON.parse(await readFile(outputPath, 'utf8')) as Record<string, string>
+    const rendered = JSON.parse(await readFile(outputPath, 'utf8')) as Record<string, RenderedRoute>
     const result: Record<string, PrerenderedRoute> = {}
     for (const [route, files] of routeFiles) {
       const styles: string[] = []
@@ -113,7 +116,7 @@ export async function prerender(options: PrerenderOptions) {
           styles.push(await readFile(join(options.root, projectPath), 'utf8'))
         }
       }
-      result[route] = { markup: markup[route], styles: styles.join('\n') }
+      result[route] = { ...rendered[route], styles: styles.join('\n') }
     }
     return result
   } finally {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -305,6 +305,7 @@ describe('dev server', () => {
     expect(client).toContain('routeManifest.liveReload')
     expect(client).toContain('popstate')
     expect(client).toContain('history.pushState')
+    expect(client).not.toContain('document.title = entry.page')
 
     const json = await fetch(`${base}/api/status.json`)
     expect(json.headers.get('content-type')).toContain('application/json')
@@ -418,6 +419,7 @@ describe('production build', () => {
     expect(entryModule).toContain('https://modules.example.test/react@19.2.0/jsx-dev-runtime?dev')
     expect(entryModule).not.toContain('__devjarRegisterModule')
     const builtHtml = await readFile(join(buildRoot, 'index.html'), 'utf8')
+    expect(builtHtml).toContain('<title data-devjar-default>Devjar</title>')
     expect(builtHtml).toContain('data-devjar-tailwind')
     expect(builtHtml).not.toContain('react-refresh')
     const runtimeFiles = await readdir(join(buildRoot, '__devjar'))
@@ -484,12 +486,16 @@ describe('static export', () => {
         `import '../styles.css'
 import { DevJar } from 'devjar'
 export default function Page() {
-  return <main className="page"><h1>Static now</h1><DevJar files={{ 'pages/index.jsx': 'export default function Page() {}' }} /></main>
+  return <>
+    <title>Static title</title>
+    <meta name="description" content="Static description" />
+    <main className="page"><h1>Static now</h1><DevJar files={{ 'pages/index.jsx': 'export default function Page() {}' }} /></main>
+  </>
 }`,
       )
       await writeFile(
         join(projectRoot, 'pages/guides/about.tsx'),
-        `export default function About() { return <h1>About statically rendered</h1> }`,
+        `export default function About() { return <><title>About title</title><h1>About statically rendered</h1></> }`,
       )
       await writeFile(
         join(projectRoot, 'pages/404.tsx'),
@@ -504,14 +510,19 @@ export default function Page() {
         prerender: true,
       })
       const document = await readFile(join(result.outDir, 'index.html'), 'utf8')
+      expect(document).toContain('<head><meta charset="utf-8"')
+      expect(document).toContain('<title>Static title</title><meta name="description" content="Static description">')
+      expect(document).not.toContain('<div id="__reactRoot"><title>')
       expect(document).toContain('<main class="page"><h1>Static now</h1>')
       expect(document).toContain('<iframe')
       expect(document).toContain('<style data-devjar-static>.page { color: black; }</style>')
       expect(document).toContain('<div id="__reactRoot">')
-      expect(await readFile(join(result.outDir, 'guides/about/index.html'), 'utf8'))
-        .toContain('<h1>About statically rendered</h1>')
-      expect(await readFile(join(result.outDir, '404.html'), 'utf8'))
-        .toContain('<h1>Static not found</h1>')
+      const aboutDocument = await readFile(join(result.outDir, 'guides/about/index.html'), 'utf8')
+      expect(aboutDocument).toContain('<title>About title</title>')
+      expect(aboutDocument).toContain('<h1>About statically rendered</h1>')
+      const notFoundDocument = await readFile(join(result.outDir, '404.html'), 'utf8')
+      expect(notFoundDocument).toContain('<title data-devjar-default>Devjar</title>')
+      expect(notFoundDocument).toContain('<h1>Static not found</h1>')
       expect(await readFile(join(result.outDir, '404/index.html'), 'utf8'))
         .toContain('<h1>Static not found</h1>')
       expect(await readFile(join(result.outDir, '__devjar/client.js'), 'utf8'))


### PR DESCRIPTION
## Summary

- preserve React 19 `<title>`, `<meta>`, `<link>`, and other hoisted head output per static route
- keep route body markup separate so metadata hydrates in the document head
- reconcile Devjar's fallback title in development instead of overwriting page titles with source filenames
- add the website's title, description, author, social metadata, and favicon
- document the zero-config React metadata convention

## Validation

- `pnpm test` (20 passing)
- `pnpm build`
- `node ./dist/bin.js build examples/website`
- browser-verified development and production hydration with one title, head-only metadata, a ready live preview, and no runtime errors

Refs #69
