### PR TITLE
Use production React transforms in static builds

### DIFF
--- a/src/cdn.ts
+++ b/src/cdn.ts
@@ -22,6 +22,7 @@ export function normalizeCdnHost(cdn: string) {
 export function createEsmShResolver(
   dependencies: Record<string, string>,
   cdn: string,
+  development: boolean,
 ) {
   const host = normalizeCdnHost(cdn)
   return (specifier: string) => {
@@ -32,7 +33,8 @@ export function createEsmShResolver(
       throw new Error(`CDN dependencies cannot use ${name}@${version}`)
     }
     const subpath = specifier.slice(name.length)
-    const dev = name === 'react' || name === 'react-dom' || name === 'react-refresh'
+    const dev = development
+      && (name === 'react' || name === 'react-dom' || name === 'react-refresh')
     const externalizeReact = host === CDN_HOST && name !== 'react'
     const parameters = [
       ...(dev ? ['dev'] : []),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -171,24 +171,34 @@ type HtmlOptions = {
 }
 
 function html(options: HtmlOptions) {
-  const resolveModule = createEsmShResolver(options.dependencies, options.cdn)
+  const resolveModule = createEsmShResolver(
+    options.dependencies,
+    options.cdn,
+    options.liveReload,
+  )
   const resolveRuntimeModule = createEsmShResolver({
     ...options.dependencies,
     ...options.devjarDependencies,
-  }, options.cdn)
+  }, options.cdn, options.liveReload)
   const imports = {
     react: resolveModule('react'),
     'react-dom': resolveModule('react-dom'),
     'react/jsx-runtime': resolveModule('react/jsx-runtime'),
-    'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
     'react-dom/client': resolveModule('react-dom/client'),
     'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
     devjar: '/_jar/runtime.js',
     ...(options.liveReload
-      ? { 'react-refresh/runtime': resolveRuntimeModule('react-refresh/runtime') }
+      ? {
+          'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
+          'react-refresh/runtime': resolveRuntimeModule('react-refresh/runtime'),
+        }
       : {}),
   }
-  const tailwindUrl = getTailwindBrowserUrl(options.dependencies, options.cdn)
+  const tailwindUrl = getTailwindBrowserUrl(
+    options.dependencies,
+    options.cdn,
+    options.liveReload,
+  )
   const tailwindPreload = tailwindUrl
     ? `<link rel="modulepreload" href="${tailwindUrl}">`
     : ''
@@ -339,6 +349,7 @@ export async function startDevServer(options: DevServerOptions) {
             cdn,
             moduleUrl: modules.moduleUrl,
             runtimeModuleUrl: '/_jar/runtime.js',
+            development: true,
             refresh: true,
             platform: 'browser',
           })
@@ -648,6 +659,7 @@ export async function buildProject(options: BuildOptions) {
       cdn,
       moduleUrl: builtModuleUrl,
       runtimeModuleUrl: '/_jar/runtime.js',
+      development: false,
       refresh: false,
       platform: 'browser',
     })

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -27,6 +27,7 @@ export type CompileProjectModuleOptions = {
   cdn: string
   moduleUrl: (projectPath: string) => string
   runtimeModuleUrl: string
+  development: boolean
   refresh: boolean
   platform: 'browser' | 'server'
 }
@@ -61,7 +62,7 @@ async function localImports(projectPath: string, source: string) {
   const output = transformSync(
     projectPath,
     source,
-    getTransformOptions(projectPath, false),
+    getTransformOptions(projectPath, false, false),
   )
   const error = getTransformErrorMessage(output.errors)
   if (error) throw new Error(error)
@@ -173,7 +174,7 @@ export async function compileProjectModule(
   const output = transformSync(
     projectPath,
     source,
-    getTransformOptions(projectPath, options.refresh),
+    getTransformOptions(projectPath, options.development, options.refresh),
   )
   const error = getTransformErrorMessage(output.errors)
   if (error) throw new Error(error)
@@ -182,7 +183,11 @@ export async function compileProjectModule(
   const [imports, exports] = parse(output.code)
   const replacements: Array<{ start: number, end: number, value: string }> = []
   const localDependencies: string[] = []
-  const resolveModule = createEsmShResolver(options.dependencies, options.cdn)
+  const resolveModule = createEsmShResolver(
+    options.dependencies,
+    options.cdn,
+    options.development,
+  )
   for (const imported of imports) {
     if (!imported.n) continue
     let value: string

--- a/src/cli/prerender.ts
+++ b/src/cli/prerender.ts
@@ -68,6 +68,7 @@ export async function prerender(options: PrerenderOptions) {
         cdn: options.cdn,
         moduleUrl: importedPath => `./${serverModuleName(importedPath)}`,
         runtimeModuleUrl: pathToFileURL(options.runtimeModulePath).href,
+        development: false,
         refresh: false,
         platform: 'server',
       })
@@ -75,11 +76,11 @@ export async function prerender(options: PrerenderOptions) {
     }
 
     const outputPath = join(temporaryRoot, 'rendered.json')
-    const resolveModule = createEsmShResolver(options.dependencies, options.cdn)
+    const resolveModule = createEsmShResolver(options.dependencies, options.cdn, false)
     const resolveRuntimeModule = createEsmShResolver({
       ...options.dependencies,
       ...options.devjarDependencies,
-    }, options.cdn)
+    }, options.cdn, false)
     const input: RenderInput = {
       routes: Object.fromEntries([...options.routes].map(([route, entry]) => {
         const projectPath = relative(options.root, entry).split(sep).join('/')
@@ -90,7 +91,6 @@ export async function prerender(options: PrerenderOptions) {
       imports: {
         react: resolveModule('react'),
         'react/jsx-runtime': resolveModule('react/jsx-runtime'),
-        'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
         'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
       },
       outputPath,

--- a/src/core.ts
+++ b/src/core.ts
@@ -566,7 +566,7 @@ function useLiveCode({
   transformWorkerUrl?: string | URL
 }) {
   const resolveModule = useMemo(
-    () => customResolveModule || createEsmShResolver(dependencies || {}, CDN_HOST),
+    () => customResolveModule || createEsmShResolver(dependencies || {}, CDN_HOST, true),
     [customResolveModule, dependencies]
   )
   const iframeRef = useRef<HTMLIFrameElement | null>(null)

--- a/src/tailwind.ts
+++ b/src/tailwind.ts
@@ -3,11 +3,13 @@ import { createEsmShResolver } from './cdn'
 export function getTailwindBrowserUrl(
   dependencies: Record<string, string>,
   cdn: string,
+  development: boolean,
 ) {
   const version = dependencies['@tailwindcss/browser'] || dependencies.tailwindcss
   if (!version) return
   return createEsmShResolver(
     { '@tailwindcss/browser': version },
     cdn,
+    development,
   )('@tailwindcss/browser')
 }

--- a/src/transform-worker.ts
+++ b/src/transform-worker.ts
@@ -55,7 +55,7 @@ self.onmessage = async ({ data }: MessageEvent<{
 
     const transformed: Record<string, string> = {}
     for (const [filename, source] of Object.entries(files)) {
-      const output = oxc.transformSync(filename, source, getTransformOptions(filename, true))
+      const output = oxc.transformSync(filename, source, getTransformOptions(filename, true, true))
 
       const errorMessage = getTransformErrorMessage(output.errors)
       if (errorMessage) throw new Error(errorMessage)

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,10 @@
 import type { OxcError, TransformOptions } from 'oxc-transform'
 
-export function getTransformOptions(filename: string, refresh: boolean): TransformOptions {
+export function getTransformOptions(
+  filename: string,
+  development: boolean,
+  refresh: boolean,
+): TransformOptions {
   return {
     lang: /\.[cm]?tsx?$/.test(filename) ? 'tsx' : 'jsx',
     sourceType: 'module',
@@ -10,7 +14,7 @@ export function getTransformOptions(filename: string, refresh: boolean): Transfo
     },
     jsx: {
       runtime: 'automatic',
-      development: true,
+      development,
       refresh,
     },
     sourcemap: false,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -96,6 +96,7 @@ describe('project loading', () => {
     const resolveModule = createEsmShResolver(
       { react: '19.1.0', '@scope/pkg': '^2.0.0' },
       CDN_HOST,
+      true,
     )
     expect(resolveModule('react/jsx-runtime')).toBe('https://esm.sh/react@19.1.0/jsx-runtime?dev')
     expect(resolveModule('react-dom/client')).toBe('https://esm.sh/react-dom@19.2.0/client?dev&external=react')
@@ -125,6 +126,7 @@ describe('project loading', () => {
       cdn: 'https://modules.example.test/',
       moduleUrl: testModuleUrl,
       runtimeModuleUrl: '/_jar/runtime.js',
+      development: true,
       refresh: false,
       platform: 'browser',
     })
@@ -154,7 +156,9 @@ describe('project loading', () => {
         await readFile(resolve(import.meta.dir, '../package.json'), 'utf8'),
       )
       const lexerVersion = encodeURIComponent(devjarPackage.dependencies['es-module-lexer'])
-      expect(entry).toContain('https://esm.sh/react@19.2.0/jsx-dev-runtime?dev')
+      expect(entry).toContain('https://esm.sh/react@19.2.0/jsx-runtime')
+      expect(entry).not.toContain('jsx-dev-runtime')
+      expect(entry).not.toContain('?dev')
       expect(entry).not.toContain('modules.example.test')
       expect(document).toContain(`https://esm.sh/es-module-lexer@${lexerVersion}`)
       expect(document).not.toContain('es-module-lexer@9.9.9')
@@ -192,10 +196,11 @@ describe('project loading', () => {
     expect(getTailwindBrowserUrl(
       { tailwindcss: '^4.1.0' },
       'https://modules.example.test/',
+      true,
     )).toBe(
       'https://modules.example.test/@tailwindcss/browser@%5E4.1.0',
     )
-    expect(getTailwindBrowserUrl({}, CDN_HOST)).toBeUndefined()
+    expect(getTailwindBrowserUrl({}, CDN_HOST, true)).toBeUndefined()
   })
 
   test('rewrites dynamic local imports as module URLs', async () => {
@@ -215,6 +220,7 @@ describe('project loading', () => {
         cdn: CDN_HOST,
         moduleUrl: testModuleUrl,
         runtimeModuleUrl: '/_jar/runtime.js',
+        development: true,
         refresh: false,
         platform: 'browser',
       })
@@ -422,12 +428,16 @@ describe('production build', () => {
     expect(await readFile(join(buildRoot, '_jar/client.js'), 'utf8')).toContain('_jar/routes.json')
     expect(await readFile(join(buildRoot, '_jar/routes.json'), 'utf8')).toBe(JSON.stringify(manifest))
     const entryModule = await readFile(join(buildRoot, manifest.routes['/'].module), 'utf8')
-    expect(entryModule).toContain('https://modules.example.test/react@19.2.0/jsx-dev-runtime?dev')
+    expect(entryModule).toContain('https://modules.example.test/react@19.2.0/jsx-runtime')
+    expect(entryModule).not.toContain('jsx-dev-runtime')
+    expect(entryModule).not.toContain('?dev')
     expect(entryModule).not.toContain('__jarRegisterModule')
     const builtHtml = await readFile(join(buildRoot, 'index.html'), 'utf8')
     expect(builtHtml).toContain('<title data-devjar-default>Devjar</title>')
     expect(builtHtml).toContain('data-devjar-tailwind')
     expect(builtHtml).not.toContain('react-refresh')
+    expect(builtHtml).not.toContain('jsx-dev-runtime')
+    expect(builtHtml).not.toContain('?dev')
     const transformAssets = JSON.parse(
       await readFile(join(buildRoot, '_jar/transform-assets.json'), 'utf8'),
     )
@@ -463,7 +473,8 @@ describe('production build', () => {
     expect(document.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
 
     const shell = await (await fetch(`${base}/projects`)).text()
-    expect(shell).toContain('https://modules.example.test/react@19.2.0?dev')
+    expect(shell).toContain('https://modules.example.test/react@19.2.0')
+    expect(shell).not.toContain('?dev')
     const routes = await (await fetch(`${base}/_jar/routes.json`)).json()
     expect(routes.routes['/projects'].page).toBe('pages/projects.tsx')
     expect(routes.liveReload).toBe(false)


### PR DESCRIPTION
## Summary
- make transform and CDN resolution modes explicit at every call site
- retain JSX development transforms and React Refresh URLs in development
- emit jsx-runtime imports and production React CDN URLs for builds and prerendering
- omit jsx-dev-runtime from production import maps

## Verification
- pnpm run build
- pnpm test
- pnpm run test:package
- pnpm run build:website

Typechecking is added independently by #82.