### PR TITLE
Test the packed CLI in Chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,35 @@ jobs:
 
       - name: Check Package
         run: pnpm test:package
+
+  browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    name: Packaged browser
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - name: Use Node 24 and pnpm
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Use Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Build Package
+        run: pnpm run build
+
+      - name: Test Packaged Browser
+        run: pnpm test:browser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,4 +69,4 @@ jobs:
         run: pnpm run build
 
       - name: Test Packaged Browser
-        run: pnpm test:browser
+        run: bun scripts/test-package-browser.ts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,8 +40,11 @@ jobs:
       - name: Build Package
         run: pnpm run build
 
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Test Package
-        run: pnpm test && pnpm test:package
+        run: pnpm test && pnpm test:package && pnpm test:browser
 
       - name: Determine npm tag
         id: npm-tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,10 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Test Package
-        run: pnpm test && pnpm test:package && pnpm test:browser
+        run: pnpm test && pnpm test:package
+
+      - name: Test Packaged Browser
+        run: bun scripts/test-package-browser.ts
 
       - name: Determine npm tag
         id: npm-tag

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "demo:build": "node ./dist/bin.js build examples/dashboard",
     "demo:start": "node ./dist/bin.js start examples/dashboard/dist",
     "test": "bun test",
-    "test:browser": "bun scripts/test-package-browser.ts",
     "test:package": "bun scripts/check-package.ts"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "demo:build": "node ./dist/bin.js build examples/dashboard",
     "demo:start": "node ./dist/bin.js start examples/dashboard/dist",
     "test": "bun test",
