### PR TITLE
feat: omit unused Devjar runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ the project does not need a local `node_modules` directory.
 Files from `public/` are copied to the root of the output directory. For example,
 `public/logo.svg` becomes `dist/logo.svg` and remains available at `/logo.svg`.
 Imports from `devjar` use the runtime and worker assets included in the build
-instead of loading another copy of Devjar from the package CDN.
+instead of loading another copy of Devjar from the package CDN. Builds without
+a `devjar` import omit the Devjar runtime, transformer workers, and WASM.
 
 Pages can render React 19 document metadata directly. Devjar preserves these
 elements in each route's `<head>` during static export:
@@ -286,9 +287,10 @@ The iframe transforms code in the browser using Oxc and shared WebAssembly
 memory, so its host page must be cross-origin isolated. Devjar packages the
 browser transformer, WASM binary, and helper worker as lazy runtime assets;
 compatible bundlers emit these files without requiring a manual copy step.
-The `jar dev` and `jar start` servers send the required headers
-automatically. Static deployments must configure equivalent headers on their
-hosting platform.
+The `jar dev` server sends the required headers so an editor can be added while
+it is running. `jar start` sends them only for builds that use the editor.
+Static deployments that use `devjar` must configure equivalent headers on
+their hosting platform; sites without the editor do not need them.
 
 <details>
 <summary>Next.js headers example</summary>

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict'
 import { execFile, spawn, type ChildProcess } from 'node:child_process'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -114,6 +114,10 @@ export default function Page() {
   await run('npm', ['install', '--ignore-scripts', tarball], projectRoot)
   const jar = join(projectRoot, 'node_modules', '.bin', executable('jar'))
   await run(jar, ['build', '--base', '/preview/'], projectRoot)
+  const builtRuntimeFiles = await readdir(join(projectRoot, 'dist/_jar'))
+  assert(builtRuntimeFiles.includes('client.js'))
+  assert(!builtRuntimeFiles.includes('runtime.js'))
+  assert(!builtRuntimeFiles.includes('transform-assets.json'))
 
   server = spawn(jar, ['start', 'dist', '--host', '127.0.0.1', '--port', '0'], {
     cwd: projectRoot,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,6 +15,7 @@ import {
   moduleAssetName,
   staticAssetExtensions,
   staticAssetName,
+  usesDevjarRuntime,
 } from './modules'
 import type { HmrChange, RouteEntry, RouteManifest } from './protocol'
 import {
@@ -161,17 +162,18 @@ const isolationHeaders = {
 const noStore = 'no-store'
 const immutableAsset = 'public, max-age=31536000, immutable'
 
-function send(
+function sendResponse(
   request: IncomingMessage,
   response: ServerResponse,
   status: number,
   type: string,
   body: string | Buffer,
+  headers: Record<string, string>,
 ) {
   response.writeHead(status, {
     'Content-Type': type,
     'Cache-Control': noStore,
-    ...isolationHeaders,
+    ...headers,
   })
   response.end(request.method === 'HEAD' ? undefined : body)
 }
@@ -181,6 +183,7 @@ type HtmlOptions = {
   devjarDependencies: Record<string, string>
   cdn: string
   base: string
+  devjarRuntime: boolean
   liveReload: boolean
   head: string
   content: string
@@ -202,8 +205,12 @@ function html(options: HtmlOptions) {
     'react-dom': resolveModule('react-dom'),
     'react/jsx-runtime': resolveModule('react/jsx-runtime'),
     'react-dom/client': resolveModule('react-dom/client'),
-    'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
-    devjar: withBase(options.base, '/_jar/runtime.js'),
+    ...(options.devjarRuntime
+      ? {
+          'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
+          devjar: withBase(options.base, '/_jar/runtime.js'),
+        }
+      : {}),
     ...(options.liveReload
       ? {
           'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
@@ -279,13 +286,14 @@ const contentTypes: Record<string, string> = {
   '.woff2': 'font/woff2',
 }
 
-async function serveFile(
+async function serveResponseFile(
   request: IncomingMessage,
   response: ServerResponse,
   root: string,
   requestPath: string,
   allowed: Set<string> | undefined,
   cacheControl: string,
+  headers: Record<string, string>,
 ) {
   const path = resolve(root, `.${normalize('/' + requestPath)}`)
   const extension = extname(path).toLowerCase()
@@ -299,11 +307,43 @@ async function serveFile(
     'Content-Type': contentTypes[extension] || 'application/octet-stream',
     'Content-Length': info.size,
     'Cache-Control': cacheControl,
-    ...isolationHeaders,
+    ...headers,
   })
   if (request.method === 'HEAD') response.end()
   else createReadStream(canonicalPath).pipe(response)
   return true
+}
+
+function createResponder(headers: Record<string, string>) {
+  return {
+    send(
+      request: IncomingMessage,
+      response: ServerResponse,
+      status: number,
+      type: string,
+      body: string | Buffer,
+    ) {
+      sendResponse(request, response, status, type, body, headers)
+    },
+    serveFile(
+      request: IncomingMessage,
+      response: ServerResponse,
+      root: string,
+      requestPath: string,
+      allowed: Set<string> | undefined,
+      cacheControl: string,
+    ) {
+      return serveResponseFile(
+        request,
+        response,
+        root,
+        requestPath,
+        allowed,
+        cacheControl,
+        headers,
+      )
+    },
+  }
 }
 
 export async function startDevServer(options: DevServerOptions) {
@@ -315,6 +355,7 @@ export async function startDevServer(options: DevServerOptions) {
   const assetsRoot = await runtimeRoot()
   const devjarDependencies = await readDevjarDependencies(assetsRoot)
   const modules = new DevModuleGraph(base)
+  const { send, serveFile } = createResponder(isolationHeaders)
   let revision = 0
 
   if (!(await fileExists(join(root, 'pages/index.tsx')))
@@ -435,6 +476,7 @@ export async function startDevServer(options: DevServerOptions) {
             devjarDependencies,
             cdn: resolveCdn(options.cdn),
             base,
+            devjarRuntime: true,
             liveReload: true,
             head: '',
             content: '',
@@ -598,10 +640,14 @@ async function readTransformAssetManifest(source: string): Promise<TransformAsse
   return Object.fromEntries(names.map(name => [name, value[name]])) as TransformAssetManifest
 }
 
-async function copyRuntimeAssets(destination: string) {
+async function copyRuntimeAssets(destination: string, devjarRuntime: boolean) {
   const source = await runtimeRoot()
-  const transformAssets = await readTransformAssetManifest(source)
   await mkdir(destination, { recursive: true })
+  if (!devjarRuntime) {
+    await cp(join(source, 'client.js'), join(destination, 'client.js'))
+    return
+  }
+  const transformAssets = await readTransformAssetManifest(source)
   const assets: Array<[string, string]> = [
     ['index.js', 'runtime.js'],
     ['client.js', 'client.js'],
@@ -632,7 +678,10 @@ async function writeRouteHtml(
   outDir: string,
   route: string,
   rendered: PrerenderedRoute,
-  options: Pick<HtmlOptions, 'dependencies' | 'devjarDependencies' | 'cdn' | 'base'>,
+  options: Pick<
+    HtmlOptions,
+    'dependencies' | 'devjarDependencies' | 'cdn' | 'base' | 'devjarRuntime'
+  >,
 ) {
   const outputPath = routeHtmlPath(outDir, route)
   await mkdir(dirname(outputPath), { recursive: true })
@@ -641,6 +690,7 @@ async function writeRouteHtml(
     devjarDependencies: options.devjarDependencies,
     cdn: options.cdn,
     base: options.base,
+    devjarRuntime: options.devjarRuntime,
     liveReload: false,
     head: rendered.head,
     content: rendered.markup,
@@ -662,9 +712,17 @@ export async function buildProject(options: BuildOptions) {
   const packageJson = await readPackage(root)
   const dependencies = packageDependencies(packageJson)
   const runtime = await runtimeRoot()
-  const devjarDependencies = await readDevjarDependencies(runtime)
   const cdn = resolveCdn(options.cdn)
   const discovered = await discoverRoutes(root)
+  const projectPaths = new Set<string>()
+  for (const page of discovered.routes.values()) {
+    const files = await collectProjectFiles(root, page)
+    for (const projectPath of files) projectPaths.add(projectPath)
+  }
+  const devjarRuntime = await usesDevjarRuntime(root, projectPaths)
+  const devjarDependencies = devjarRuntime
+    ? await readDevjarDependencies(runtime)
+    : {}
   const manifest = await loadRouteManifest(root, {
     liveReload: false,
     revision: 0,
@@ -684,12 +742,6 @@ export async function buildProject(options: BuildOptions) {
     : Object.fromEntries([...discovered.routes.keys()].map(route => (
         [route, { head: '', markup: '', styles: '' }]
       )))
-  const projectPaths = new Set<string>()
-  for (const page of discovered.routes.values()) {
-    const files = await collectProjectFiles(root, page)
-    for (const projectPath of files) projectPaths.add(projectPath)
-  }
-
   await rm(outDir, { recursive: true, force: true })
   await mkdir(outDir, { recursive: true })
   await copyPublicFiles(join(root, 'public'), outDir)
@@ -700,9 +752,10 @@ export async function buildProject(options: BuildOptions) {
       devjarDependencies,
       cdn,
       base,
+      devjarRuntime,
     })
   }
-  await copyRuntimeAssets(join(outDir, '_jar'))
+  await copyRuntimeAssets(join(outDir, '_jar'), devjarRuntime)
   const modulesRoot = join(outDir, '_jar/modules')
   const projectAssetsRoot = join(outDir, '_jar/assets')
   await mkdir(modulesRoot, { recursive: true })
@@ -729,7 +782,7 @@ export async function buildProject(options: BuildOptions) {
   await writeFile(join(outDir, '_jar/routes.json'), JSON.stringify(manifest))
   await copyApiFiles(join(root, 'api'), join(outDir, 'api'))
 
-  return { root, outDir, routes: Object.keys(manifest.routes), base }
+  return { root, outDir, routes: Object.keys(manifest.routes), base, devjarRuntime }
 }
 
 export async function startBuiltServer(options: StartServerOptions) {
@@ -743,6 +796,8 @@ export async function startBuiltServer(options: StartServerOptions) {
   const manifest = JSON.parse(await readFile(join(root, 'manifest.json'), 'utf8')) as RouteManifest
   if (manifest.version !== 3) throw new Error(`Unsupported Devjar build version: ${manifest.version}`)
   const base = normalizeBase(manifest.base)
+  const devjarRuntime = await fileExists(join(root, '_jar/runtime.js'))
+  const { send, serveFile } = createResponder(devjarRuntime ? isolationHeaders : {})
   const fallbackHtml = await readFile(join(root, 'index.html'), 'utf8')
   const routeHtml = new Map<string, string>()
   for (const route of Object.keys(manifest.routes)) {
@@ -822,6 +877,7 @@ export async function startBuiltServer(options: StartServerOptions) {
     port: (server.address() as import('node:net').AddressInfo).port,
     root,
     base,
+    devjarRuntime,
     close,
   }
 }

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -176,6 +176,25 @@ function rewriteCssAssets(
   )
 }
 
+export async function usesDevjarRuntime(root: string, projectPaths: Set<string>) {
+  for (const projectPath of projectPaths) {
+    if (!sourceExtensions.includes(extname(projectPath))) continue
+    const source = await readFile(resolve(root, projectPath), 'utf8')
+    const output = transformSync(
+      projectPath,
+      source,
+      getTransformOptions(projectPath, false, false),
+    )
+    const error = getTransformErrorMessage(output.errors)
+    if (error) return true
+
+    await init
+    const [imports] = parse(output.code)
+    if (imports.some(imported => imported.n === 'devjar')) return true
+  }
+  return false
+}
+
 export async function collectProjectFiles(root: string, entry: string) {
   const projectPaths = new Set<string>()
   const queue = [entry]

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -141,6 +141,8 @@ describe('project loading', () => {
     const projectRoot = await mkdtemp(join(tmpdir(), 'devjar-zero-config-'))
     try {
       await cp(root, projectRoot, { recursive: true })
+      const indexPath = join(projectRoot, 'pages/index.tsx')
+      await writeFile(indexPath, `import 'devjar'\n${await readFile(indexPath, 'utf8')}`)
       const packageJsonPath = join(projectRoot, 'package.json')
       const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
       packageJson.devjar = { cdn: 'https://modules.example.test/' }
@@ -482,7 +484,7 @@ describe('production build', () => {
     if (projectRoot) await rm(projectRoot, { recursive: true, force: true })
   })
 
-  test('writes routes, runtime assets, public files, and static APIs', async () => {
+  test('omits the unused Devjar runtime while writing the static site', async () => {
     const manifest = JSON.parse(await readFile(join(buildRoot, 'manifest.json'), 'utf8'))
     expect(Object.keys(manifest.routes).sort()).toEqual(['/', '/404', '/projects', '/settings'])
     expect(manifest.version).toBe(3)
@@ -507,18 +509,13 @@ describe('production build', () => {
     expect(builtHtml).not.toContain('react-refresh')
     expect(builtHtml).not.toContain('jsx-dev-runtime')
     expect(builtHtml).not.toContain('?dev')
-    const transformAssets = JSON.parse(
-      await readFile(join(buildRoot, '_jar/transform-assets.json'), 'utf8'),
-    )
-    expect(Object.values(transformAssets)).toHaveLength(4)
-    for (const asset of Object.values(transformAssets) as string[]) {
-      expect(asset).toMatch(/^assets\/[a-z0-9.-]+-[a-z0-9]+\.(?:js|wasm)$/)
-      expect((await readFile(join(buildRoot, '_jar', asset))).byteLength).toBeGreaterThan(0)
-    }
+    expect(builtHtml).not.toContain('/_jar/runtime.js')
+    expect(builtHtml).not.toContain('es-module-lexer')
     const runtimeFiles = await readdir(join(buildRoot, '_jar'))
-    expect(runtimeFiles.some(file => /^.+-[a-z0-9]+\.js$/.test(file))).toBe(true)
-    expect(runtimeFiles).not.toContain('transform-worker.js')
-    expect(runtimeFiles).not.toContain('wasi-worker-browser.js')
+    expect(runtimeFiles).toContain('client.js')
+    expect(runtimeFiles).not.toContain('runtime.js')
+    expect(runtimeFiles).not.toContain('transform-assets.json')
+    expect(await readdir(join(buildRoot, '_jar/assets'))).toEqual([])
     expect(await readFile(join(buildRoot, 'api/projects.json'), 'utf8')).toContain('Mobile refresh')
     expect(await readFile(join(buildRoot, 'mark.svg'), 'utf8')).toContain('<svg')
   })
@@ -539,10 +536,11 @@ describe('production build', () => {
     server = await startBuiltServer({ root: buildRoot, host: '127.0.0.1', port: 0 })
     const origin = `http://${server.host}:${server.port}`
     expect(server.base).toBe('/preview/')
+    expect(server.devjarRuntime).toBe(false)
     expect((await fetch(origin)).status).toBe(404)
     const document = await fetch(`${origin}/preview/`)
-    expect(document.headers.get('cross-origin-opener-policy')).toBe('same-origin')
-    expect(document.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
+    expect(document.headers.get('cross-origin-opener-policy')).toBeNull()
+    expect(document.headers.get('cross-origin-embedder-policy')).toBeNull()
 
     const shell = await (await fetch(`${origin}/preview/projects`)).text()
     expect(shell).toContain('https://modules.example.test/react@19.2.0')
@@ -555,10 +553,7 @@ describe('production build', () => {
     expect(projectModule.status).toBe(200)
     expect(projectModule.headers.get('content-type')).toContain('text/javascript')
     const transformAssetsResponse = await fetch(`${origin}/preview/_jar/transform-assets.json`)
-    expect(transformAssetsResponse.headers.get('cache-control')).toBe('no-store')
-    const transformAssets = await transformAssetsResponse.json()
-    const worker = await fetch(`${origin}/preview/_jar/${transformAssets.wasiWorker}`)
-    expect(worker.headers.get('cache-control')).toBe('public, max-age=31536000, immutable')
+    expect(transformAssetsResponse.status).toBe(404)
     expect((await fetch(`${origin}/preview/_jar/events`)).status).toBe(404)
     expect(await (await fetch(`${origin}/preview/api/projects.json`)).json()).toHaveLength(4)
     expect(await (await fetch(`${origin}/preview/mark.svg`)).text()).toContain('<svg')
@@ -623,6 +618,7 @@ export default function Page() {
         prerender: true,
         base: '/',
       })
+      expect(result.devjarRuntime).toBe(true)
       const document = await readFile(join(result.outDir, 'index.html'), 'utf8')
       expect(document).toContain('<head><meta charset="utf-8"')
       expect(document).toContain('<title>Static title</title><meta name="description" content="Static description">')
@@ -651,6 +647,23 @@ export default function Page() {
       expect(assetFiles.some(file => /^logo-[a-f0-9]{10}\.svg$/.test(file))).toBe(true)
       expect(assetFiles.some(file => /^background-[a-f0-9]{10}\.png$/.test(file))).toBe(true)
       expect(assetFiles.some(file => /^body-[a-f0-9]{10}\.woff2$/.test(file))).toBe(true)
+      const transformAssets = JSON.parse(
+        await readFile(join(result.outDir, '_jar/transform-assets.json'), 'utf8'),
+      )
+      expect(Object.values(transformAssets)).toHaveLength(4)
+      const builtServer = await startBuiltServer({
+        root: result.outDir,
+        host: '127.0.0.1',
+        port: 0,
+      })
+      try {
+        expect(builtServer.devjarRuntime).toBe(true)
+        const response = await fetch(`http://${builtServer.host}:${builtServer.port}`)
+        expect(response.headers.get('cross-origin-opener-policy')).toBe('same-origin')
+        expect(response.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
+      } finally {
+        await builtServer.close()
+      }
     } finally {
       await new Promise<void>(resolvePromise => cdn.close(() => resolvePromise()))
       await rm(projectRoot, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- detect reachable `devjar` imports during production builds
- omit the editor runtime, transform workers, WASM, and related import-map entries when unused
- keep cross-origin isolation enabled in development, but only enable it in `jar start` for editor builds
- verify both a minimal packaged site and the editor-powered Devjar website

## Validation
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm test:package`
- `bun scripts/test-package-browser.ts`
- `pnpm build:website`