### PR TITLE
Enforce TypeScript checks before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build Website
         run: pnpm run build:website
 
+      - name: Typecheck
+        run: pnpm typecheck
+
       - name: Test CLI
         run: pnpm test
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
         run: pnpm run build
 
       - name: Test Package
-        run: pnpm test && pnpm test:package
+        run: pnpm typecheck && pnpm test && pnpm test:package
 
       - name: Determine npm tag
         id: npm-tag

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "demo:build": "node ./dist/bin.js build examples/dashboard",
     "demo:start": "node ./dist/bin.js start examples/dashboard/dist",
     "test": "bun test",
-    "test:package": "bun scripts/check-package.ts"
+    "test:package": "bun scripts/check-package.ts",
+    "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
     "react": "^19.0.0"

--- a/src/cli/client.tsx
+++ b/src/cli/client.tsx
@@ -26,12 +26,18 @@ function getRoot(id: string) {
 
 const hostRoot = getRoot('root')
 const errorRoot = getRoot('__jarError')
-let appRoot = document.getElementById('__reactRoot')
-if (!appRoot) {
-  appRoot = document.createElement('div')
-  appRoot.id = '__reactRoot'
-  hostRoot.appendChild(appRoot)
+
+function getAppRoot() {
+  const existingRoot = document.getElementById('__reactRoot')
+  if (existingRoot) return existingRoot
+
+  const root = document.createElement('div')
+  root.id = '__reactRoot'
+  hostRoot.appendChild(root)
+  return root
 }
+
+const appRoot = getAppRoot()
 let reactRoot: Root | undefined
 
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {

--- a/src/transform-worker.ts
+++ b/src/transform-worker.ts
@@ -6,13 +6,16 @@ type OxcTransform = Pick<typeof import('oxc-transform'), 'transformSync'>
 // handler before the WASI module begins its asynchronous initialization.
 const dynamicImport = new Function('specifier', 'return import(specifier)')
 const workerUrl = new URL(globalThis.location.href)
-const bindingUrl = workerUrl.searchParams.get('binding')
-const wasmUrl = workerUrl.searchParams.get('wasm')
-const wasiWorkerUrl = workerUrl.searchParams.get('wasiWorker')
 
-if (!bindingUrl || !wasmUrl || !wasiWorkerUrl) {
-  throw new Error('devjar: transform worker asset URLs are required')
+function requiredAssetUrl(name: string) {
+  const url = workerUrl.searchParams.get(name)
+  if (!url) throw new Error(`devjar: transform worker asset URL is required: ${name}`)
+  return url
 }
+
+const bindingUrl = requiredAssetUrl('binding')
+const wasmUrl = requiredAssetUrl('wasm')
+const wasiWorkerUrl = requiredAssetUrl('wasiWorker')
 
 Object.assign(globalThis, {
   __devjarOxcWasmUrl: wasmUrl,


### PR DESCRIPTION
## Summary
- make the CLI application root and transform asset URLs statically non-null
- add a dedicated pnpm typecheck command
- run typechecking in pull-request CI and before publishing

## Verification
- pnpm typecheck
- pnpm run build
- pnpm test
- pnpm run test:package