+    "test:browser": "bun scripts/test-package-browser.ts",
     "test:package": "bun scripts/check-package.ts"
   },
   "peerDependencies": {
@@ -49,6 +50,7 @@
   },
   "devDependencies": {
     "@oxc-transform/binding-wasm32-wasi": "0.144.0",
+    "@playwright/test": "^1.62.1",
     "@sugar-high/react": "2.2.0",
     "@types/node": "^22.10.7",
     "@types/react": "^19.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@oxc-transform/binding-wasm32-wasi':
         specifier: 0.144.0
         version: 0.144.0
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@sugar-high/react':
         specifier: 2.2.0
         version: 2.2.0(react@19.2.7)(sugar-high@2.2.1)
@@ -326,6 +329,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@rollup/plugin-commonjs@29.0.3':
     resolution: {integrity: sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==}
@@ -826,6 +834,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -889,6 +902,16 @@ packages:
   piscina@5.3.0:
     resolution: {integrity: sha512-9D3tPBayfoal6l9l4Y8NrMn1jkV718qJoYrla6P51+hh9h0Q+9/1c8KgEnoBQqhguyfgjay4biADI8HJG3pkoA==}
     engines: {node: '>=20.x'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pretty-bytes@7.1.1:
     resolution: {integrity: sha512-X+vn9z8nOFZQlxOLmfJ0iKDdMD7jYTsTW12OAlCpdoE3Igik6L37pugIZi+N3usuyp5McfgKPWi12q3zvHLeGQ==}
@@ -1185,6 +1208,10 @@ snapshots:
 
   '@oxc-transform/binding-win32-x64-msvc@0.144.0':
     optional: true
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@rollup/plugin-commonjs@29.0.3(rollup@4.62.2)':
     dependencies:
@@ -1536,6 +1563,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -1607,6 +1637,14 @@ snapshots:
   piscina@5.3.0:
     optionalDependencies:
       '@napi-rs/nice': 1.1.1
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pretty-bytes@7.1.1: {}
 

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -1,0 +1,179 @@
+import assert from 'node:assert/strict'
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { chromium, type Browser, type Page } from '@playwright/test'
+
+const runFile = promisify(execFile)
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const temporaryRoot = await mkdtemp(join(tmpdir(), 'devjar-package-browser-'))
+const packageDirectory = join(temporaryRoot, 'package')
+const projectRoot = join(temporaryRoot, 'project')
+let browser: Browser | undefined
+let server: ChildProcess | undefined
+
+function executable(name: string) {
+  return process.platform === 'win32' ? `${name}.cmd` : name
+}
+
+async function run(command: string, args: string[], cwd: string) {
+  return runFile(command, args, {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  })
+}
+
+function serverUrl(child: ChildProcess) {
+  return new Promise<string>((resolvePromise, reject) => {
+    let output = ''
+    let errors = ''
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timed out waiting for the packaged server.${errors ? `\n${errors}` : ''}`))
+    }, 10_000)
+
+    child.stdout?.setEncoding('utf8')
+    child.stderr?.setEncoding('utf8')
+    child.stdout?.on('data', chunk => {
+      output += chunk
+      const match = output.match(/http:\/\/127\.0\.0\.1:\d+\//)
+      if (!match) return
+      clearTimeout(timeout)
+      resolvePromise(match[0])
+    })
+    child.stderr?.on('data', chunk => {
+      errors += chunk
+    })
+    child.once('exit', code => {
+      clearTimeout(timeout)
+      reject(new Error(`Packaged server exited with code ${code}.${errors ? `\n${errors}` : ''}`))
+    })
+  })
+}
+
+async function stopServer(child: ChildProcess) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  await new Promise<void>(resolvePromise => {
+    const timeout = setTimeout(() => {
+      child.kill('SIGKILL')
+      resolvePromise()
+    }, 5_000)
+    child.once('exit', () => {
+      clearTimeout(timeout)
+      resolvePromise()
+    })
+    child.kill('SIGTERM')
+  })
+}
+
+async function assertPage(page: Page, heading: string, title: string) {
+  await page.waitForFunction(
+    expected => document.querySelector('h1')?.textContent === expected.heading
+      && document.title === expected.title,
+    { heading, title },
+  )
+  assert.equal(await page.locator('h1').textContent(), heading)
+  assert.equal(await page.title(), title)
+}
+
+try {
+  await mkdir(packageDirectory, { recursive: true })
+  await mkdir(join(projectRoot, 'pages/docs'), { recursive: true })
+  const packed = await run(
+    'npm',
+    ['pack', '--json', '--pack-destination', packageDirectory],
+    root,
+  )
+  const packResult = JSON.parse(packed.stdout)[0] as { filename: string }
+  const tarball = join(packageDirectory, packResult.filename)
+  assert((await readFile(tarball)).byteLength > 0, 'npm pack did not create a tarball')
+
+  await writeFile(join(projectRoot, 'package.json'), JSON.stringify({
+    private: true,
+    dependencies: {
+      react: '19.2.0',
+      'react-dom': '19.2.0',
+    },
+  }))
+  await writeFile(join(projectRoot, 'pages/index.tsx'), `export default function Page() {
+  return <><title>Package home</title><main><h1>Home</h1><a href="/docs/start">Docs</a></main></>
+}`)
+  await writeFile(join(projectRoot, 'pages/docs/start.tsx'), `export default function Page() {
+  return <><title>Package docs</title><main><h1>Docs</h1><a href="/">Home</a></main></>
+}`)
+  await writeFile(join(projectRoot, 'pages/404.tsx'), `export default function Page() {
+  return <><title>Package missing</title><main><h1>Custom 404</h1><a href="/">Home</a></main></>
+}`)
+
+  await run('npm', ['install', '--ignore-scripts', tarball], projectRoot)
+  const jar = join(projectRoot, 'node_modules', '.bin', executable('jar'))
+  await run(jar, ['build'], projectRoot)
+
+  server = spawn(jar, ['start', 'dist', '--host', '127.0.0.1', '--port', '0'], {
+    cwd: projectRoot,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const baseUrl = await serverUrl(server)
+
+  browser = await chromium.launch({ headless: true })
+  const page = await browser.newPage()
+  const consoleErrors: string[] = []
+  const pageErrors: string[] = []
+  page.on('console', message => {
+    if (message.type() === 'error') consoleErrors.push(message.text())
+  })
+  page.on('pageerror', error => pageErrors.push(error.stack || error.message))
+  await page.addInitScript(`
+    globalThis.__devjarRenderCount = 0
+    addEventListener('devjar:render', () => globalThis.__devjarRenderCount++)
+  `)
+
+  const homeResponse = await page.goto(baseUrl)
+  assert.equal(homeResponse?.status(), 200)
+  await page.waitForFunction('globalThis.__devjarRenderCount > 0')
+  await assertPage(page, 'Home', 'Package home')
+
+  const homeRenderCount = await page.evaluate('globalThis.__devjarRenderCount') as number
+  await page.locator('a[href="/docs/start"]').click()
+  await page.waitForURL(`${baseUrl}docs/start`)
+  await page.waitForFunction(
+    count => (globalThis as typeof globalThis & { __devjarRenderCount: number })
+      .__devjarRenderCount > count,
+    homeRenderCount,
+  )
+  await assertPage(page, 'Docs', 'Package docs')
+
+  const docsRenderCount = await page.evaluate('globalThis.__devjarRenderCount') as number
+  await page.goBack()
+  await page.waitForURL(baseUrl)
+  await page.waitForFunction(
+    count => (globalThis as typeof globalThis & { __devjarRenderCount: number })
+      .__devjarRenderCount > count,
+    docsRenderCount,
+  )
+  await assertPage(page, 'Home', 'Package home')
+
+  const docsResponse = await page.goto(`${baseUrl}docs/start`)
+  assert.equal(docsResponse?.status(), 200)
+  await page.waitForFunction('globalThis.__devjarRenderCount > 0')
+  await assertPage(page, 'Docs', 'Package docs')
+  assert.deepEqual(consoleErrors, [])
+  assert.deepEqual(pageErrors, [])
+
+  consoleErrors.length = 0
+  const missingResponse = await page.goto(`${baseUrl}missing`)
+  assert.equal(missingResponse?.status(), 404)
+  await page.waitForFunction('globalThis.__devjarRenderCount > 0')
+  await assertPage(page, 'Custom 404', 'Package missing')
+  assert(consoleErrors.every(message => message.includes('404 (Not Found)')))
+  assert.deepEqual(pageErrors, [])
+
+  console.log('Packaged CLI builds, hydrates, navigates, and renders its custom 404 in Chromium without unexpected browser errors.')
+} finally {
+  await browser?.close()
+  if (server) await stopServer(server)
+  await rm(temporaryRoot, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary
- pack Devjar and install the tarball into a fresh temporary React project
- build and serve that project using only the installed jar binary
- verify Chromium hydration, client navigation, back navigation, direct nested routes, metadata changes, and the custom 404
- reject unexpected console and page errors
- gate both pull-request CI and npm publishing on the packaged-browser smoke test

## Verification
- pnpm run build
- pnpm test:browser
- pnpm test
- pnpm run test:package