### PR TITLE
feat: support public base paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ jar build --cdn https://modules.example.com
 The CLI applies dependency versions to CDN URLs using the
 `package@version/subpath` convention.
 
+Use `--base <path>` when the site will be hosted below the domain root. The
+same base is embedded in the build, so `jar start` reads it automatically:
+
+```sh
+jar dev --base /preview/
+jar build --base /preview/
+```
+
+Pages, public files, API files, and Devjar runtime assets are then served below
+`/preview/`. Base paths are normalized with one leading and trailing slash.
+
 ### Build and host
 
 Create a static build, then serve it without source-file watching or on-request

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -39,7 +39,7 @@ function serverUrl(child: ChildProcess) {
     child.stderr?.setEncoding('utf8')
     child.stdout?.on('data', chunk => {
       output += chunk
-      const match = output.match(/http:\/\/127\.0\.0\.1:\d+\//)
+      const match = output.match(/http:\/\/127\.0\.0\.1:\d+\/\S*/)
       if (!match) return
       clearTimeout(timeout)
       resolvePromise(match[0])
@@ -110,7 +110,7 @@ try {
 
   await run('npm', ['install', '--ignore-scripts', tarball], projectRoot)
   const jar = join(projectRoot, 'node_modules', '.bin', executable('jar'))
-  await run(jar, ['build'], projectRoot)
+  await run(jar, ['build', '--base', '/preview/'], projectRoot)
 
   server = spawn(jar, ['start', 'dist', '--host', '127.0.0.1', '--port', '0'], {
     cwd: projectRoot,
@@ -171,7 +171,7 @@ try {
   assert(consoleErrors.every(message => message.includes('404 (Not Found)')))
   assert.deepEqual(pageErrors, [])
 
-  console.log('Packaged CLI builds, hydrates, navigates, and renders its custom 404 in Chromium without unexpected browser errors.')
+  console.log('Packaged CLI builds at a subpath, hydrates, navigates, and renders its custom 404 in Chromium without unexpected browser errors.')
 } finally {
   await browser?.close()
   if (server) await stopServer(server)

--- a/src/bin/jar.ts
+++ b/src/bin/jar.ts
@@ -22,6 +22,7 @@ Commands:
 
 Options:
   --cdn <url>      ESM-compatible module CDN (dev and build)
+  --base <path>    Public base path (dev and build; default: /)
   --host <host>    Host to listen on (dev and start; default: localhost)
   --port <port>    Port to listen on (dev and start; default: 3000)
   -o, --out-dir   Build output relative to the project root (default: dist)
@@ -79,6 +80,7 @@ async function run() {
   let host: string | undefined
   let port: number | undefined
   let cdn: string | undefined
+  let base: string | undefined
   let outDir: string | undefined
 
   for (let index = 0; index < args.length; index++) {
@@ -86,6 +88,7 @@ async function run() {
     if (arg === '--host') host = valueAfter(args, index++)
     else if (arg === '--port' || arg === '-p') port = Number(valueAfter(args, index++))
     else if (arg === '--cdn') cdn = valueAfter(args, index++)
+    else if (arg === '--base') base = valueAfter(args, index++)
     else if (arg === '--out-dir' || arg === '-o') outDir = valueAfter(args, index++)
     else if (arg.startsWith('-')) throw new Error(`Unknown option: ${arg}`)
     else if (!root) root = arg
@@ -98,8 +101,8 @@ async function run() {
   if (command === 'build' && (host || port !== undefined)) {
     throw new Error('build does not accept --host or --port')
   }
-  if (command === 'start' && (cdn || outDir)) {
-    throw new Error('start does not accept --cdn or --out-dir; configure these when building')
+  if (command === 'start' && (cdn || base || outDir)) {
+    throw new Error('start does not accept --cdn, --base, or --out-dir; configure these when building')
   }
   if (command === 'dev' && outDir) throw new Error('dev does not accept --out-dir')
 
@@ -109,6 +112,7 @@ async function run() {
       outDir: outDir || 'dist',
       cdn,
       prerender: true,
+      base: base || '/',
     })
     console.log(style(1, 'Devjar build complete'))
     console.log('')
@@ -128,11 +132,12 @@ async function run() {
         host: host || 'localhost',
         port: port ?? 3000,
         cdn,
+        base: base || '/',
       })
   const browserHost = server.host === '0.0.0.0' || server.host === '::'
     ? 'localhost'
     : server.host.includes(':') ? `[${server.host}]` : server.host
-  const url = `http://${browserHost}:${server.port}/`
+  const url = `http://${browserHost}:${server.port}${server.base}`
   console.log(style(1, command === 'start' ? 'Devjar production server ready' : 'Devjar development server ready'))
   console.log('')
   console.log(`Local  ${style(36, url)}`)

--- a/src/cli/client.tsx
+++ b/src/cli/client.tsx
@@ -27,6 +27,14 @@ function getRoot(id: string) {
 const hostRoot = getRoot('root')
 const errorRoot = getRoot('__jarError')
 
+function getBase() {
+  const base = document.querySelector<HTMLMetaElement>('meta[name="devjar-base"]')?.content
+  if (!base) throw new Error('Devjar could not find its base path')
+  return base
+}
+
+const base = getBase()
+
 function getAppRoot() {
   const existingRoot = document.getElementById('__reactRoot')
   if (existingRoot) return existingRoot
@@ -74,13 +82,26 @@ function normalizeRoute(route: string) {
   return cleanRoute ? `/${cleanRoute}` : '/'
 }
 
+function withBase(path: string) {
+  if (path === '/') return base
+  return base === '/' ? path : `${base.slice(0, -1)}${path}`
+}
+
+function routeFromPathname(pathname: string) {
+  if (base === '/') return normalizeRoute(pathname)
+  if (pathname === base.slice(0, -1)) return '/'
+  if (pathname.startsWith(base)) return normalizeRoute(pathname.slice(base.length))
+  return normalizeRoute(pathname)
+}
+
 async function getRouteManifest(revision: number) {
-  const url = new URL('/_jar/routes.json', location.origin)
+  const url = new URL(withBase('/_jar/routes.json'), location.origin)
   if (revision) url.searchParams.set('v', String(revision))
   const response = await fetch(url)
   const data = await response.json()
   if (!response.ok) throw new Error(data.error || 'Unable to load routes')
-  if (data.version !== 2) throw new Error(`Unsupported Devjar route manifest: ${data.version}`)
+  if (data.version !== 3) throw new Error(`Unsupported Devjar route manifest: ${data.version}`)
+  if (data.base !== base) throw new Error(`Unexpected Devjar base path: ${data.base}`)
   return data as RouteManifest
 }
 
@@ -193,9 +214,10 @@ function routeAnchor(target: EventTarget | null) {
   if (!anchor) return
   const url = new URL(anchor.href, location.href)
   if (url.origin !== location.origin) return
-  if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/_jar/')) return
-  if (/\.[^/]+$/.test(url.pathname)) return
-  return { anchor, url }
+  const route = routeFromPathname(url.pathname)
+  if (route.startsWith('/api/') || route.startsWith('/_jar/')) return
+  if (/\.[^/]+$/.test(route)) return
+  return { anchor, route, url }
 }
 
 function shouldNavigate(event: MouseEvent, anchor: HTMLAnchorElement) {
@@ -208,18 +230,19 @@ function shouldNavigate(event: MouseEvent, anchor: HTMLAnchorElement) {
 function navigate(event: MouseEvent) {
   const route = routeAnchor(event.target)
   if (!route || !shouldNavigate(event, route.anchor)) return
-  if (route.url.pathname === location.pathname
+  const pathname = withBase(route.route)
+  if (pathname === location.pathname
     && route.url.search === location.search
     && route.url.hash) return
 
   event.preventDefault()
-  history.pushState(null, '', route.url.pathname + route.url.search + route.url.hash)
-  void load(route.url.pathname).catch(() => {})
+  history.pushState(null, '', pathname + route.url.search + route.url.hash)
+  void load(route.route).catch(() => {})
 }
 
 function preloadNavigation(event: Event) {
   const route = routeAnchor(event.target)
-  if (route) preloadRoute(route.url.pathname)
+  if (route) preloadRoute(route.route)
 }
 
 async function start() {
@@ -241,12 +264,12 @@ async function start() {
   document.addEventListener('pointerover', preloadNavigation)
   document.addEventListener('focusin', preloadNavigation)
   addEventListener('popstate', () => {
-    void load(location.pathname).catch(() => {})
+    void load(routeFromPathname(location.pathname)).catch(() => {})
   })
 
-  await load(location.pathname)
+  await load(routeFromPathname(location.pathname))
   if (hotUpdater) {
-    const events = new EventSource('/_jar/events')
+    const events = new EventSource(withBase('/_jar/events'))
     events.addEventListener('change', event => {
       const change = JSON.parse((event as MessageEvent).data) as HmrChange
       hotUpdater.enqueue(change, showError)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -12,7 +12,14 @@ import {
   moduleAssetName,
 } from './modules'
 import type { HmrChange, RouteEntry, RouteManifest } from './protocol'
-import { normalizeRoute, routeFromPagePath, sourceExtensions } from '../project'
+import {
+  normalizeBase,
+  normalizeRoute,
+  routeFromPagePath,
+  sourceExtensions,
+  withBase,
+  withoutBase,
+} from '../project'
 import { getTailwindBrowserUrl } from '../tailwind'
 import { prerender, type PrerenderedRoute } from './prerender'
 
@@ -26,6 +33,7 @@ export type DevServerOptions = {
   host: string
   port: number
   cdn: string | undefined
+  base: string
 }
 
 export type BuildOptions = {
@@ -33,6 +41,7 @@ export type BuildOptions = {
   outDir: string
   cdn: string | undefined
   prerender: boolean
+  base: string
 }
 
 export type StartServerOptions = {
@@ -44,6 +53,7 @@ export type StartServerOptions = {
 export type LoadRouteManifestOptions = {
   liveReload: boolean
   revision: number
+  base: string
   moduleUrl: (projectPath: string) => string
 }
 
@@ -128,7 +138,8 @@ export async function loadRouteManifest(
     : undefined
 
   return {
-    version: 2,
+    version: 3,
+    base: options.base,
     liveReload: options.liveReload,
     revision: options.revision,
     routes,
@@ -164,6 +175,7 @@ type HtmlOptions = {
   dependencies: Record<string, string>
   devjarDependencies: Record<string, string>
   cdn: string
+  base: string
   liveReload: boolean
   head: string
   content: string
@@ -186,7 +198,7 @@ function html(options: HtmlOptions) {
     'react/jsx-runtime': resolveModule('react/jsx-runtime'),
     'react-dom/client': resolveModule('react-dom/client'),
     'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
-    devjar: '/_jar/runtime.js',
+    devjar: withBase(options.base, '/_jar/runtime.js'),
     ...(options.liveReload
       ? {
           'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
@@ -211,9 +223,9 @@ import * as RefreshModule from 'react-refresh/runtime'
 const RefreshRuntime = RefreshModule.default || RefreshModule
 RefreshRuntime.injectIntoGlobalHook(globalThis)
 globalThis.__jarRefreshRuntime = RefreshRuntime
-await import('/_jar/client.js')
+await import(${JSON.stringify(withBase(options.base, '/_jar/client.js'))})
 </script>`
-    : '<script type="module" src="/_jar/client.js"></script>'
+    : `<script type="module" src="${withBase(options.base, '/_jar/client.js')}"></script>`
   const staticStyles = options.styles
     ? `<style data-devjar-static>${options.styles.replace(/<\/style/gi, '<\\/style')}</style>`
     : ''
@@ -222,7 +234,7 @@ await import('/_jar/client.js')
     : `<title data-devjar-default>Devjar</title>${options.head}`
   return `<!doctype html>
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-${documentHead}${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
+<meta name="devjar-base" content="${options.base}">${documentHead}${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
 <style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>${staticStyles}
 </head><body><div id="root"><div id="__reactRoot">${options.content}</div></div><pre id="__jarError" class="devjar-error" hidden></pre><script>
 const errorRoot = document.getElementById('__jarError')
@@ -283,10 +295,11 @@ export async function startDevServer(options: DevServerOptions) {
   const root = await realpath(resolve(options.root))
   const host = options.host
   const port = options.port
+  const base = normalizeBase(options.base)
   const events = new Set<ServerResponse>()
   const assetsRoot = await runtimeRoot()
   const devjarDependencies = await readDevjarDependencies(assetsRoot)
-  const modules = new DevModuleGraph()
+  const modules = new DevModuleGraph(base)
   let revision = 0
 
   if (!(await fileExists(join(root, 'pages/index.tsx')))
@@ -304,7 +317,12 @@ export async function startDevServer(options: DevServerOptions) {
         response.end('Method not allowed')
         return
       }
-      if (url.pathname === '/_jar/events') {
+      const requestPath = withoutBase(base, url.pathname)
+      if (!requestPath) {
+        send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
+        return
+      }
+      if (requestPath === '/_jar/events') {
         response.writeHead(200, {
           'Content-Type': 'text/event-stream',
           'Cache-Control': 'no-cache',
@@ -319,11 +337,12 @@ export async function startDevServer(options: DevServerOptions) {
         request.on('close', () => events.delete(response))
         return
       }
-      if (url.pathname === '/_jar/routes.json') {
+      if (requestPath === '/_jar/routes.json') {
         try {
           const manifest = await loadRouteManifest(root, {
             liveReload: true,
             revision,
+            base,
             moduleUrl: modules.moduleUrl,
           })
           send(request, response, 200, 'application/json; charset=utf-8', JSON.stringify(manifest))
@@ -332,7 +351,7 @@ export async function startDevServer(options: DevServerOptions) {
         }
         return
       }
-      if (url.pathname === '/_jar/module') {
+      if (requestPath === '/_jar/module') {
         const projectPath = url.searchParams.get('path')
         if (!projectPath) {
           send(request, response, 400, 'text/plain; charset=utf-8', 'Module path is required')
@@ -348,7 +367,7 @@ export async function startDevServer(options: DevServerOptions) {
             dependencies,
             cdn,
             moduleUrl: modules.moduleUrl,
-            runtimeModuleUrl: '/_jar/runtime.js',
+            runtimeModuleUrl: withBase(base, '/_jar/runtime.js'),
             development: true,
             refresh: true,
             platform: 'browser',
@@ -360,22 +379,22 @@ export async function startDevServer(options: DevServerOptions) {
         }
         return
       }
-      if (url.pathname === '/_jar/runtime.js') {
+      if (requestPath === '/_jar/runtime.js') {
         if (!await serveFile(request, response, assetsRoot, 'index.js', undefined, noStore)) send(request, response, 500, 'text/plain', 'Devjar runtime is missing')
         return
       }
-      if (url.pathname.startsWith('/_jar/')) {
-        const cacheControl = url.pathname.startsWith('/_jar/assets/') ? immutableAsset : noStore
-        if (!await serveFile(request, response, assetsRoot, url.pathname.slice('/_jar/'.length), undefined, cacheControl)) send(request, response, 404, 'text/plain', 'Not found')
+      if (requestPath.startsWith('/_jar/')) {
+        const cacheControl = requestPath.startsWith('/_jar/assets/') ? immutableAsset : noStore
+        if (!await serveFile(request, response, assetsRoot, requestPath.slice('/_jar/'.length), undefined, cacheControl)) send(request, response, 404, 'text/plain', 'Not found')
         return
       }
-      if (url.pathname.startsWith('/api/')) {
-        if (!await serveFile(request, response, join(root, 'api'), url.pathname.slice('/api/'.length), new Set(['.json', '.txt']), noStore)) {
+      if (requestPath.startsWith('/api/')) {
+        if (!await serveFile(request, response, join(root, 'api'), requestPath.slice('/api/'.length), new Set(['.json', '.txt']), noStore)) {
           send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
         }
         return
       }
-      if (await serveFile(request, response, join(root, 'public'), url.pathname.slice(1), undefined, noStore)) return
+      if (await serveFile(request, response, join(root, 'public'), requestPath.slice(1), undefined, noStore)) return
       const packageJson = await readPackage(root)
       send(
         request,
@@ -387,6 +406,7 @@ export async function startDevServer(options: DevServerOptions) {
             dependencies: packageDependencies(packageJson),
             devjarDependencies,
             cdn: resolveCdn(options.cdn),
+            base,
             liveReload: true,
             head: '',
             content: '',
@@ -468,6 +488,7 @@ export async function startDevServer(options: DevServerOptions) {
     host,
     port: (server.address() as import('node:net').AddressInfo).port,
     root,
+    base,
     close,
   }
 }
@@ -583,7 +604,7 @@ async function writeRouteHtml(
   outDir: string,
   route: string,
   rendered: PrerenderedRoute,
-  options: Pick<HtmlOptions, 'dependencies' | 'devjarDependencies' | 'cdn'>,
+  options: Pick<HtmlOptions, 'dependencies' | 'devjarDependencies' | 'cdn' | 'base'>,
 ) {
   const outputPath = routeHtmlPath(outDir, route)
   await mkdir(dirname(outputPath), { recursive: true })
@@ -591,6 +612,7 @@ async function writeRouteHtml(
     dependencies: options.dependencies,
     devjarDependencies: options.devjarDependencies,
     cdn: options.cdn,
+    base: options.base,
     liveReload: false,
     head: rendered.head,
     content: rendered.markup,
@@ -602,6 +624,7 @@ async function writeRouteHtml(
 
 export async function buildProject(options: BuildOptions) {
   const root = await realpath(resolve(options.root))
+  const base = normalizeBase(options.base)
   const outDir = resolve(root, options.outDir)
   const outputBoundary = await existingDirectory(outDir)
   if (outDir === root || !isInside(root, outDir) || !isInside(root, outputBoundary)) {
@@ -617,7 +640,8 @@ export async function buildProject(options: BuildOptions) {
   const manifest = await loadRouteManifest(root, {
     liveReload: false,
     revision: 0,
-    moduleUrl: builtModuleUrl,
+    base,
+    moduleUrl: projectPath => builtModuleUrl(projectPath, base),
   })
   const renderedRoutes = options.prerender
     ? await prerender({
@@ -646,6 +670,7 @@ export async function buildProject(options: BuildOptions) {
       dependencies,
       devjarDependencies,
       cdn,
+      base,
     })
   }
   await copyRuntimeAssets(join(outDir, '_jar'))
@@ -657,8 +682,8 @@ export async function buildProject(options: BuildOptions) {
       projectPath,
       dependencies,
       cdn,
-      moduleUrl: builtModuleUrl,
-      runtimeModuleUrl: '/_jar/runtime.js',
+      moduleUrl: projectPath => builtModuleUrl(projectPath, base),
+      runtimeModuleUrl: withBase(base, '/_jar/runtime.js'),
       development: false,
       refresh: false,
       platform: 'browser',
@@ -668,7 +693,7 @@ export async function buildProject(options: BuildOptions) {
   await writeFile(join(outDir, '_jar/routes.json'), JSON.stringify(manifest))
   await copyApiFiles(join(root, 'api'), join(outDir, 'api'))
 
-  return { root, outDir, routes: Object.keys(manifest.routes) }
+  return { root, outDir, routes: Object.keys(manifest.routes), base }
 }
 
 export async function startBuiltServer(options: StartServerOptions) {
@@ -680,7 +705,8 @@ export async function startBuiltServer(options: StartServerOptions) {
   const host = options.host
   const port = options.port
   const manifest = JSON.parse(await readFile(join(root, 'manifest.json'), 'utf8')) as RouteManifest
-  if (manifest.version !== 2) throw new Error(`Unsupported Devjar build version: ${manifest.version}`)
+  if (manifest.version !== 3) throw new Error(`Unsupported Devjar build version: ${manifest.version}`)
+  const base = normalizeBase(manifest.base)
   const fallbackHtml = await readFile(join(root, 'index.html'), 'utf8')
   const routeHtml = new Map<string, string>()
   for (const route of Object.keys(manifest.routes)) {
@@ -697,21 +723,26 @@ export async function startBuiltServer(options: StartServerOptions) {
         response.end(request.method === 'HEAD' ? undefined : 'Method not allowed')
         return
       }
-      if (url.pathname.startsWith('/_jar/')) {
-        const cacheControl = url.pathname.startsWith('/_jar/assets/') ? immutableAsset : noStore
-        if (!await serveFile(request, response, join(root, '_jar'), url.pathname.slice('/_jar/'.length), undefined, cacheControl)) {
+      const requestPath = withoutBase(base, url.pathname)
+      if (!requestPath) {
+        send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
+        return
+      }
+      if (requestPath.startsWith('/_jar/')) {
+        const cacheControl = requestPath.startsWith('/_jar/assets/') ? immutableAsset : noStore
+        if (!await serveFile(request, response, join(root, '_jar'), requestPath.slice('/_jar/'.length), undefined, cacheControl)) {
           send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
         }
         return
       }
-      if (url.pathname.startsWith('/api/')) {
-        if (!await serveFile(request, response, join(root, 'api'), url.pathname.slice('/api/'.length), new Set(['.json', '.txt']), noStore)) {
+      if (requestPath.startsWith('/api/')) {
+        if (!await serveFile(request, response, join(root, 'api'), requestPath.slice('/api/'.length), new Set(['.json', '.txt']), noStore)) {
           send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
         }
         return
       }
-      if (await serveFile(request, response, root, url.pathname.slice(1), undefined, noStore)) return
-      const route = normalizeRoute(url.pathname)
+      if (await serveFile(request, response, root, requestPath.slice(1), undefined, noStore)) return
+      const route = normalizeRoute(requestPath)
       const routeDocument = routeHtml.get(route)
       if (routeDocument) {
         send(request, response, 200, 'text/html; charset=utf-8', routeDocument)
@@ -754,6 +785,7 @@ export async function startBuiltServer(options: StartServerOptions) {
     host,
     port: (server.address() as import('node:net').AddressInfo).port,
     root,
+    base,
     close,
   }
 }

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -3,7 +3,7 @@ import { extname, relative, resolve, sep } from 'node:path'
 import { init, parse } from 'es-module-lexer'
 import { transformSync } from 'oxc-transform'
 import { createEsmShResolver } from '../cdn'
-import { sourceExtensions } from '../project'
+import { sourceExtensions, withBase } from '../project'
 import { getTransformErrorMessage, getTransformOptions } from '../transform'
 import type { HmrUpdate } from './protocol'
 
@@ -108,18 +108,18 @@ export async function collectProjectFiles(root: string, entry: string) {
   return projectPaths
 }
 
-export function devModuleUrl(projectPath: string, version: number) {
+export function devModuleUrl(projectPath: string, version: number, base: string) {
   const parameters = new URLSearchParams({ path: projectPath })
   if (version) parameters.set('v', String(version))
-  return `/_jar/module?${parameters}`
+  return `${withBase(base, '/_jar/module')}?${parameters}`
 }
 
 export function moduleAssetName(projectPath: string) {
   return `${Buffer.from(projectPath).toString('base64url')}.js`
 }
 
-export function builtModuleUrl(projectPath: string) {
-  return `/_jar/modules/${moduleAssetName(projectPath)}`
+export function builtModuleUrl(projectPath: string, base: string) {
+  return withBase(base, `/_jar/modules/${moduleAssetName(projectPath)}`)
 }
 
 function browserCssModule(source: string, projectPath: string) {
@@ -246,8 +246,10 @@ export class DevModuleGraph {
   private readonly importers = new Map<string, Set<string>>()
   private readonly versions = new Map<string, number>()
 
+  constructor(private readonly base: string) {}
+
   readonly moduleUrl = (projectPath: string) => (
-    devModuleUrl(projectPath, this.versions.get(projectPath) || 0)
+    devModuleUrl(projectPath, this.versions.get(projectPath) || 0, this.base)
   )
 
   update(projectPath: string, compiled: CompiledProjectModule) {

--- a/src/cli/protocol.ts
+++ b/src/cli/protocol.ts
@@ -4,7 +4,8 @@ export type RouteEntry = {
 }
 
 export type RouteManifest = {
-  version: 2
+  version: 3
+  base: string
   liveReload: boolean
   revision: number
   routes: Record<string, RouteEntry>

--- a/src/project.ts
+++ b/src/project.ts
@@ -5,6 +5,29 @@ export function normalizeRoute(route: string) {
   return cleanRoute ? `/${cleanRoute}` : '/'
 }
 
+export function normalizeBase(base: string) {
+  if (/[?#]/.test(base) || base.includes('://') || /[<>"']/.test(base)) {
+    throw new Error(`Invalid base path: ${base}`)
+  }
+  const segments = base.replace(/\\/g, '/').split('/').filter(Boolean)
+  if (segments.some(segment => segment === '.' || segment === '..')) {
+    throw new Error(`Invalid base path: ${base}`)
+  }
+  return segments.length ? `/${segments.join('/')}/` : '/'
+}
+
+export function withBase(base: string, path: string) {
+  if (path === '/') return base
+  return base === '/' ? path : `${base.slice(0, -1)}${path}`
+}
+
+export function withoutBase(base: string, pathname: string) {
+  if (base === '/') return pathname
+  if (pathname === base.slice(0, -1)) return '/'
+  if (!pathname.startsWith(base)) return
+  return `/${pathname.slice(base.length)}`
+}
+
 export function routeFromPagePath(pagePath: string) {
   const extension = sourceExtensions.find(extension => pagePath.endsWith(extension))
   if (!extension) return

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -15,6 +15,7 @@ import { createIframeRouteManifest, linkModules } from '../src/core'
 import { collectProjectFiles, compileProjectModule } from '../src/cli/modules'
 import { getTailwindBrowserUrl } from '../src/tailwind'
 import { testCdnModule } from '../scripts/test-cdn'
+import { normalizeBase, withBase, withoutBase } from '../src/project'
 
 const root = resolve(import.meta.dir, '../examples/basic')
 const dashboardRoot = resolve(import.meta.dir, '../examples/dashboard')
@@ -28,6 +29,7 @@ function loadTestRouteManifest(projectRoot: string) {
   return loadRouteManifest(projectRoot, {
     liveReload: true,
     revision: 7,
+    base: '/',
     moduleUrl: testModuleUrl,
   })
 }
@@ -105,7 +107,8 @@ describe('project loading', () => {
 
   test('loads a route manifest with module entries', async () => {
     const manifest = await loadTestRouteManifest(root)
-    expect(manifest.version).toBe(2)
+    expect(manifest.version).toBe(3)
+    expect(manifest.base).toBe('/')
     expect(manifest.revision).toBe(7)
     expect(manifest.routes['/']).toEqual({
       module: '/modules/pages/index.tsx',
@@ -148,6 +151,7 @@ describe('project loading', () => {
         outDir: 'dist',
         cdn: undefined,
         prerender: false,
+        base: '/',
       })
       const manifest = JSON.parse(await readFile(join(result.outDir, 'manifest.json'), 'utf8'))
       const entry = await readFile(join(result.outDir, manifest.routes['/'].module), 'utf8')
@@ -171,6 +175,16 @@ describe('project loading', () => {
     const manifest = await loadTestRouteManifest(dashboardRoot)
     expect(manifest.routes['/projects'].page).toBe('pages/projects.tsx')
     expect(manifest.notFound?.page).toBe('pages/404.tsx')
+  })
+
+  test('normalizes and applies public base paths', () => {
+    expect(normalizeBase('docs/preview')).toBe('/docs/preview/')
+    expect(normalizeBase('/')).toBe('/')
+    expect(withBase('/docs/', '/_jar/client.js')).toBe('/docs/_jar/client.js')
+    expect(withoutBase('/docs/', '/docs/about')).toBe('/about')
+    expect(withoutBase('/docs/', '/docs')).toBe('/')
+    expect(withoutBase('/docs/', '/outside')).toBeUndefined()
+    expect(() => normalizeBase('../docs')).toThrow('Invalid base path')
   })
 
   test('loads the website and its editable source files', async () => {
@@ -269,6 +283,7 @@ describe('dev server', () => {
       host: '127.0.0.1',
       port: 0,
       cdn: undefined,
+      base: '/',
     })
     const base = `http://${server.host}:${server.port}`
 
@@ -355,6 +370,7 @@ export default function Page() { return <Card /> }`,
       host: '127.0.0.1',
       port: 0,
       cdn: undefined,
+      base: '/',
     })
     const base = `http://${hmrServer.host}:${hmrServer.port}`
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined
@@ -410,6 +426,7 @@ describe('production build', () => {
       outDir: 'dist',
       cdn: 'https://modules.example.test/',
       prerender: false,
+      base: '/preview/',
     })
     buildRoot = result.outDir
   })
@@ -422,18 +439,24 @@ describe('production build', () => {
   test('writes routes, runtime assets, public files, and static APIs', async () => {
     const manifest = JSON.parse(await readFile(join(buildRoot, 'manifest.json'), 'utf8'))
     expect(Object.keys(manifest.routes).sort()).toEqual(['/', '/404', '/projects', '/settings'])
-    expect(manifest.version).toBe(2)
+    expect(manifest.version).toBe(3)
+    expect(manifest.base).toBe('/preview/')
     expect(manifest.liveReload).toBe(false)
-    expect(manifest.routes['/'].module).toMatch(/^\/_jar\/modules\/.+\.js$/)
+    expect(manifest.routes['/'].module).toMatch(/^\/preview\/_jar\/modules\/.+\.js$/)
     expect(await readFile(join(buildRoot, '_jar/client.js'), 'utf8')).toContain('_jar/routes.json')
     expect(await readFile(join(buildRoot, '_jar/routes.json'), 'utf8')).toBe(JSON.stringify(manifest))
-    const entryModule = await readFile(join(buildRoot, manifest.routes['/'].module), 'utf8')
+    const entryModule = await readFile(
+      join(buildRoot, withoutBase(manifest.base, manifest.routes['/'].module)!),
+      'utf8',
+    )
     expect(entryModule).toContain('https://modules.example.test/react@19.2.0/jsx-runtime')
     expect(entryModule).not.toContain('jsx-dev-runtime')
     expect(entryModule).not.toContain('?dev')
     expect(entryModule).not.toContain('__jarRegisterModule')
     const builtHtml = await readFile(join(buildRoot, 'index.html'), 'utf8')
     expect(builtHtml).toContain('<title data-devjar-default>Devjar</title>')
+    expect(builtHtml).toContain('<meta name="devjar-base" content="/preview/">')
+    expect(builtHtml).toContain('src="/preview/_jar/client.js"')
     expect(builtHtml).toContain('data-devjar-tailwind')
     expect(builtHtml).not.toContain('react-refresh')
     expect(builtHtml).not.toContain('jsx-dev-runtime')
@@ -460,6 +483,7 @@ describe('production build', () => {
       outDir: '../outside',
       cdn: undefined,
       prerender: false,
+      base: '/',
     })).rejects.toThrow(
       'The build output must be a directory inside the project root',
     )
@@ -467,29 +491,31 @@ describe('production build', () => {
 
   test('serves prebuilt projects without development events', async () => {
     server = await startBuiltServer({ root: buildRoot, host: '127.0.0.1', port: 0 })
-    const base = `http://${server.host}:${server.port}`
-    const document = await fetch(base)
+    const origin = `http://${server.host}:${server.port}`
+    expect(server.base).toBe('/preview/')
+    expect((await fetch(origin)).status).toBe(404)
+    const document = await fetch(`${origin}/preview/`)
     expect(document.headers.get('cross-origin-opener-policy')).toBe('same-origin')
     expect(document.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
 
-    const shell = await (await fetch(`${base}/projects`)).text()
+    const shell = await (await fetch(`${origin}/preview/projects`)).text()
     expect(shell).toContain('https://modules.example.test/react@19.2.0')
     expect(shell).not.toContain('?dev')
-    const routes = await (await fetch(`${base}/_jar/routes.json`)).json()
+    const routes = await (await fetch(`${origin}/preview/_jar/routes.json`)).json()
     expect(routes.routes['/projects'].page).toBe('pages/projects.tsx')
     expect(routes.liveReload).toBe(false)
     expect(routes.notFound.page).toBe('pages/404.tsx')
-    const projectModule = await fetch(`${base}${routes.routes['/projects'].module}`)
+    const projectModule = await fetch(`${origin}${routes.routes['/projects'].module}`)
     expect(projectModule.status).toBe(200)
     expect(projectModule.headers.get('content-type')).toContain('text/javascript')
-    const transformAssetsResponse = await fetch(`${base}/_jar/transform-assets.json`)
+    const transformAssetsResponse = await fetch(`${origin}/preview/_jar/transform-assets.json`)
     expect(transformAssetsResponse.headers.get('cache-control')).toBe('no-store')
     const transformAssets = await transformAssetsResponse.json()
-    const worker = await fetch(`${base}/_jar/${transformAssets.wasiWorker}`)
+    const worker = await fetch(`${origin}/preview/_jar/${transformAssets.wasiWorker}`)
     expect(worker.headers.get('cache-control')).toBe('public, max-age=31536000, immutable')
-    expect((await fetch(`${base}/_jar/events`)).status).toBe(404)
-    expect(await (await fetch(`${base}/api/projects.json`)).json()).toHaveLength(4)
-    expect(await (await fetch(`${base}/mark.svg`)).text()).toContain('<svg')
+    expect((await fetch(`${origin}/preview/_jar/events`)).status).toBe(404)
+    expect(await (await fetch(`${origin}/preview/api/projects.json`)).json()).toHaveLength(4)
+    expect(await (await fetch(`${origin}/preview/mark.svg`)).text()).toContain('<svg')
 
     await server.close()
   })
@@ -540,6 +566,7 @@ export default function Page() {
         outDir: 'dist',
         cdn: `http://127.0.0.1:${address.port}`,
         prerender: true,
+        base: '/',
       })
       const document = await readFile(join(result.outDir, 'index.html'), 'utf8')
       expect(document).toContain('<head><meta charset="utf-8"')


### PR DESCRIPTION
## Summary
- add a zero-config `--base` CLI flag for dev and build
- prefix generated routes, runtime modules, APIs, and public assets with the normalized base
- persist the base in production manifests so `jar start` applies it automatically
- run the packaged Chromium smoke test under `/preview/`

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm test:package`
- `bun scripts/test-package-browser.ts`