### PR TITLE
Rename the runtime URL prefix from /__devjar to /_jar

### DIFF
--- a/src/cli/client.tsx
+++ b/src/cli/client.tsx
@@ -25,7 +25,7 @@ function getRoot(id: string) {
 }
 
 const hostRoot = getRoot('root')
-const errorRoot = getRoot('__devjarError')
+const errorRoot = getRoot('__jarError')
 let appRoot = document.getElementById('__reactRoot')
 if (!appRoot) {
   appRoot = document.createElement('div')
@@ -69,7 +69,7 @@ function normalizeRoute(route: string) {
 }
 
 async function getRouteManifest(revision: number) {
-  const url = new URL('/__devjar/routes.json', location.origin)
+  const url = new URL('/_jar/routes.json', location.origin)
   if (revision) url.searchParams.set('v', String(revision))
   const response = await fetch(url)
   const data = await response.json()
@@ -187,7 +187,7 @@ function routeAnchor(target: EventTarget | null) {
   if (!anchor) return
   const url = new URL(anchor.href, location.href)
   if (url.origin !== location.origin) return
-  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/__devjar/')) return
+  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/_jar/')) return
   if (/\.[^/]+$/.test(url.pathname)) return
   return { anchor, url }
 }
@@ -220,7 +220,7 @@ async function start() {
   routeManifest = await getRouteManifest(0)
   const hotUpdater = routeManifest.liveReload
     ? createHotUpdater({
-        refreshRuntime: globalThis.__devjarRefreshRuntime,
+        refreshRuntime: globalThis.__jarRefreshRuntime,
         reloadRoutes: async revision => {
           routeManifest = await getRouteManifest(revision)
         },
@@ -240,7 +240,7 @@ async function start() {
 
   await load(location.pathname)
   if (hotUpdater) {
-    const events = new EventSource('/__devjar/events')
+    const events = new EventSource('/_jar/events')
     events.addEventListener('change', event => {
       const change = JSON.parse((event as MessageEvent).data) as HmrChange
       hotUpdater.enqueue(change, showError)

--- a/src/cli/hmr.ts
+++ b/src/cli/hmr.ts
@@ -26,8 +26,8 @@ type HotUpdaterOptions = {
 }
 
 declare global {
-  var __devjarRefreshRuntime: RefreshRuntime
-  var __devjarRegisterModule: (
+  var __jarRefreshRuntime: RefreshRuntime
+  var __jarRegisterModule: (
     path: string,
     url: string,
     exports: ModuleExports,
@@ -59,7 +59,7 @@ export function createHotUpdater(options: HotUpdaterOptions) {
   }>()
   let queue = Promise.resolve()
 
-  globalThis.__devjarRegisterModule = (path, url, exports) => {
+  globalThis.__jarRegisterModule = (path, url, exports) => {
     for (const [name, value] of Object.entries(exports)) {
       if (refreshRuntime.isLikelyComponentType(value)) {
         refreshRuntime.register(value, `${path} export ${name}`)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -181,7 +181,7 @@ function html(options: HtmlOptions) {
     'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
     'react-dom/client': resolveModule('react-dom/client'),
     'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
-    devjar: '/__devjar/runtime.js',
+    devjar: '/_jar/runtime.js',
     ...(options.liveReload
       ? { 'react-refresh/runtime': resolveRuntimeModule('react-refresh/runtime') }
       : {}),
@@ -198,10 +198,10 @@ function html(options: HtmlOptions) {
 import * as RefreshModule from 'react-refresh/runtime'
 const RefreshRuntime = RefreshModule.default || RefreshModule
 RefreshRuntime.injectIntoGlobalHook(globalThis)
-globalThis.__devjarRefreshRuntime = RefreshRuntime
-await import('/__devjar/client.js')
+globalThis.__jarRefreshRuntime = RefreshRuntime
+await import('/_jar/client.js')
 </script>`
-    : '<script type="module" src="/__devjar/client.js"></script>'
+    : '<script type="module" src="/_jar/client.js"></script>'
   const staticStyles = options.styles
     ? `<style data-devjar-static>${options.styles.replace(/<\/style/gi, '<\\/style')}</style>`
     : ''
@@ -212,8 +212,8 @@ await import('/__devjar/client.js')
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 ${documentHead}${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
 <style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>${staticStyles}
-</head><body><div id="root"><div id="__reactRoot">${options.content}</div></div><pre id="__devjarError" class="devjar-error" hidden></pre><script>
-const errorRoot = document.getElementById('__devjarError')
+</head><body><div id="root"><div id="__reactRoot">${options.content}</div></div><pre id="__jarError" class="devjar-error" hidden></pre><script>
+const errorRoot = document.getElementById('__jarError')
 const showBootstrapError = value => {
   errorRoot.hidden = false
   errorRoot.textContent = 'Devjar could not start:\\n\\n' + value
@@ -291,7 +291,7 @@ export async function startDevServer(options: DevServerOptions) {
         response.end('Method not allowed')
         return
       }
-      if (url.pathname === '/__devjar/events') {
+      if (url.pathname === '/_jar/events') {
         response.writeHead(200, {
           'Content-Type': 'text/event-stream',
           'Cache-Control': 'no-cache',
@@ -306,7 +306,7 @@ export async function startDevServer(options: DevServerOptions) {
         request.on('close', () => events.delete(response))
         return
       }
-      if (url.pathname === '/__devjar/routes.json') {
+      if (url.pathname === '/_jar/routes.json') {
         try {
           const manifest = await loadRouteManifest(root, {
             liveReload: true,
@@ -319,7 +319,7 @@ export async function startDevServer(options: DevServerOptions) {
         }
         return
       }
-      if (url.pathname === '/__devjar/module') {
+      if (url.pathname === '/_jar/module') {
         const projectPath = url.searchParams.get('path')
         if (!projectPath) {
           send(request, response, 400, 'text/plain; charset=utf-8', 'Module path is required')
@@ -335,7 +335,7 @@ export async function startDevServer(options: DevServerOptions) {
             dependencies,
             cdn,
             moduleUrl: modules.moduleUrl,
-            runtimeModuleUrl: '/__devjar/runtime.js',
+            runtimeModuleUrl: '/_jar/runtime.js',
             refresh: true,
             platform: 'browser',
           })
@@ -346,12 +346,12 @@ export async function startDevServer(options: DevServerOptions) {
         }
         return
       }
-      if (url.pathname === '/__devjar/runtime.js') {
+      if (url.pathname === '/_jar/runtime.js') {
         if (!await serveFile(request, response, assetsRoot, 'index.js', undefined)) send(request, response, 500, 'text/plain', 'Devjar runtime is missing')
         return
       }
-      if (url.pathname.startsWith('/__devjar/')) {
-        if (!await serveFile(request, response, assetsRoot, url.pathname.slice('/__devjar/'.length), undefined)) send(request, response, 404, 'text/plain', 'Not found')
+      if (url.pathname.startsWith('/_jar/')) {
+        if (!await serveFile(request, response, assetsRoot, url.pathname.slice('/_jar/'.length), undefined)) send(request, response, 404, 'text/plain', 'Not found')
         return
       }
       if (url.pathname.startsWith('/api/')) {
@@ -612,8 +612,8 @@ export async function buildProject(options: BuildOptions) {
       cdn,
     })
   }
-  await copyRuntimeAssets(join(outDir, '__devjar'))
-  const modulesRoot = join(outDir, '__devjar/modules')
+  await copyRuntimeAssets(join(outDir, '_jar'))
+  const modulesRoot = join(outDir, '_jar/modules')
   await mkdir(modulesRoot, { recursive: true })
   for (const projectPath of projectPaths) {
     const compiled = await compileProjectModule({
@@ -622,13 +622,13 @@ export async function buildProject(options: BuildOptions) {
       dependencies,
       cdn,
       moduleUrl: builtModuleUrl,
-      runtimeModuleUrl: '/__devjar/runtime.js',
+      runtimeModuleUrl: '/_jar/runtime.js',
       refresh: false,
       platform: 'browser',
     })
     await writeFile(join(modulesRoot, moduleAssetName(projectPath)), compiled.code)
   }
-  await writeFile(join(outDir, '__devjar/routes.json'), JSON.stringify(manifest))
+  await writeFile(join(outDir, '_jar/routes.json'), JSON.stringify(manifest))
   await copyApiFiles(join(root, 'api'), join(outDir, 'api'))
 
   return { root, outDir, routes: Object.keys(manifest.routes) }
@@ -660,8 +660,8 @@ export async function startBuiltServer(options: StartServerOptions) {
         response.end(request.method === 'HEAD' ? undefined : 'Method not allowed')
         return
       }
-      if (url.pathname.startsWith('/__devjar/')) {
-        if (!await serveFile(request, response, join(root, '__devjar'), url.pathname.slice('/__devjar/'.length), undefined)) {
+      if (url.pathname.startsWith('/_jar/')) {
+        if (!await serveFile(request, response, join(root, '_jar'), url.pathname.slice('/_jar/'.length), undefined)) {
           send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
         }
         return

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -110,7 +110,7 @@ export async function collectProjectFiles(root: string, entry: string) {
 export function devModuleUrl(projectPath: string, version: number) {
   const parameters = new URLSearchParams({ path: projectPath })
   if (version) parameters.set('v', String(version))
-  return `/__devjar/module?${parameters}`
+  return `/_jar/module?${parameters}`
 }
 
 export function moduleAssetName(projectPath: string) {
@@ -118,20 +118,20 @@ export function moduleAssetName(projectPath: string) {
 }
 
 export function builtModuleUrl(projectPath: string) {
-  return `/__devjar/modules/${moduleAssetName(projectPath)}`
+  return `/_jar/modules/${moduleAssetName(projectPath)}`
 }
 
 function browserCssModule(source: string, projectPath: string) {
   return `const sheet = new CSSStyleSheet()
 sheet.replaceSync(${JSON.stringify(source)})
-globalThis.__devjarStyleSheets ||= new Map()
-const previous = globalThis.__devjarStyleSheets.get(${JSON.stringify(projectPath)})
+globalThis.__jarStyleSheets ||= new Map()
+const previous = globalThis.__jarStyleSheets.get(${JSON.stringify(projectPath)})
 const sheets = [...document.adoptedStyleSheets]
 const index = sheets.indexOf(previous)
 if (index < 0) sheets.push(sheet)
 else sheets[index] = sheet
 document.adoptedStyleSheets = sheets
-globalThis.__devjarStyleSheets.set(${JSON.stringify(projectPath)}, sheet)
+globalThis.__jarStyleSheets.set(${JSON.stringify(projectPath)}, sheet)
 export default sheet
 `
 }
@@ -223,10 +223,10 @@ export async function compileProjectModule(
       .filter(exported => exported.ln)
       .map(exported => `${JSON.stringify(exported.n)}: ${exported.ln}`)
       .join(', ')
-    code = `const $RefreshReg$ = (type, id) => globalThis.__devjarRefreshRuntime.register(type, ${JSON.stringify(`${projectPath} `)} + id)
-const $RefreshSig$ = globalThis.__devjarRefreshRuntime.createSignatureFunctionForTransform
+    code = `const $RefreshReg$ = (type, id) => globalThis.__jarRefreshRuntime.register(type, ${JSON.stringify(`${projectPath} `)} + id)
+const $RefreshSig$ = globalThis.__jarRefreshRuntime.createSignatureFunctionForTransform
 ${code}
-globalThis.__devjarRegisterModule(${JSON.stringify(projectPath)}, import.meta.url, { ${registeredExports} })
+globalThis.__jarRegisterModule(${JSON.stringify(projectPath)}, import.meta.url, { ${registeredExports} })
 `
   }
   return {

--- a/src/core.ts
+++ b/src/core.ts
@@ -17,7 +17,7 @@ type RenderFunction = (
 ) => Promise<void>
 
 declare global {
-  var __devjar__: Record<string, { resolveModule?: ResolveModule }> | undefined
+  var __jar__: Record<string, { resolveModule?: ResolveModule }> | undefined
   interface Window {
     __render__?: RenderFunction
   }
@@ -485,7 +485,7 @@ function createMainScript({ uid }: { uid: string }) {
 const _createModule = ${createModule.toString()};
 const _createRenderer = ${createRenderer.toString()};
 
-const resolveModule = (specifier) => window.parent.__devjar__[globalThis.uid].resolveModule(specifier)
+const resolveModule = (specifier) => window.parent.__jar__[globalThis.uid].resolveModule(specifier)
 
 globalThis.uid = ${JSON.stringify(uid)};
 globalThis.__render__ = _createRenderer(_createModule, resolveModule);
@@ -554,16 +554,16 @@ function useLiveCode({
   // Let resolveModule execute on parent window side since it might involve
   // variables that iframe cannot access.
   useEffect(() => {
-    if (!globalThis.__devjar__) {
-      globalThis.__devjar__ = {};
+    if (!globalThis.__jar__) {
+      globalThis.__jar__ = {};
     }
-    globalThis.__devjar__[uid] = {
+    globalThis.__jar__[uid] = {
       resolveModule,
     }
 
     return () => {
-      if (globalThis.__devjar__) {
-        delete globalThis.__devjar__[uid]
+      if (globalThis.__jar__) {
+        delete globalThis.__jar__[uid]
       }
     }
   }, [resolveModule, uid])

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -124,7 +124,7 @@ describe('project loading', () => {
       dependencies: { react: '19.2.0' },
       cdn: 'https://modules.example.test/',
       moduleUrl: testModuleUrl,
-      runtimeModuleUrl: '/__devjar/runtime.js',
+      runtimeModuleUrl: '/_jar/runtime.js',
       refresh: false,
       platform: 'browser',
     })
@@ -214,7 +214,7 @@ describe('project loading', () => {
         dependencies: {},
         cdn: CDN_HOST,
         moduleUrl: testModuleUrl,
-        runtimeModuleUrl: '/__devjar/runtime.js',
+        runtimeModuleUrl: '/_jar/runtime.js',
         refresh: false,
         platform: 'browser',
       })
@@ -271,7 +271,7 @@ describe('dev server', () => {
     expect(shell.headers.get('cross-origin-opener-policy')).toBe('same-origin')
     expect(shell.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
     const shellSource = await shell.text()
-    expect(shellSource).toContain('/__devjar/client.js')
+    expect(shellSource).toContain('/_jar/client.js')
     expect(shellSource).toContain("import * as RefreshModule from 'react-refresh/runtime'")
     expect(shellSource).toContain('data-devjar-tailwind')
     expect(shellSource).toContain('https://esm.sh/@tailwindcss/browser@%5E4.1.0')
@@ -282,23 +282,23 @@ describe('dev server', () => {
     const bootstrap = shellSource.match(/<script>\n([\s\S]+?)<\/script>/)?.[1]
     expect(() => new Function(bootstrap || '')).not.toThrow()
 
-    const routes = await (await fetch(`${base}/__devjar/routes.json`)).json()
+    const routes = await (await fetch(`${base}/_jar/routes.json`)).json()
     expect(routes.routes['/about'].page).toBe('pages/about.tsx')
     const pageModule = await (await fetch(`${base}${routes.routes['/about'].module}`)).text()
-    expect(pageModule).toContain('/__devjar/module?path=components%2Fshell.tsx')
-    expect(pageModule).toContain('/__devjar/module?path=styles.css')
+    expect(pageModule).toContain('/_jar/module?path=components%2Fshell.tsx')
+    expect(pageModule).toContain('/_jar/module?path=styles.css')
     expect(pageModule).toContain('https://esm.sh/react@19.2.0/jsx-dev-runtime?dev')
-    expect(pageModule).toContain('__devjarRegisterModule')
-    expect(pageModule).toContain('__devjarRefreshRuntime')
-    const sharedModule = await (await fetch(`${base}/__devjar/module?path=components%2Fshell.tsx`)).text()
+    expect(pageModule).toContain('__jarRegisterModule')
+    expect(pageModule).toContain('__jarRefreshRuntime')
+    const sharedModule = await (await fetch(`${base}/_jar/module?path=components%2Fshell.tsx`)).text()
     expect(sharedModule).not.toContain('ReactNode')
-    const client = await (await fetch(`${base}/__devjar/client.js`)).text()
+    const client = await (await fetch(`${base}/_jar/client.js`)).text()
     await init
     expect(() => parse(client)).not.toThrow()
-    expect(client).toContain('/__devjar/routes.json')
+    expect(client).toContain('/_jar/routes.json')
     expect(client).toContain('modulepreload')
     expect(client).toContain('pointerover')
-    expect(client).not.toContain('/__devjar/project')
+    expect(client).not.toContain('/_jar/project')
     expect(client).not.toContain('linkModules')
     expect(client).not.toContain('createElement("iframe")')
     expect(client).not.toContain('@tailwindcss/browser')
@@ -316,10 +316,10 @@ describe('dev server', () => {
     expect((await fetch(`${base}/api/blocked.js`)).status).toBe(404)
     expect((await fetch(`${base}/api/status.json`, { method: 'POST' })).status).toBe(405)
 
-    const worker = await fetch(`${base}/__devjar/transform-worker.js`)
+    const worker = await fetch(`${base}/_jar/transform-worker.js`)
     expect(worker.headers.get('content-type')).toContain('text/javascript')
     expect(worker.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
-    const wasm = await fetch(`${base}/__devjar/transform.wasm32-wasi.wasm`)
+    const wasm = await fetch(`${base}/_jar/transform.wasm32-wasi.wasm`)
     expect(wasm.headers.get('content-type')).toBe('application/wasm')
 
     await server.close()
@@ -348,14 +348,14 @@ export default function Page() { return <Card /> }`,
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
     try {
       await new Promise(resolvePromise => setTimeout(resolvePromise, 100))
-      const routes = await (await fetch(`${base}/__devjar/routes.json`)).json()
+      const routes = await (await fetch(`${base}/_jar/routes.json`)).json()
       const pageModule = await (await fetch(`${base}${routes.routes['/'].module}`)).text()
-      const cardModuleUrl = pageModule.match(/\/__devjar\/module\?path=components%2Fcard\.tsx/)?.[0]
+      const cardModuleUrl = pageModule.match(/\/_jar\/module\?path=components%2Fcard\.tsx/)?.[0]
       expect(cardModuleUrl).toBeDefined()
       const cardModule = await (await fetch(`${base}${cardModuleUrl}`)).text()
-      expect(cardModule).toContain('__devjarRegisterModule')
+      expect(cardModule).toContain('__jarRegisterModule')
 
-      const eventResponse = await fetch(`${base}/__devjar/events`)
+      const eventResponse = await fetch(`${base}/_jar/events`)
       reader = eventResponse.body!.getReader()
       await reader.read()
       await writeFile(cardPath, `export function Card() { return <p>two</p> }`)
@@ -374,7 +374,7 @@ export default function Page() { return <Card /> }`,
         updates: [{
           path: 'components/card.tsx',
           type: 'refresh',
-          url: '/__devjar/module?path=components%2Fcard.tsx&v=1',
+          url: '/_jar/module?path=components%2Fcard.tsx&v=1',
         }],
       })
     } finally {
@@ -412,17 +412,17 @@ describe('production build', () => {
     expect(Object.keys(manifest.routes).sort()).toEqual(['/', '/404', '/projects', '/settings'])
     expect(manifest.version).toBe(2)
     expect(manifest.liveReload).toBe(false)
-    expect(manifest.routes['/'].module).toMatch(/^\/__devjar\/modules\/.+\.js$/)
-    expect(await readFile(join(buildRoot, '__devjar/client.js'), 'utf8')).toContain('__devjar/routes.json')
-    expect(await readFile(join(buildRoot, '__devjar/routes.json'), 'utf8')).toBe(JSON.stringify(manifest))
+    expect(manifest.routes['/'].module).toMatch(/^\/_jar\/modules\/.+\.js$/)
+    expect(await readFile(join(buildRoot, '_jar/client.js'), 'utf8')).toContain('_jar/routes.json')
+    expect(await readFile(join(buildRoot, '_jar/routes.json'), 'utf8')).toBe(JSON.stringify(manifest))
     const entryModule = await readFile(join(buildRoot, manifest.routes['/'].module), 'utf8')
     expect(entryModule).toContain('https://modules.example.test/react@19.2.0/jsx-dev-runtime?dev')
-    expect(entryModule).not.toContain('__devjarRegisterModule')
+    expect(entryModule).not.toContain('__jarRegisterModule')
     const builtHtml = await readFile(join(buildRoot, 'index.html'), 'utf8')
     expect(builtHtml).toContain('<title data-devjar-default>Devjar</title>')
     expect(builtHtml).toContain('data-devjar-tailwind')
     expect(builtHtml).not.toContain('react-refresh')
-    const runtimeFiles = await readdir(join(buildRoot, '__devjar'))
+    const runtimeFiles = await readdir(join(buildRoot, '_jar'))
     expect(runtimeFiles.some(file => /^.+-[a-z0-9]+\.js$/.test(file))).toBe(true)
     expect(await readFile(join(buildRoot, 'api/projects.json'), 'utf8')).toContain('Mobile refresh')
     expect(await readFile(join(buildRoot, 'mark.svg'), 'utf8')).toContain('<svg')
@@ -448,14 +448,14 @@ describe('production build', () => {
 
     const shell = await (await fetch(`${base}/projects`)).text()
     expect(shell).toContain('https://modules.example.test/react@19.2.0?dev')
-    const routes = await (await fetch(`${base}/__devjar/routes.json`)).json()
+    const routes = await (await fetch(`${base}/_jar/routes.json`)).json()
     expect(routes.routes['/projects'].page).toBe('pages/projects.tsx')
     expect(routes.liveReload).toBe(false)
     expect(routes.notFound.page).toBe('pages/404.tsx')
     const projectModule = await fetch(`${base}${routes.routes['/projects'].module}`)
     expect(projectModule.status).toBe(200)
     expect(projectModule.headers.get('content-type')).toContain('text/javascript')
-    expect((await fetch(`${base}/__devjar/events`)).status).toBe(404)
+    expect((await fetch(`${base}/_jar/events`)).status).toBe(404)
     expect(await (await fetch(`${base}/api/projects.json`)).json()).toHaveLength(4)
     expect(await (await fetch(`${base}/mark.svg`)).text()).toContain('<svg')
 
@@ -525,11 +525,11 @@ export default function Page() {
       expect(notFoundDocument).toContain('<h1>Static not found</h1>')
       expect(await readFile(join(result.outDir, '404/index.html'), 'utf8'))
         .toContain('<h1>Static not found</h1>')
-      expect(await readFile(join(result.outDir, '__devjar/client.js'), 'utf8'))
+      expect(await readFile(join(result.outDir, '_jar/client.js'), 'utf8'))
         .toContain('hydrateRoot')
       const manifest = JSON.parse(await readFile(join(result.outDir, 'manifest.json'), 'utf8'))
       const pageModule = await readFile(join(result.outDir, manifest.routes['/'].module), 'utf8')
-      expect(pageModule).toContain('/__devjar/runtime.js')
+      expect(pageModule).toContain('/_jar/runtime.js')
       expect(pageModule).not.toContain(`${address.port}/devjar`)
     } finally {
       await new Promise<void>(resolvePromise => cdn.close(() => resolvePromise()))


### PR DESCRIPTION
## Summary

The CLI serves its runtime assets, dev-server endpoints, and compiled modules under `/__devjar/`, and the same `__devjar` directory is written into production build output — where the "dev" reads wrong. This renames the URL prefix and output directory to `/_jar/`, following the single-underscore framework convention (`/_next/`, `/_astro/`), and shortens the matching CLI internals for consistency.

## Changes

- URL prefix `/__devjar/*` → `/_jar/*` (dev server routes, built-asset server, build output directory, module/runtime/routes/events URLs)
- HMR globals → `__jarRefreshRuntime`, `__jarRegisterModule`; stylesheet registry → `__jarStyleSheets`
- Bootstrap error element id → `__jarError`; iframe resolver bridge → `__jar__`
- Untouched: sandbox-generated code in `src/core.ts` and the oxc worker globals (`__devjarOxc*`), which never appear in URLs

## Verification

- `pnpm run build` — pass; `dist/client.js`/`dist/bin.js` contain `/_jar/` and zero `__devjar` references
- `bun test` — 21 pass, 0 fail (includes `test/cli.test.ts`: 18 pass)