### PR TITLE
Deploy the website as a static Devjar build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist
 next-env.d.ts
 tsconfig.tsbuildinfo
 .pnpm-store
+.vercel
+.env.local

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:worker": "bun scripts/build-workers.ts",
     "prepublishOnly": "pnpm run build",
     "build:site": "pnpm run build && next build ./site",
+    "build:website": "pnpm run build && node ./dist/bin.js build examples/website --out-dir dist",
     "start": "next start ./site",
     "dev": "pnpm run build && (pnpm run dev:lib & pnpm run dev:client & pnpm run dev:worker & pnpm run dev:site & wait)",
     "dev:lib": "bunchee --watch",

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test'
+import { readFile } from 'node:fs/promises'
+
+describe('Vercel deployment', () => {
+  test('builds the static website with cross-origin isolation', async () => {
+    const config = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'))
+
+    expect(config.framework).toBeNull()
+    expect(config.buildCommand).toBe('pnpm run build:website')
+    expect(config.outputDirectory).toBe('examples/website/dist')
+    expect(config.headers).toEqual([
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
+        ],
+      },
+    ])
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "buildCommand": "pnpm run build:website",
+  "outputDirectory": "examples/website/dist",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        },
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "credentialless"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- build the pages-based website example with the Devjar CLI on Vercel
- serve `examples/website/dist` with the framework preset set to Other
- apply COOP and COEP to every static response
- cover the deployment contract with a focused test

## Verification

- `pnpm run build:website`
- `pnpm test` — 21 passing
- preview: https://devjar-r82i79ukm-huozhi.vercel.app
- document and transform worker return `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: credentialless`
- browser reports `crossOriginIsolated === true`
- static page hydrates and an editor update refreshes the iframe with no browser errors

Refs #69