### PR TITLE
Rename the CLI binary from devjar to jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ my-prototype/
 ```
 
 ```sh
-npx devjar dev
+npx jar dev
 ```
 
-Running `devjar` without a command is an alias for `devjar dev`. The development
+Running `jar` without a command is an alias for `jar dev`. The development
 server watches the project and updates the browser as files change.
 
 The pages directory maps directly to URLs:
@@ -188,8 +188,8 @@ list to enable Tailwind. Bare imports use esm.sh by default. Select a different
 ESM-compatible CDN with the `--cdn` flag:
 
 ```sh
-devjar dev --cdn https://modules.example.com
-devjar build --cdn https://modules.example.com
+jar dev --cdn https://modules.example.com
+jar build --cdn https://modules.example.com
 ```
 
 The CLI applies dependency versions to CDN URLs using the
@@ -201,8 +201,8 @@ Create a static build, then serve it without source-file watching or on-request
 transforms:
 
 ```sh
-devjar build
-devjar start dist
+jar build
+jar start dist
 ```
 
 The build writes the initial React content and imported CSS into an HTML file for
@@ -242,9 +242,9 @@ must remain inside the project root.
 The repository includes three runnable examples:
 
 ```sh
-devjar dev examples/basic
-devjar dev examples/dashboard
-devjar dev examples/website
+jar dev examples/basic
+jar dev examples/dashboard
+jar dev examples/website
 ```
 
 The dashboard demonstrates page navigation, shared components, a CDN-loaded
@@ -253,7 +253,7 @@ The website example runs Devjar's own editor and live preview as a pages-based
 Devjar project.
 
 ```sh
-devjar dev [root] --host localhost --port 3000
+jar dev [root] --host localhost --port 3000
 ```
 
 ## Notice: iframe cross-origin isolation
@@ -262,7 +262,7 @@ The iframe transforms code in the browser using Oxc and shared WebAssembly
 memory, so its host page must be cross-origin isolated. Devjar packages the
 browser transformer, WASM binary, and helper worker as lazy runtime assets;
 compatible bundlers emit these files without requiring a manual copy step.
-The `devjar dev` and `devjar start` servers send the required headers
+The `jar dev` and `jar start` servers send the required headers
 automatically. Static deployments must configure equivalent headers on their
 hosting platform.
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ my-prototype/
 ```
 
 ```sh
-npx jar dev
+npx devjar dev
 ```
 
 Running `jar` without a command is an alias for `jar dev`. The development

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     }
   },
   "bin": {
-    "devjar": "./dist/bin.js"
+    "jar": "./dist/bin.js"
   },
   "license": "MIT",
   "repository": {

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -6,8 +6,8 @@ import { testCdnModule } from './test-cdn'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const packageJson = await Bun.file(join(root, 'package.json')).json()
-if (packageJson.bin?.devjar !== './dist/bin.js') {
-  throw new Error('package.json must expose dist/bin.js as the devjar binary')
+if (packageJson.bin?.jar !== './dist/bin.js') {
+  throw new Error('package.json must expose dist/bin.js as the jar binary')
 }
 
 const cache = mkdtempSync(join(tmpdir(), 'devjar-npm-cache-'))

--- a/src/bin/jar.ts
+++ b/src/bin/jar.ts
@@ -12,14 +12,14 @@ function style(code: number, value: string) {
 }
 
 function help() {
-  console.log(`devjar [command] [root] [options]
+  console.log(`jar [command] [root] [options]
 
 Turn a folder of React pages into a prototype.
 
 Commands:
   dev      Start a development server (default)
   build    Create production output in <root>/dist
-  start    Serve a directory created by devjar build
+  start    Serve a directory created by jar build
 
 Options:
   --cdn <url>      ESM-compatible module CDN (dev and build)
@@ -30,10 +30,10 @@ Options:
   -h, --help       Show this help
 
 Examples:
-  devjar
-  devjar dev examples/dashboard
-  devjar build examples/dashboard
-  devjar start examples/dashboard/dist`)
+  jar
+  jar dev examples/dashboard
+  jar build examples/dashboard
+  jar start examples/dashboard/dist`)
 }
 
 function valueAfter(args: string[], index: number) {
@@ -155,6 +155,6 @@ async function run() {
 }
 
 run().catch(error => {
-  console.error(`Devjar: ${friendlyError(error)}`)
+  console.error(`Jar: ${friendlyError(error)}`)
   process.exitCode = 1
 })


### PR DESCRIPTION
## Summary

Renames the zero-config CLI command from `devjar` to the shorter `jar`: `jar dev`, `jar build`, `jar start`. The npm package name stays `devjar` — it's still installed with `pnpm add devjar` and imported as `import { DevJar } from 'devjar'`; only the executable changes.

## Changes

- `package.json` `bin`: `devjar` → `jar` (still `./dist/bin.js`)
- `src/bin/devjar.ts` → `src/bin/jar.ts` — bunchee maps the `bin` key to `src/bin/<name>.ts`, so the entry point follows the new name
- Help text and examples now show `jar`; error prefix is `Jar:`
- `scripts/check-package.ts` asserts the new `jar` bin mapping
- README CLI command examples updated (package/import references left as `devjar`)

## Verification

- `pnpm run build` — pass
- `node dist/bin.js --help` — prints `jar [command] [root] [options]`
- `node dist/bin.js --version` — prints `0.11.0`
- `bun test` — 21 pass, 0 fail
- `pnpm test:package` — pass ("Package contains the CLI and required runtime assets")