### PR TITLE
Content-hash the transform worker assets for immutable caching

### DIFF
--- a/scripts/build-workers.ts
+++ b/scripts/build-workers.ts
@@ -1,9 +1,21 @@
-import { copyFile } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { copyFile, readFile, writeFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { dirname, join, parse } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..')
 const bindingDirectory = join(root, 'node_modules/@oxc-transform/binding-wasm32-wasi')
+const distDirectory = join(root, 'dist')
+
+// Single source of truth for the runtime transform assets. The CLI copies the
+// emitted files and the browser runtime builds their URLs from the hashed
+// names recorded here.
+export type TransformAssetManifest = {
+  worker: string
+  binding: string
+  wasm: string
+  wasiWorker: string
+}
 
 const result = await Bun.build({
   entrypoints: [
@@ -11,8 +23,10 @@ const result = await Bun.build({
     join(bindingDirectory, 'transform.wasi-browser.js'),
     join(bindingDirectory, 'wasi-worker-browser.mjs'),
   ],
-  outdir: join(root, 'dist'),
-  naming: '[name].[ext]',
+  outdir: distDirectory,
+  // Content-hash the filenames so the emitted assets are immutable and can be
+  // cached forever. The hash is stable for identical content.
+  naming: '[name]-[hash].[ext]',
   target: 'browser',
   format: 'esm',
   footer: 'export {}',
@@ -48,11 +62,45 @@ if (!result.success) {
   process.exit(1)
 }
 
-await copyFile(
-  join(bindingDirectory, 'transform.wasm32-wasi.wasm'),
-  join(root, 'dist/transform.wasm32-wasi.wasm'),
-)
+// Content-hash the copied wasm binary with the same scheme Bun uses
+// (`name-<hash>.<ext>`), then emit it under the hashed name.
+function contentHash(bytes: Buffer | Uint8Array) {
+  return createHash('sha256').update(bytes).digest('hex').slice(0, 10)
+}
+
+function hashFileName(fileName: string, hash: string) {
+  const { name, ext } = parse(fileName)
+  return `${name}-${hash}${ext}`
+}
+
+const wasmSourcePath = join(bindingDirectory, 'transform.wasm32-wasi.wasm')
+const wasmBytes = await readFile(wasmSourcePath)
+const wasmName = hashFileName('transform.wasm32-wasi.wasm', contentHash(wasmBytes))
+await copyFile(wasmSourcePath, join(distDirectory, wasmName))
+
+// Map each entrypoint to its emitted (hashed) output file name. Outputs keep
+// the entrypoint's name as a stem (`<name>-<hash>.js`), so match on that.
+function emittedName(entrypoint: string) {
+  const stem = parse(entrypoint).name
+  const output = result.outputs.find(o => {
+    if (o.kind !== 'entry-point') return false
+    const base = parse(o.path).base
+    return base === `${stem}.js` || base.startsWith(`${stem}-`)
+  })
+  if (!output) throw new Error(`Missing build output for ${entrypoint}`)
+  return parse(output.path).base
+}
+
+const manifest: TransformAssetManifest = {
+  worker: emittedName(join(root, 'src/transform-worker.ts')),
+  binding: emittedName(join(bindingDirectory, 'transform.wasi-browser.js')),
+  wasm: wasmName,
+  wasiWorker: emittedName(join(bindingDirectory, 'wasi-worker-browser.mjs')),
+}
+await writeFile(join(distDirectory, 'transform-assets.json'), `${JSON.stringify(manifest, null, 2)}\n`)
 
 for (const output of result.outputs) {
   console.log(`${output.path.replace(`${root}/`, '')} ${output.size} bytes`)
 }
+console.log(`dist/${wasmName} ${wasmBytes.byteLength} bytes`)
+console.log('dist/transform-assets.json')

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -30,15 +30,29 @@ const required = [
   'dist/http-loader.mjs',
   'dist/index.js',
   'dist/prerender-runner.mjs',
-  'dist/transform-worker.js',
-  'dist/transform.wasm32-wasi.wasm',
+  'dist/transform-assets.json',
 ]
 const missing = required.filter(file => !files.has(file))
-const hasRuntimeChunk = [...files].some(file => /^dist\/.+-[a-z0-9]+\.js$/.test(file))
-
-if (missing.length || !hasRuntimeChunk) {
-  if (!hasRuntimeChunk) missing.push('dist/<runtime>-<hash>.js')
+if (missing.length) {
   throw new Error(`Package is missing required files: ${missing.join(', ')}`)
+}
+
+// The transform worker assets are content-hashed for immutable caching. The
+// manifest records their hashed names; assert each hashed asset is published.
+const assetManifestPath = join(root, 'dist', 'transform-assets.json')
+const assetManifest = JSON.parse(await Bun.file(assetManifestPath).text()) as {
+  worker: string
+  binding: string
+  wasm: string
+  wasiWorker: string
+}
+const hashedAssets = [assetManifest.worker, assetManifest.binding, assetManifest.wasm, assetManifest.wasiWorker]
+const missingHashed = hashedAssets.filter(name => !files.has(`dist/${name}`))
+const unhashed = hashedAssets.filter(name => !/-[a-z0-9]+\.(js|wasm)$/.test(name))
+if (missingHashed.length || unhashed.length) {
+  throw new Error(
+    `Package transform assets invalid: missing=${missingHashed.join(', ') || 'none'} unhashed=${unhashed.join(', ') || 'none'}`,
+  )
 }
 
 const cli = Bun.spawnSync(['node', 'dist/bin.js', '--version'], { cwd: root })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -516,13 +516,29 @@ async function copyPublicFiles(source: string, destination: string) {
 async function copyRuntimeAssets(destination: string) {
   const source = await runtimeRoot()
   await mkdir(destination, { recursive: true })
+
+  // The transform worker assets are content-hashed for immutable caching. Their
+  // hashed names are recorded in transform-assets.json, which the browser
+  // runtime reads to resolve them. Copy the manifest plus each hashed asset.
+  const manifestPath = join(source, 'transform-assets.json')
+  if (!await fileExists(manifestPath)) {
+    throw new Error('Devjar runtime asset is missing: transform-assets.json')
+  }
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8')) as {
+    worker: string
+    binding: string
+    wasm: string
+    wasiWorker: string
+  }
+
   const assets: Array<[string, string]> = [
     ['index.js', 'runtime.js'],
     ['client.js', 'client.js'],
-    ['transform-worker.js', 'transform-worker.js'],
-    ['transform.wasi-browser.js', 'transform.wasi-browser.js'],
-    ['transform.wasm32-wasi.wasm', 'transform.wasm32-wasi.wasm'],
-    ['wasi-worker-browser.js', 'wasi-worker-browser.js'],
+    ['transform-assets.json', 'transform-assets.json'],
+    [manifest.worker, manifest.worker],
+    [manifest.binding, manifest.binding],
+    [manifest.wasm, manifest.wasm],
+    [manifest.wasiWorker, manifest.wasiWorker],
   ]
   const entryFiles = new Set(assets.map(([sourceName]) => sourceName))
   for (const name of await readdir(source)) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -57,22 +57,43 @@ function normalizeProjectPath(filename: string) {
   return parts.join('/')
 }
 
-function createTransformWorker(transformWorkerUrl?: string | URL) {
+type TransformAssetManifest = {
+  worker: string
+  binding: string
+  wasm: string
+  wasiWorker: string
+}
+
+// The worker assets are content-hashed at build time for immutable caching.
+// Their hashed names live in transform-assets.json next to this module, so the
+// runtime resolves them relative to import.meta.url. Fetched once and cached.
+let transformAssetsPromise: Promise<TransformAssetManifest> | undefined
+function loadTransformAssets(): Promise<TransformAssetManifest> {
+  transformAssetsPromise ??= fetch(new URL('./transform-assets.json', import.meta.url))
+    .then(res => {
+      if (!res.ok) throw new Error(`devjar: failed to load transform assets (${res.status})`)
+      return res.json() as Promise<TransformAssetManifest>
+    })
+  return transformAssetsPromise
+}
+
+async function createTransformWorker(transformWorkerUrl?: string | URL) {
+  const assets = await loadTransformAssets()
   const workerUrl = new URL(
-    transformWorkerUrl ?? new URL('./transform-worker.js', import.meta.url),
+    transformWorkerUrl ?? new URL(`./${assets.worker}`, import.meta.url),
     globalThis.location.href,
   )
   workerUrl.searchParams.set(
     'binding',
-    new URL('./transform.wasi-browser.js', import.meta.url).href,
+    new URL(`./${assets.binding}`, import.meta.url).href,
   )
   workerUrl.searchParams.set(
     'wasm',
-    new URL('./transform.wasm32-wasi.wasm', import.meta.url).href,
+    new URL(`./${assets.wasm}`, import.meta.url).href,
   )
   workerUrl.searchParams.set(
     'wasiWorker',
-    new URL('./wasi-worker-browser.js', import.meta.url).href,
+    new URL(`./${assets.wasiWorker}`, import.meta.url).href,
   )
 
   return new Worker(workerUrl, {
@@ -619,9 +640,9 @@ function useLiveCode({
     }
   }, [])
 
-  const transformFiles = useCallback((files: Record<string, string>) => {
+  const transformFiles = useCallback(async (files: Record<string, string>) => {
     if (!transformWorkerRef.current) {
-      const worker = createTransformWorker(transformWorkerUrl)
+      const worker = await createTransformWorker(transformWorkerUrl)
       worker.onmessage = ({ data }: MessageEvent<TransformWorkerResponse>) => {
         const request = transformRequestsRef.current.get(data.id)
         if (!request) return

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -316,10 +316,19 @@ describe('dev server', () => {
     expect((await fetch(`${base}/api/blocked.js`)).status).toBe(404)
     expect((await fetch(`${base}/api/status.json`, { method: 'POST' })).status).toBe(405)
 
-    const worker = await fetch(`${base}/_jar/transform-worker.js`)
+    // The transform assets are content-hashed; resolve their names via the manifest.
+    const assetManifest = await (await fetch(`${base}/_jar/transform-assets.json`)).json() as {
+      worker: string
+      binding: string
+      wasm: string
+      wasiWorker: string
+    }
+    expect(assetManifest.worker).toMatch(/^transform-worker-[a-z0-9]+\.js$/)
+    const worker = await fetch(`${base}/_jar/${assetManifest.worker}`)
     expect(worker.headers.get('content-type')).toContain('text/javascript')
     expect(worker.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
-    const wasm = await fetch(`${base}/_jar/transform.wasm32-wasi.wasm`)
+    expect(assetManifest.wasm).toMatch(/^transform\.wasm32-wasi-[a-z0-9]+\.wasm$/)
+    const wasm = await fetch(`${base}/_jar/${assetManifest.wasm}`)
     expect(wasm.headers.get('content-type')).toBe('application/wasm')
 
     await server.close()

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -16,6 +16,12 @@ describe('Vercel deployment', () => {
           { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
         ],
       },
+      {
+        source: '/_jar/(.*-[a-z0-9]+\\.(?:js|wasm))',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+        ],
+      },
     ])
   })
 })

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,15 @@
           "value": "credentialless"
         }
       ]
+    },
+    {
+      "source": "/_jar/(.*-[a-z0-9]+\\.(?:js|wasm))",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Why

The transform worker assets (the worker bundle, Oxc binding, wasi worker, and the ~3.2MB wasm) were emitted under fixed filenames. Vercel can't fingerprint fixed names, so it served them with `max-age=0, must-revalidate` — the ~4.2MB total re-downloaded/revalidated on every page load.

## What

Content-hash the assets (the same `[contenthash]` approach Next.js uses) so the URLs are self-versioning and can be cached immutably forever.

- **`scripts/build-workers.ts`** — emit with `naming: '[name]-[hash].[ext]'`, content-hash the copied `.wasm` (`sha256`, truncated, same `<name>-<hash>.<ext>` shape), and write `dist/transform-assets.json` mapping the 4 logical names to their hashed filenames.
- **`src/core.ts`** — `createTransformWorker` fetches `transform-assets.json` once (cached, resolved relative to `import.meta.url`) and builds the worker/binding/wasm/wasiWorker URLs from it. No hardcoded names.
- **`src/cli/index.ts`** — `copyRuntimeAssets` copies the manifest plus each hashed asset into the project's `_jar/` output.
- **`vercel.json`** — serve `/_jar/*-<hash>.(js|wasm)` with `Cache-Control: public, max-age=31536000, immutable`.
- **`scripts/check-package.ts`** — assert the manifest and each hashed asset are published (and actually hashed).

The manifest is the single source of truth shared by the build, the runtime, and the CLI, so the hashed names never drift.

## Verification

- `pnpm run build` — emits hashed assets + `transform-assets.json`.
- `bun test` — 21 pass, 0 fail.
- `pnpm run test:package` — package contains the CLI and required runtime assets (14 files).
- `node ./dist/bin.js build examples/dashboard` — copies hashed assets + manifest into `_jar/`.