### PR TITLE
chore: define the supported Node runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,10 @@ on:
 
 jobs:
   install:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    name: Node 24 / ${{ matrix.os }}
+    name: Node 24
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,30 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node: 22
+          - os: ubuntu-latest
+            node: 24
+          - os: windows-latest
+            node: 24
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
 
-    name: Node
+    name: Node ${{ matrix.node }} / ${{ matrix.os }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
 
-      - name: Use Node 24 and pnpm
+      - name: Use Node ${{ matrix.node }} and pnpm
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node }}
           cache: 'pnpm'
 
       - name: Use Bun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,27 +11,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            node: 22
-          - os: ubuntu-latest
-            node: 24
-          - os: windows-latest
-            node: 24
+        os:
+          - ubuntu-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
 
-    name: Node ${{ matrix.node }} / ${{ matrix.os }}
+    name: Node 24 / ${{ matrix.os }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v6
 
-      - name: Use Node ${{ matrix.node }} and pnpm
+      - name: Use Node 24 and pnpm
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 24
           cache: 'pnpm'
 
       - name: Use Bun

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Repository guidance
 
+## Commits
+
+- Use Conventional Commits for commit messages.
+
 ## TypeScript and API design
 
 - Avoid optional parameters and default arguments when callers can pass values explicitly.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Devjar includes a zero-config CLI for turning a folder of React pages into a
 prototype. All settings are passed as command-line flags; the CLI does not load
 a configuration file or a `devjar` field from `package.json`. It reads only
 `dependencies` and `devDependencies` to resolve package versions from a CDN.
+The CLI requires Node.js 22 or newer.
 
 The project does not need a bundler configuration or a local `node_modules`
 directory:

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "sugar-high": "2.2.1",
     "typescript": "^7.0.2"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "packageManager": "pnpm@11.9.0"
 }

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -9,6 +9,9 @@ const packageJson = await Bun.file(join(root, 'package.json')).json()
 if (packageJson.bin?.jar !== './dist/bin.js') {
   throw new Error('package.json must expose dist/bin.js as the jar binary')
 }
+if (packageJson.engines?.node !== '>=22') {
+  throw new Error('package.json must require Node.js 22 or newer')
+}
 
 const cache = mkdtempSync(join(tmpdir(), 'devjar-npm-cache-'))
 const env = Object.fromEntries(

--- a/src/bin/jar.ts
+++ b/src/bin/jar.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { buildProject, startBuiltServer, startDevServer } from '../cli/index'


### PR DESCRIPTION
## Summary
- declare Node.js 22 or newer as the CLI runtime contract
- test Node 24 on Linux
- let Bunchee emit the CLI shebang so Windows line endings cannot duplicate it
- validate the engines declaration in the package check and document it in the CLI guide
- require Conventional Commit messages in AGENTS.md

## Verification
- pnpm run build
- pnpm test
- pnpm run test:package
- local verification on Node 24.18.0
- CI verifies Node 24 on Linux