### PR TITLE
feat: support static asset imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,22 @@ The pages directory maps directly to URLs:
 | `pages/docs/start.tsx` | `/docs/start` |
 | `pages/404.tsx` | unmatched routes |
 
-Pages can import local JavaScript, TypeScript, JSX, TSX, and CSS files. Bare
-imports are loaded from esm.sh using versions in `dependencies` or
-`devDependencies`:
+Pages can import local JavaScript, TypeScript, JSX, TSX, and CSS files. Image,
+font, audio, video, and PDF imports export their public URL, and relative
+`url(...)` references in CSS use the same asset pipeline:
+
+```jsx
+import logo from '../assets/logo.svg'
+import '../styles.css'
+
+export default function Page() {
+  return <img src={logo} alt="Logo" />
+}
+```
+
+Production builds copy imported assets to `_jar/assets/` with content-hashed
+filenames so they can be cached as immutable files. Bare imports are loaded
+from esm.sh using versions in `dependencies` or `devDependencies`:
 
 ```json
 {

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -82,6 +82,7 @@ async function assertPage(page: Page, heading: string, title: string) {
 try {
   await mkdir(packageDirectory, { recursive: true })
   await mkdir(join(projectRoot, 'pages/docs'), { recursive: true })
+  await mkdir(join(projectRoot, 'assets'), { recursive: true })
   const packed = await run(
     'npm',
     ['pack', '--json', '--pack-destination', packageDirectory],
@@ -98,8 +99,10 @@ try {
       'react-dom': '19.2.0',
     },
   }))
-  await writeFile(join(projectRoot, 'pages/index.tsx'), `export default function Page() {
-  return <><title>Package home</title><main><h1>Home</h1><a href="/docs/start">Docs</a></main></>
+  await writeFile(join(projectRoot, 'assets/logo.svg'), '<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8"><circle cx="4" cy="4" r="4" /></svg>')
+  await writeFile(join(projectRoot, 'pages/index.tsx'), `import logo from '../assets/logo.svg'
+export default function Page() {
+  return <><title>Package home</title><main><h1>Home</h1><img src={logo} alt="Logo" /><a href="/docs/start">Docs</a></main></>
 }`)
   await writeFile(join(projectRoot, 'pages/docs/start.tsx'), `export default function Page() {
   return <><title>Package docs</title><main><h1>Docs</h1><a href="/">Home</a></main></>
@@ -135,6 +138,12 @@ try {
   assert.equal(homeResponse?.status(), 200)
   await page.waitForFunction('globalThis.__devjarRenderCount > 0')
   await assertPage(page, 'Home', 'Package home')
+  const logoPath = await page.locator('img[alt="Logo"]').getAttribute('src')
+  assert.match(logoPath || '', /^\/preview\/_jar\/assets\/logo-[a-f0-9]{10}\.svg$/)
+  const logoResponse = await page.request.get(new URL(logoPath!, baseUrl).href)
+  assert.equal(logoResponse.status(), 200)
+  assert.match(logoResponse.headers()['content-type'], /image\/svg\+xml/)
+  assert.equal(logoResponse.headers()['cache-control'], 'public, max-age=31536000, immutable')
 
   const homeRenderCount = await page.evaluate('globalThis.__devjarRenderCount') as number
   await page.locator('a[href="/docs/start"]').click()

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,11 +5,16 @@ import { dirname, extname, join, normalize, relative, resolve, sep } from 'node:
 import { fileURLToPath } from 'node:url'
 import { CDN_HOST, createEsmShResolver, normalizeCdnHost } from '../cdn'
 import {
+  builtAssetUrl,
   builtModuleUrl,
   collectProjectFiles,
   compileProjectModule,
+  devAssetUrl,
   DevModuleGraph,
+  isStaticAsset,
   moduleAssetName,
+  staticAssetExtensions,
+  staticAssetName,
 } from './modules'
 import type { HmrChange, RouteEntry, RouteManifest } from './protocol'
 import {
@@ -248,6 +253,7 @@ addEventListener('unhandledrejection', event => showBootstrapError(event.reason?
 }
 
 const contentTypes: Record<string, string> = {
+  '.avif': 'image/avif',
   '.css': 'text/css; charset=utf-8',
   '.gif': 'image/gif',
   '.html': 'text/html; charset=utf-8',
@@ -256,10 +262,18 @@ const contentTypes: Record<string, string> = {
   '.jpg': 'image/jpeg',
   '.js': 'text/javascript; charset=utf-8',
   '.json': 'application/json; charset=utf-8',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
+  '.ogg': 'audio/ogg',
+  '.otf': 'font/otf',
+  '.pdf': 'application/pdf',
   '.png': 'image/png',
   '.svg': 'image/svg+xml',
   '.txt': 'text/plain; charset=utf-8',
+  '.ttf': 'font/ttf',
   '.wasm': 'application/wasm',
+  '.wav': 'audio/wav',
+  '.webm': 'video/webm',
   '.webp': 'image/webp',
   '.woff': 'font/woff',
   '.woff2': 'font/woff2',
@@ -274,14 +288,15 @@ async function serveFile(
   cacheControl: string,
 ) {
   const path = resolve(root, `.${normalize('/' + requestPath)}`)
-  if (!isInside(root, path) || (allowed && !allowed.has(extname(path)))) return false
+  const extension = extname(path).toLowerCase()
+  if (!isInside(root, path) || (allowed && !allowed.has(extension))) return false
   if (!(await fileExists(path))) return false
   const canonicalRoot = await realpath(root)
   const canonicalPath = await realpath(path)
   if (!isInside(canonicalRoot, canonicalPath)) return false
   const info = await stat(canonicalPath)
   response.writeHead(200, {
-    'Content-Type': contentTypes[extname(path)] || 'application/octet-stream',
+    'Content-Type': contentTypes[extension] || 'application/octet-stream',
     'Content-Length': info.size,
     'Cache-Control': cacheControl,
     ...isolationHeaders,
@@ -367,6 +382,7 @@ export async function startDevServer(options: DevServerOptions) {
             dependencies,
             cdn,
             moduleUrl: modules.moduleUrl,
+            assetUrl: (projectPath, contents) => devAssetUrl(projectPath, contents, base),
             runtimeModuleUrl: withBase(base, '/_jar/runtime.js'),
             development: true,
             refresh: true,
@@ -377,6 +393,18 @@ export async function startDevServer(options: DevServerOptions) {
         } catch (error) {
           send(request, response, 404, 'text/javascript; charset=utf-8', `throw new Error(${JSON.stringify(error instanceof Error ? error.message : String(error))})`)
         }
+        return
+      }
+      if (requestPath === '/_jar/asset') {
+        const projectPath = url.searchParams.get('path')
+        if (!projectPath || !await serveFile(
+          request,
+          response,
+          root,
+          projectPath,
+          new Set(staticAssetExtensions),
+          noStore,
+        )) send(request, response, 404, 'text/plain', 'Not found')
         return
       }
       if (requestPath === '/_jar/runtime.js') {
@@ -650,6 +678,7 @@ export async function buildProject(options: BuildOptions) {
         dependencies,
         devjarDependencies,
         cdn,
+        base,
         runtimeModulePath: join(runtime, 'index.js'),
       })
     : Object.fromEntries([...discovered.routes.keys()].map(route => (
@@ -675,14 +704,21 @@ export async function buildProject(options: BuildOptions) {
   }
   await copyRuntimeAssets(join(outDir, '_jar'))
   const modulesRoot = join(outDir, '_jar/modules')
+  const projectAssetsRoot = join(outDir, '_jar/assets')
   await mkdir(modulesRoot, { recursive: true })
+  await mkdir(projectAssetsRoot, { recursive: true })
   for (const projectPath of projectPaths) {
+    if (isStaticAsset(projectPath)) {
+      const contents = await readFile(join(root, projectPath))
+      await writeFile(join(projectAssetsRoot, staticAssetName(projectPath, contents)), contents)
+    }
     const compiled = await compileProjectModule({
       root,
       projectPath,
       dependencies,
       cdn,
       moduleUrl: projectPath => builtModuleUrl(projectPath, base),
+      assetUrl: (projectPath, contents) => builtAssetUrl(projectPath, contents, base),
       runtimeModuleUrl: withBase(base, '/_jar/runtime.js'),
       development: false,
       refresh: false,

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -1,5 +1,6 @@
+import { createHash } from 'node:crypto'
 import { readFile, realpath, stat } from 'node:fs/promises'
-import { extname, relative, resolve, sep } from 'node:path'
+import { basename, extname, relative, resolve, sep } from 'node:path'
 import { init, parse } from 'es-module-lexer'
 import { transformSync } from 'oxc-transform'
 import { createEsmShResolver } from '../cdn'
@@ -7,7 +8,27 @@ import { sourceExtensions, withBase } from '../project'
 import { getTransformErrorMessage, getTransformOptions } from '../transform'
 import type { HmrUpdate } from './protocol'
 
-export const localExtensions = [...sourceExtensions, '.css']
+export const staticAssetExtensions = [
+  '.avif',
+  '.gif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.mp3',
+  '.mp4',
+  '.ogg',
+  '.otf',
+  '.pdf',
+  '.png',
+  '.svg',
+  '.ttf',
+  '.wav',
+  '.webm',
+  '.webp',
+  '.woff',
+  '.woff2',
+] as const
+export const localExtensions = [...sourceExtensions, '.css', ...staticAssetExtensions]
 
 type ModuleGraphEntry = {
   dependencies: Set<string>
@@ -18,6 +39,7 @@ export type CompiledProjectModule = {
   code: string
   dependencies: string[]
   refreshBoundary: boolean
+  style: string | undefined
 }
 
 export type CompileProjectModuleOptions = {
@@ -26,10 +48,36 @@ export type CompileProjectModuleOptions = {
   dependencies: Record<string, string>
   cdn: string
   moduleUrl: (projectPath: string) => string
+  assetUrl: (projectPath: string, contents: Buffer) => string
   runtimeModuleUrl: string
   development: boolean
   refresh: boolean
   platform: 'browser' | 'server'
+}
+
+export function isStaticAsset(projectPath: string) {
+  return (staticAssetExtensions as readonly string[]).includes(extname(projectPath).toLowerCase())
+}
+
+export function staticAssetName(projectPath: string, contents: Buffer) {
+  const extension = extname(projectPath).toLowerCase()
+  const name = basename(projectPath, extname(projectPath))
+    .replace(/[^a-zA-Z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'asset'
+  const hash = createHash('sha256').update(contents).digest('hex').slice(0, 10)
+  return `${name}-${hash}${extension}`
+}
+
+export function devAssetUrl(projectPath: string, contents: Buffer, base: string) {
+  const parameters = new URLSearchParams({
+    path: projectPath,
+    v: createHash('sha256').update(contents).digest('hex').slice(0, 10),
+  })
+  return `${withBase(base, '/_jar/asset')}?${parameters}`
+}
+
+export function builtAssetUrl(projectPath: string, contents: Buffer, base: string) {
+  return withBase(base, `/_jar/assets/${staticAssetName(projectPath, contents)}`)
 }
 
 async function fileExists(path: string) {
@@ -47,7 +95,7 @@ function isInside(root: string, path: string) {
 }
 
 async function findSourceFile(path: string) {
-  if (await fileExists(path) && localExtensions.includes(extname(path))) return path
+  if (await fileExists(path) && localExtensions.includes(extname(path).toLowerCase())) return path
   if (extname(path)) return
   for (const extension of localExtensions) {
     if (await fileExists(path + extension)) return path + extension
@@ -78,6 +126,56 @@ async function localImports(projectPath: string, source: string) {
   return imports
 }
 
+function cssAssetSpecifiers(source: string) {
+  const specifiers = new Set<string>()
+  for (const match of source.matchAll(/url\(\s*(?:(["'])(.*?)\1|([^)'"\s][^)]*))\s*\)/g)) {
+    const specifier = (match[2] || match[3] || '').trim()
+    const path = specifier.split(/[?#]/, 1)[0]
+    if (path && !path.startsWith('/') && !path.startsWith('#')
+      && !/^(?:data|https?):/i.test(path)) specifiers.add(specifier)
+  }
+  return specifiers
+}
+
+async function resolveCssAssets(
+  root: string,
+  sourcePath: string,
+  source: string,
+) {
+  const assets = new Map<string, { path: string, projectPath: string, contents: Buffer }>()
+  for (const specifier of cssAssetSpecifiers(source)) {
+    const path = specifier.split(/[?#]/, 1)[0]
+    const assetPath = await resolveProjectSource(root, relative(root, resolve(sourcePath, '..', path)))
+    if (!isStaticAsset(assetPath)) {
+      throw new Error(`CSS URL must reference a static asset: ${specifier}`)
+    }
+    assets.set(specifier, {
+      path: assetPath,
+      projectPath: relative(root, assetPath).split(sep).join('/'),
+      contents: await readFile(assetPath),
+    })
+  }
+  return assets
+}
+
+function rewriteCssAssets(
+  source: string,
+  assets: Map<string, { path: string, projectPath: string, contents: Buffer }>,
+  assetUrl: CompileProjectModuleOptions['assetUrl'],
+) {
+  return source.replace(
+    /url\(\s*(?:(["'])(.*?)\1|([^)'"\s][^)]*))\s*\)/g,
+    (match, _quote: string | undefined, quoted: string | undefined, unquoted: string | undefined) => {
+      const specifier = (quoted || unquoted || '').trim()
+      const asset = assets.get(specifier)
+      if (!asset) return match
+      const path = specifier.split(/[?#]/, 1)[0]
+      const suffix = specifier.slice(path.length)
+      return match.replace(specifier, `${assetUrl(asset.projectPath, asset.contents)}${suffix}`)
+    },
+  )
+}
+
 export async function collectProjectFiles(root: string, entry: string) {
   const projectPaths = new Set<string>()
   const queue = [entry]
@@ -94,9 +192,15 @@ export async function collectProjectFiles(root: string, entry: string) {
 
     const projectPath = relative(root, canonicalPath).split(sep).join('/')
     projectPaths.add(projectPath)
-    if (extname(canonicalPath) === '.css') continue
+    if (isStaticAsset(canonicalPath)) continue
 
     const source = await readFile(canonicalPath, 'utf8')
+    if (extname(canonicalPath) === '.css') {
+      for (const asset of (await resolveCssAssets(root, canonicalPath, source)).values()) {
+        queue.push(asset.path)
+      }
+      continue
+    }
     for (const specifier of await localImports(projectPath, source)) {
       const imported = await findSourceFile(resolve(canonicalPath, '..', specifier))
       if (!imported) {
@@ -160,14 +264,27 @@ export async function compileProjectModule(
 ): Promise<CompiledProjectModule> {
   const sourcePath = await resolveProjectSource(options.root, options.projectPath)
   const projectPath = relative(options.root, sourcePath).split(sep).join('/')
-  const source = await readFile(sourcePath, 'utf8')
+  const contents = await readFile(sourcePath)
+  if (isStaticAsset(sourcePath)) {
+    return {
+      code: `export default ${JSON.stringify(options.assetUrl(projectPath, contents))}\n`,
+      dependencies: [],
+      refreshBoundary: false,
+      style: undefined,
+    }
+  }
+
+  let source = contents.toString('utf8')
   if (extname(sourcePath) === '.css') {
+    const assets = await resolveCssAssets(options.root, sourcePath, source)
+    source = rewriteCssAssets(source, assets, options.assetUrl)
     return {
       code: options.platform === 'browser'
         ? browserCssModule(source, projectPath)
         : serverCssModule(source),
-      dependencies: [],
+      dependencies: [...assets.values()].map(asset => asset.projectPath),
       refreshBoundary: false,
+      style: source,
     }
   }
 
@@ -238,6 +355,7 @@ globalThis.__jarRegisterModule(${JSON.stringify(projectPath)}, import.meta.url, 
     code,
     dependencies: [...new Set(localDependencies)],
     refreshBoundary,
+    style: undefined,
   }
 }
 
@@ -280,12 +398,20 @@ export class DevModuleGraph {
     let reload = false
 
     for (const projectPath of changedFiles) {
-      if (!localExtensions.includes(extname(projectPath))
-        || !this.modules.has(projectPath)) continue
+      if (!localExtensions.includes(extname(projectPath).toLowerCase())
+        || (!this.modules.has(projectPath) && !this.importers.has(projectPath))) continue
       invalidated.add(projectPath)
-      if (extname(projectPath) === '.css') {
+      if (extname(projectPath).toLowerCase() === '.css') {
         cssUpdates.add(projectPath)
         continue
+      }
+      if (isStaticAsset(projectPath)) {
+        for (const importer of this.importers.get(projectPath) || []) {
+          if (extname(importer).toLowerCase() === '.css') {
+            invalidated.add(importer)
+            cssUpdates.add(importer)
+          }
+        }
       }
       const result = this.findRefreshBoundaries(projectPath)
       reload ||= result.reload

--- a/src/cli/prerender.ts
+++ b/src/cli/prerender.ts
@@ -5,7 +5,12 @@ import { extname, join, relative, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
 import { createEsmShResolver } from '../cdn'
-import { collectProjectFiles, compileProjectModule, moduleAssetName } from './modules'
+import {
+  builtAssetUrl,
+  collectProjectFiles,
+  compileProjectModule,
+  moduleAssetName,
+} from './modules'
 
 type PrerenderOptions = {
   root: string
@@ -13,6 +18,7 @@ type PrerenderOptions = {
   dependencies: Record<string, string>
   devjarDependencies: Record<string, string>
   cdn: string
+  base: string
   runtimeModulePath: string
 }
 
@@ -54,6 +60,7 @@ export async function prerender(options: PrerenderOptions) {
   try {
     const projectFiles = new Set<string>()
     const routeFiles = new Map<string, Set<string>>()
+    const projectStyles = new Map<string, string>()
     for (const [route, entry] of options.routes) {
       const files = await collectProjectFiles(options.root, entry)
       routeFiles.set(route, files)
@@ -67,12 +74,18 @@ export async function prerender(options: PrerenderOptions) {
         dependencies: options.dependencies,
         cdn: options.cdn,
         moduleUrl: importedPath => `./${serverModuleName(importedPath)}`,
+        assetUrl: (projectPath, contents) => builtAssetUrl(
+          projectPath,
+          contents,
+          options.base,
+        ),
         runtimeModuleUrl: pathToFileURL(options.runtimeModulePath).href,
         development: false,
         refresh: false,
         platform: 'server',
       })
       await writeFile(join(temporaryRoot, serverModuleName(projectPath)), compiled.code)
+      if (compiled.style !== undefined) projectStyles.set(projectPath, compiled.style)
     }
 
     const outputPath = join(temporaryRoot, 'rendered.json')
@@ -113,7 +126,7 @@ export async function prerender(options: PrerenderOptions) {
       const styles: string[] = []
       for (const projectPath of files) {
         if (extname(projectPath) === '.css') {
-          styles.push(await readFile(join(options.root, projectPath), 'utf8'))
+          styles.push(projectStyles.get(projectPath)!)
         }
       }
       result[route] = { ...rendered[route], styles: styles.join('\n') }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -128,6 +128,7 @@ describe('project loading', () => {
       dependencies: { react: '19.2.0' },
       cdn: 'https://modules.example.test/',
       moduleUrl: testModuleUrl,
+      assetUrl: () => '/assets/test',
       runtimeModuleUrl: '/_jar/runtime.js',
       development: true,
       refresh: false,
@@ -233,6 +234,7 @@ describe('project loading', () => {
         dependencies: {},
         cdn: CDN_HOST,
         moduleUrl: testModuleUrl,
+        assetUrl: () => '/assets/test',
         runtimeModuleUrl: '/_jar/runtime.js',
         development: true,
         refresh: false,
@@ -357,10 +359,14 @@ describe('dev server', () => {
     const projectRoot = await mkdtemp(join(tmpdir(), 'devjar-hmr-'))
     await mkdir(join(projectRoot, 'pages'))
     await mkdir(join(projectRoot, 'components'))
+    await writeFile(join(projectRoot, 'components/icon.svg'), '<svg><title>Icon</title></svg>')
+    await writeFile(join(projectRoot, 'styles.css'), `.hero { background: url('./components/icon.svg'); }`)
     await writeFile(
       join(projectRoot, 'pages/index.tsx'),
       `import { Card } from '../components/card'
-export default function Page() { return <Card /> }`,
+import icon from '../components/icon.svg'
+import '../styles.css'
+export default function Page() { return <><img className="hero" src={icon} /><Card /></> }`,
     )
     const cardPath = join(projectRoot, 'components/card.tsx')
     await writeFile(cardPath, `export function Card() { return <p>one</p> }`)
@@ -379,9 +385,22 @@ export default function Page() { return <Card /> }`,
       const routes = await (await fetch(`${base}/_jar/routes.json`)).json()
       const pageModule = await (await fetch(`${base}${routes.routes['/'].module}`)).text()
       const cardModuleUrl = pageModule.match(/\/_jar\/module\?path=components%2Fcard\.tsx/)?.[0]
+      const assetModuleUrl = pageModule.match(/\/_jar\/module\?path=components%2Ficon\.svg/)?.[0]
+      const cssModuleUrl = pageModule.match(/\/_jar\/module\?path=styles\.css/)?.[0]
       expect(cardModuleUrl).toBeDefined()
+      expect(assetModuleUrl).toBeDefined()
+      expect(cssModuleUrl).toBeDefined()
       const cardModule = await (await fetch(`${base}${cardModuleUrl}`)).text()
       expect(cardModule).toContain('__jarRegisterModule')
+      const assetModule = await (await fetch(`${base}${assetModuleUrl}`)).text()
+      const assetUrl = assetModule.match(/"(\/_jar\/asset\?path=components%2Ficon\.svg&v=[a-f0-9]{10})"/)?.[1]
+      expect(assetUrl).toBeDefined()
+      const asset = await fetch(`${base}${assetUrl}`)
+      expect(asset.headers.get('content-type')).toContain('image/svg+xml')
+      expect(asset.headers.get('cache-control')).toBe('no-store')
+      expect(await asset.text()).toContain('<title>Icon</title>')
+      const cssModule = await (await fetch(`${base}${cssModuleUrl}`)).text()
+      expect(cssModule).toContain('/_jar/asset?path=components%2Ficon.svg')
 
       const eventResponse = await fetch(`${base}/_jar/events`)
       reader = eventResponse.body!.getReader()
@@ -404,6 +423,33 @@ export default function Page() { return <Card /> }`,
           type: 'refresh',
           url: '/_jar/module?path=components%2Fcard.tsx&v=1',
         }],
