### PR TITLE
Polish the Devjar icon

### DIFF
--- a/examples/website/public/icon.svg
+++ b/examples/website/public/icon.svg
@@ -1,10 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
   <title id="title">devjar</title>
   <rect width="64" height="64" rx="8" fill="#fafafa"/>
-  <g fill="none" stroke="#262626" stroke-linecap="square" stroke-linejoin="miter">
-    <path d="M22 12h20m-22 5h24" stroke-width="3"/>
-    <path d="M22 18v7l-6 6v19l4 4h24l4-4V31l-6-6v-7" stroke-width="3"/>
-    <path d="M48 33h3v19l-5 5H23v-3" stroke-width="2" stroke-dasharray="5 4"/>
-    <path d="m24 35 5 5-5 5m10 0h7" stroke-width="3"/>
-  </g>
+  <path d="M23 16h18v9l4 5a8 8 0 0 1 2 5v13a6 6 0 0 1-6 6H23a6 6 0 0 1-6-6V35a8 8 0 0 1 2-5l4-5V16Zm2 19 5 5-5 5m10 0h7" fill="none" stroke="#171717" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/site/app/icon.svg
+++ b/site/app/icon.svg
@@ -1,10 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
   <title id="title">devjar</title>
   <rect width="64" height="64" rx="8" fill="#fafafa"/>
-  <g fill="none" stroke="#262626" stroke-linecap="square" stroke-linejoin="miter">
-    <path d="M22 12h20m-22 5h24" stroke-width="3"/>
-    <path d="M22 18v7l-6 6v19l4 4h24l4-4V31l-6-6v-7" stroke-width="3"/>
-    <path d="M48 33h3v19l-5 5H23v-3" stroke-width="2" stroke-dasharray="5 4"/>
-    <path d="m24 35 5 5-5 5m10 0h7" stroke-width="3"/>
-  </g>
+  <path d="M23 16h18v9l4 5a8 8 0 0 1 2 5v13a6 6 0 0 1-6 6H23a6 6 0 0 1-6-6V35a8 8 0 0 1 2-5l4-5V16Zm2 19 5 5-5 5m10 0h7" fill="none" stroke="#171717" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
## Summary

- simplify the Devjar mark to one rounded jar and terminal path
- remove the separate lid, dashed offset border, and mixed stroke weights
- keep the site and pages-based website example assets identical
- retain the dashboard example’s intentionally separate black-circle mark

## Verification

- rendered at 512px and 32px
- validated both SVGs with `xmllint`
- confirmed the assets are byte-identical and contain no dashed geometry

Refs #69