+      })
+
+      await writeFile(join(projectRoot, 'components/icon.svg'), '<svg><title>Updated</title></svg>')
+      const assetChange = await Promise.race([
+        readChangeEvent(reader),
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('Timed out waiting for asset HMR update')), 2_000)
+        }),
+      ])
+      const { timestamp: assetTimestamp, ...assetChangeWithoutTimestamp } = assetChange
+      expect(assetTimestamp).toBeNumber()
+      expect(assetChangeWithoutTimestamp).toEqual({
+        revision: routes.revision + 2,
+        reload: false,
+        routes: false,
+        updates: [
+          {
+            path: 'styles.css',
+            type: 'css',
+            url: '/_jar/module?path=styles.css&v=1',
+          },
+          {
+            path: 'pages/index.tsx',
+            type: 'refresh',
+            url: '/_jar/module?path=pages%2Findex.tsx&v=1',
+          },
+        ],
       })
     } finally {
       await reader?.cancel()
@@ -536,18 +582,20 @@ describe('static export', () => {
     try {
       await mkdir(join(projectRoot, 'pages'))
       await mkdir(join(projectRoot, 'pages/guides'))
+      await mkdir(join(projectRoot, 'assets'))
       await writeFile(join(projectRoot, 'package.json'), JSON.stringify({
         dependencies: { react: '19.2.0', 'react-dom': '19.2.0' },
       }))
       await writeFile(
         join(projectRoot, 'pages/index.tsx'),
         `import '../styles.css'
+import logo from '../assets/logo.svg'
 import { DevJar } from 'devjar'
 export default function Page() {
   return <>
     <title>Static title</title>
     <meta name="description" content="Static description" />
-    <main className="page"><h1>Static now</h1><DevJar files={{ 'pages/index.jsx': 'export default function Page() {}' }} /></main>
+    <main className="page"><h1>Static now</h1><img src={logo} alt="Logo" /><DevJar files={{ 'pages/index.jsx': 'export default function Page() {}' }} /></main>
   </>
 }`,
       )
@@ -559,7 +607,14 @@ export default function Page() {
         join(projectRoot, 'pages/404.tsx'),
         `export default function NotFound() { return <h1>Static not found</h1> }`,
       )
-      await writeFile(join(projectRoot, 'styles.css'), '.page { color: black; }')
+      await writeFile(
+        join(projectRoot, 'styles.css'),
+        `.page { color: black; background-image: url('./assets/background.png'); }
+@font-face { font-family: Body; src: url("./assets/body.woff2?#iefix") format("woff2"); }`,
+      )
+      await writeFile(join(projectRoot, 'assets/logo.svg'), '<svg><circle r="4" /></svg>')
+      await writeFile(join(projectRoot, 'assets/background.png'), Buffer.from('background'))
+      await writeFile(join(projectRoot, 'assets/body.woff2'), Buffer.from('font'))
 
       const result = await buildProject({
         root: projectRoot,
@@ -573,8 +628,10 @@ export default function Page() {
       expect(document).toContain('<title>Static title</title><meta name="description" content="Static description">')
       expect(document).not.toContain('<div id="__reactRoot"><title>')
       expect(document).toContain('<main class="page"><h1>Static now</h1>')
+      expect(document).toMatch(/<img src="\/_jar\/assets\/logo-[a-f0-9]{10}\.svg" alt="Logo"/)
       expect(document).toContain('<iframe')
-      expect(document).toContain('<style data-devjar-static>.page { color: black; }</style>')
+      expect(document).toMatch(/background-image: url\('\/_jar\/assets\/background-[a-f0-9]{10}\.png'\)/)
+      expect(document).toMatch(/src: url\("\/_jar\/assets\/body-[a-f0-9]{10}\.woff2\?#iefix"\)/)
       expect(document).toContain('<div id="__reactRoot">')
       const aboutDocument = await readFile(join(result.outDir, 'guides/about/index.html'), 'utf8')
       expect(aboutDocument).toContain('<title>About title</title>')
@@ -590,6 +647,10 @@ export default function Page() {
       const pageModule = await readFile(join(result.outDir, manifest.routes['/'].module), 'utf8')
       expect(pageModule).toContain('/_jar/runtime.js')
       expect(pageModule).not.toContain(`${address.port}/devjar`)
+      const assetFiles = await readdir(join(result.outDir, '_jar/assets'))
+      expect(assetFiles.some(file => /^logo-[a-f0-9]{10}\.svg$/.test(file))).toBe(true)
+      expect(assetFiles.some(file => /^background-[a-f0-9]{10}\.png$/.test(file))).toBe(true)
+      expect(assetFiles.some(file => /^body-[a-f0-9]{10}\.woff2$/.test(file))).toBe(true)
     } finally {
       await new Promise<void>(resolvePromise => cdn.close(() => resolvePromise()))
       await rm(projectRoot, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- turn imported images, fonts, audio, video, and PDFs into public URL modules
- resolve relative `url(...)` assets in CSS and prerendered styles
- emit content-hashed assets under `_jar/assets/` with immutable production caching
- refresh JavaScript and CSS importers when an asset changes in development

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm test:package`
- `bun scripts/test-package-browser.ts`