### PR TITLE
feat: vendor production dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,10 @@ export default function Page() {
 ```
 
 Production builds copy imported assets to `_jar/assets/` with content-hashed
-filenames so they can be cached as immutable files. Bare imports are loaded
-from esm.sh using versions in `dependencies` or `devDependencies`:
+filenames so they can be cached as immutable files. Production builds also
+vendor bare imports and their transitive assets under `_jar/vendor/`; deployed
+sites do not depend on the module CDN. Dependency versions come from
+`dependencies` or `devDependencies`:
 
 ```json
 {
@@ -198,8 +200,9 @@ are available at their corresponding `/api/` URLs. Executable API routes are
 not supported.
 
 For CLI projects, add `tailwindcss` or `@tailwindcss/browser` to the dependency
-list to enable Tailwind. Bare imports use esm.sh by default. Select a different
-ESM-compatible CDN with the `--cdn` flag:
+list to enable Tailwind. Bare imports use esm.sh in development and as the
+source for vendored production modules. Select a different ESM-compatible CDN
+with the `--cdn` flag:
 
 ```sh
 jar dev --cdn https://modules.example.com
@@ -207,7 +210,10 @@ jar build --cdn https://modules.example.com
 ```
 
 The CLI applies dependency versions to CDN URLs using the
-`package@version/subpath` convention.
+`package@version/subpath` convention. During `jar build`, the selected CDN must
+be available while dependencies are collected, but it is not contacted by the
+deployed site. Modules and their referenced assets are stored below a
+content-hashed directory and can be cached as immutable files.
 
 Use `--base <path>` when the site will be hosted below the domain root. The
 same base is embedded in the build, so `jar start` reads it automatically:
@@ -233,8 +239,9 @@ jar start dist
 The build writes the initial React content and imported CSS into an HTML file for
 each route, then hydrates that content in the browser. Opening or hosting the
 HTML therefore shows page content before client JavaScript runs. Package imports
-are loaded from the selected CDN during static rendering and in the browser, so
-the project does not need a local `node_modules` directory.
+are loaded from the selected CDN during the build and emitted as local files, so
+the project does not need a local `node_modules` directory and the deployed site
+does not need the CDN.
 
 Files from `public/` are copied to the root of the output directory. For example,
 `public/logo.svg` becomes `dist/logo.svg` and remains available at `/logo.svg`.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ transforms:
 
 ```sh
 jar build
-jar start dist
+jar start
 ```
 
 The build writes the initial React content and imported CSS into an HTML file for
@@ -242,6 +242,11 @@ HTML therefore shows page content before client JavaScript runs. Package imports
 are loaded from the selected CDN during the build and emitted as local files, so
 the project does not need a local `node_modules` directory and the deployed site
 does not need the CDN.
+
+`jar start [root]` treats `root` as the project directory and serves its `dist`
+build by default. Pass the same `--out-dir <directory>` used for the build when
+using a custom output directory. A build directory passed directly remains
+supported for compatibility.
 
 Files from `public/` are copied to the root of the output directory. For example,
 `public/logo.svg` becomes `dist/logo.svg` and remains available at `/logo.svg`.

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -1,6 +1,6 @@
-import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { testCdnModule } from './test-cdn'
 
@@ -87,14 +87,15 @@ const [buildOutput, buildError, buildExitCode] = await Promise.all([
 ])
 cdn.stop(true)
 const usedDefaultOutput = existsSync(join(cliProject, 'dist', 'manifest.json'))
+const displayedOutput = relative(root, realpathSync(join(cliProject, 'dist')))
 rmSync(cliProject, { recursive: true, force: true })
 
 if (
   buildExitCode !== 0
   || !usedDefaultOutput
   || !buildOutput.includes('Devjar build complete')
-  || !buildOutput.includes('Output  ')
-  || !buildOutput.includes('Routes  2')
+  || !buildOutput.includes(`Output  ${displayedOutput}`)
+  || !buildOutput.includes('Routes\n├── /\n└── /about')
 ) {
   if (buildError) console.error(buildError)
   throw new Error('The packaged CLI did not report a completed build in dist')

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -129,6 +129,11 @@ export default function Page() {
   const page = await browser.newPage()
   const consoleErrors: string[] = []
   const pageErrors: string[] = []
+  const externalRequests: string[] = []
+  const builtOrigin = new URL(baseUrl).origin
+  page.on('request', request => {
+    if (new URL(request.url()).origin !== builtOrigin) externalRequests.push(request.url())
+  })
   page.on('console', message => {
     if (message.type() === 'error') consoleErrors.push(message.text())
   })
@@ -142,6 +147,17 @@ export default function Page() {
   assert.equal(homeResponse?.status(), 200)
   await page.waitForFunction('globalThis.__devjarRenderCount > 0')
   await assertPage(page, 'Home', 'Package home')
+  assert.deepEqual(externalRequests, [])
+  const vendorUrls = await page.evaluate(() => performance.getEntriesByType('resource')
+    .map(entry => entry.name)
+    .filter(url => url.includes('/_jar/vendor/')))
+  assert(vendorUrls.length > 0, 'The browser did not load vendored dependencies')
+  const vendorResponse = await page.request.get(vendorUrls[0])
+  assert.equal(vendorResponse.status(), 200)
+  assert.equal(
+    vendorResponse.headers()['cache-control'],
+    'public, max-age=31536000, immutable',
+  )
   const logoPath = await page.locator('img[alt="Logo"]').getAttribute('src')
   assert.match(logoPath || '', /^\/preview\/_jar\/assets\/logo-[a-f0-9]{10}\.svg$/)
   const logoResponse = await page.request.get(new URL(logoPath!, baseUrl).href)
@@ -184,7 +200,7 @@ export default function Page() {
   assert(consoleErrors.every(message => message.includes('404 (Not Found)')))
   assert.deepEqual(pageErrors, [])
 
-  console.log('Packaged CLI builds at a subpath, hydrates, navigates, and renders its custom 404 in Chromium without unexpected browser errors.')
+  console.log('Packaged CLI vendors dependencies, builds at a subpath, hydrates, navigates, and renders its custom 404 in Chromium without unexpected browser errors.')
 } finally {
   await browser?.close()
   if (server) await stopServer(server)

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -119,8 +119,8 @@ export default function Page() {
   assert(!builtRuntimeFiles.includes('runtime.js'))
   assert(!builtRuntimeFiles.includes('transform-assets.json'))
 
-  server = spawn(jar, ['start', 'dist', '--host', '127.0.0.1', '--port', '0'], {
-    cwd: projectRoot,
+  server = spawn(jar, ['start', 'project', '--host', '127.0.0.1', '--port', '0'], {
+    cwd: temporaryRoot,
     stdio: ['ignore', 'pipe', 'pipe'],
   })
   const baseUrl = await serverUrl(server)

--- a/src/bin/jar.ts
+++ b/src/bin/jar.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
+import { join, relative } from 'node:path'
 import { buildProject, startBuiltServer, startDevServer } from '../cli/index'
 
 type Command = 'dev' | 'build' | 'start'
@@ -63,6 +63,15 @@ function friendlyError(error: unknown) {
   return error instanceof Error ? error.message : String(error)
 }
 
+function routeTree(routes: string[]) {
+  return [...routes]
+    .sort((a, b) => a === '/' ? -1 : b === '/' ? 1 : a.localeCompare(b))
+    .map((route, index, sortedRoutes) => (
+      `${index === sortedRoutes.length - 1 ? '└──' : '├──'} ${route}`
+    ))
+    .join('\n')
+}
+
 async function run() {
   const args = process.argv.slice(2)
   if (args.includes('--help') || args.includes('-h')) {
@@ -116,8 +125,10 @@ async function run() {
     })
     console.log(style(1, 'Devjar build complete'))
     console.log('')
-    console.log(`Output  ${style(36, result.outDir)}`)
-    console.log(`Routes  ${result.routes.length}`)
+    console.log(`Output  ${style(36, relative(process.cwd(), result.outDir) || '.')}`)
+    console.log('')
+    console.log('Routes')
+    console.log(routeTree(result.routes))
     return
   }
 

--- a/src/bin/jar.ts
+++ b/src/bin/jar.ts
@@ -18,14 +18,14 @@ Turn a folder of React pages into a prototype.
 Commands:
   dev      Start a development server (default)
   build    Create production output in <root>/dist
-  start    Serve a directory created by jar build
+  start    Serve the production build from <root>/dist
 
 Options:
   --cdn <url>      ESM-compatible module CDN (dev and build)
   --base <path>    Public base path (dev and build; default: /)
   --host <host>    Host to listen on (dev and start; default: localhost)
   --port <port>    Port to listen on (dev and start; default: 3000)
-  -o, --out-dir   Build output relative to the project root (default: dist)
+  -o, --out-dir   Build output relative to the project root (build and start; default: dist)
   -v, --version    Show the installed version
   -h, --help       Show this help
 
@@ -33,7 +33,7 @@ Examples:
   jar
   jar dev examples/dashboard
   jar build examples/dashboard
-  jar start examples/dashboard/dist`)
+  jar start examples/dashboard`)
 }
 
 function valueAfter(args: string[], index: number) {
@@ -70,6 +70,17 @@ function routeTree(routes: string[]) {
       `${index === sortedRoutes.length - 1 ? '└──' : '├──'} ${route}`
     ))
     .join('\n')
+}
+
+async function startRoot(root: string, outDir: string | undefined) {
+  if (outDir) return join(root, outDir)
+  try {
+    await readFile(join(root, 'manifest.json'))
+    return root
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    return join(root, 'dist')
+  }
 }
 
 async function run() {
@@ -110,8 +121,8 @@ async function run() {
   if (command === 'build' && (host || port !== undefined)) {
     throw new Error('build does not accept --host or --port')
   }
-  if (command === 'start' && (cdn || base || outDir)) {
-    throw new Error('start does not accept --cdn, --base, or --out-dir; configure these when building')
+  if (command === 'start' && (cdn || base)) {
+    throw new Error('start does not accept --cdn or --base; configure these when building')
   }
   if (command === 'dev' && outDir) throw new Error('dev does not accept --out-dir')
 
@@ -134,7 +145,7 @@ async function run() {
 
   const server = command === 'start'
     ? await startBuiltServer({
-        root: root || join(process.cwd(), 'dist'),
+        root: await startRoot(root || process.cwd(), outDir),
         host: host || 'localhost',
         port: port ?? 3000,
       })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import {
   builtAssetUrl,
   builtModuleUrl,
   collectProjectFiles,
+  collectPackageImports,
   compileProjectModule,
   devAssetUrl,
   DevModuleGraph,
@@ -28,6 +29,7 @@ import {
 } from '../project'
 import { getTailwindBrowserUrl } from '../tailwind'
 import { prerender, type PrerenderedRoute } from './prerender'
+import { vendorModules } from './vendor'
 
 type PackageJson = {
   dependencies?: Record<string, string>
@@ -179,9 +181,9 @@ function sendResponse(
 }
 
 type HtmlOptions = {
-  dependencies: Record<string, string>
-  devjarDependencies: Record<string, string>
-  cdn: string
+  resolveModule: (specifier: string) => string
+  resolveRuntimeModule: (specifier: string) => string
+  tailwindUrl: string | undefined
   base: string
   devjarRuntime: boolean
   liveReload: boolean
@@ -191,43 +193,29 @@ type HtmlOptions = {
 }
 
 function html(options: HtmlOptions) {
-  const resolveModule = createEsmShResolver(
-    options.dependencies,
-    options.cdn,
-    options.liveReload,
-  )
-  const resolveRuntimeModule = createEsmShResolver({
-    ...options.dependencies,
-    ...options.devjarDependencies,
-  }, options.cdn, options.liveReload)
   const imports = {
-    react: resolveModule('react'),
-    'react-dom': resolveModule('react-dom'),
-    'react/jsx-runtime': resolveModule('react/jsx-runtime'),
-    'react-dom/client': resolveModule('react-dom/client'),
+    react: options.resolveModule('react'),
+    'react-dom': options.resolveModule('react-dom'),
+    'react/jsx-runtime': options.resolveModule('react/jsx-runtime'),
+    'react-dom/client': options.resolveModule('react-dom/client'),
     ...(options.devjarRuntime
       ? {
-          'es-module-lexer': resolveRuntimeModule('es-module-lexer'),
+          'es-module-lexer': options.resolveRuntimeModule('es-module-lexer'),
           devjar: withBase(options.base, '/_jar/runtime.js'),
         }
       : {}),
     ...(options.liveReload
       ? {
-          'react/jsx-dev-runtime': resolveModule('react/jsx-dev-runtime'),
-          'react-refresh/runtime': resolveRuntimeModule('react-refresh/runtime'),
+          'react/jsx-dev-runtime': options.resolveModule('react/jsx-dev-runtime'),
+          'react-refresh/runtime': options.resolveRuntimeModule('react-refresh/runtime'),
         }
       : {}),
   }
-  const tailwindUrl = getTailwindBrowserUrl(
-    options.dependencies,
-    options.cdn,
-    options.liveReload,
-  )
-  const tailwindPreload = tailwindUrl
-    ? `<link rel="modulepreload" href="${tailwindUrl}">`
+  const tailwindPreload = options.tailwindUrl
+    ? `<link rel="modulepreload" href="${options.tailwindUrl}">`
     : ''
-  const tailwindScript = tailwindUrl
-    ? `<script data-devjar-tailwind type="module" src="${tailwindUrl}"></script>`
+  const tailwindScript = options.tailwindUrl
+    ? `<script data-devjar-tailwind type="module" src="${options.tailwindUrl}"></script>`
     : ''
   const clientScript = options.liveReload
     ? `<script type="module">
@@ -420,8 +408,7 @@ export async function startDevServer(options: DevServerOptions) {
           const compiled = await compileProjectModule({
             root,
             projectPath,
-            dependencies,
-            cdn,
+            resolveModule: createEsmShResolver(dependencies, cdn, true),
             moduleUrl: modules.moduleUrl,
             assetUrl: (projectPath, contents) => devAssetUrl(projectPath, contents, base),
             runtimeModuleUrl: withBase(base, '/_jar/runtime.js'),
@@ -453,7 +440,10 @@ export async function startDevServer(options: DevServerOptions) {
         return
       }
       if (requestPath.startsWith('/_jar/')) {
-        const cacheControl = requestPath.startsWith('/_jar/assets/') ? immutableAsset : noStore
+        const cacheControl = requestPath.startsWith('/_jar/assets/')
+          || requestPath.startsWith('/_jar/vendor/')
+          ? immutableAsset
+          : noStore
         if (!await serveFile(request, response, assetsRoot, requestPath.slice('/_jar/'.length), undefined, cacheControl)) send(request, response, 404, 'text/plain', 'Not found')
         return
       }
@@ -465,6 +455,8 @@ export async function startDevServer(options: DevServerOptions) {
       }
       if (await serveFile(request, response, join(root, 'public'), requestPath.slice(1), undefined, noStore)) return
       const packageJson = await readPackage(root)
+      const dependencies = packageDependencies(packageJson)
+      const cdn = resolveCdn(options.cdn)
       send(
         request,
         response,
@@ -472,9 +464,12 @@ export async function startDevServer(options: DevServerOptions) {
         'text/html; charset=utf-8',
         html(
           {
-            dependencies: packageDependencies(packageJson),
-            devjarDependencies,
-            cdn: resolveCdn(options.cdn),
+            resolveModule: createEsmShResolver(dependencies, cdn, true),
+            resolveRuntimeModule: createEsmShResolver({
+              ...dependencies,
+              ...devjarDependencies,
+            }, cdn, true),
+            tailwindUrl: getTailwindBrowserUrl(dependencies, cdn, true),
             base,
             devjarRuntime: true,
             liveReload: true,
@@ -680,15 +675,19 @@ async function writeRouteHtml(
   rendered: PrerenderedRoute,
   options: Pick<
     HtmlOptions,
-    'dependencies' | 'devjarDependencies' | 'cdn' | 'base' | 'devjarRuntime'
+    | 'resolveModule'
+    | 'resolveRuntimeModule'
+    | 'tailwindUrl'
+    | 'base'
+    | 'devjarRuntime'
   >,
 ) {
   const outputPath = routeHtmlPath(outDir, route)
   await mkdir(dirname(outputPath), { recursive: true })
   const document = html({
-    dependencies: options.dependencies,
-    devjarDependencies: options.devjarDependencies,
-    cdn: options.cdn,
+    resolveModule: options.resolveModule,
+    resolveRuntimeModule: options.resolveRuntimeModule,
+    tailwindUrl: options.tailwindUrl,
     base: options.base,
     devjarRuntime: options.devjarRuntime,
     liveReload: false,
@@ -723,6 +722,30 @@ export async function buildProject(options: BuildOptions) {
   const devjarDependencies = devjarRuntime
     ? await readDevjarDependencies(runtime)
     : {}
+  const resolveSourceModule = createEsmShResolver(dependencies, cdn, false)
+  const resolveSourceRuntimeModule = createEsmShResolver({
+    ...dependencies,
+    ...devjarDependencies,
+  }, cdn, false)
+  const packageImports = await collectPackageImports(root, projectPaths)
+  const htmlImports = ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client']
+  const tailwindSourceUrl = getTailwindBrowserUrl(dependencies, cdn, false)
+  const sourceUrls = new Set([
+    ...htmlImports.map(resolveSourceModule),
+    ...[...packageImports].map(resolveSourceModule),
+    ...(devjarRuntime ? [resolveSourceRuntimeModule('es-module-lexer')] : []),
+    ...(tailwindSourceUrl ? [tailwindSourceUrl] : []),
+  ])
+  const vendored = await vendorModules({
+    moduleUrls: [...sourceUrls],
+    resolveModule: resolveSourceModule,
+  })
+  const resolveBuiltModule = (specifier: string) => (
+    vendored.moduleUrl(resolveSourceModule(specifier), base)
+  )
+  const resolveBuiltRuntimeModule = (specifier: string) => (
+    vendored.moduleUrl(resolveSourceRuntimeModule(specifier), base)
+  )
   const manifest = await loadRouteManifest(root, {
     liveReload: false,
     revision: 0,
@@ -748,14 +771,17 @@ export async function buildProject(options: BuildOptions) {
   await writeFile(join(outDir, 'manifest.json'), JSON.stringify(manifest))
   for (const route of Object.keys(manifest.routes)) {
     await writeRouteHtml(outDir, route, renderedRoutes[route], {
-      dependencies,
-      devjarDependencies,
-      cdn,
+      resolveModule: resolveBuiltModule,
+      resolveRuntimeModule: resolveBuiltRuntimeModule,
+      tailwindUrl: tailwindSourceUrl
+        ? vendored.moduleUrl(tailwindSourceUrl, base)
+        : undefined,
       base,
       devjarRuntime,
     })
   }
   await copyRuntimeAssets(join(outDir, '_jar'), devjarRuntime)
+  await vendored.write(join(outDir, '_jar/vendor'), base)
   const modulesRoot = join(outDir, '_jar/modules')
   const projectAssetsRoot = join(outDir, '_jar/assets')
   await mkdir(modulesRoot, { recursive: true })
@@ -768,8 +794,7 @@ export async function buildProject(options: BuildOptions) {
     const compiled = await compileProjectModule({
       root,
       projectPath,
-      dependencies,
-      cdn,
+      resolveModule: resolveBuiltModule,
       moduleUrl: projectPath => builtModuleUrl(projectPath, base),
       assetUrl: (projectPath, contents) => builtAssetUrl(projectPath, contents, base),
       runtimeModuleUrl: withBase(base, '/_jar/runtime.js'),
@@ -820,7 +845,10 @@ export async function startBuiltServer(options: StartServerOptions) {
         return
       }
       if (requestPath.startsWith('/_jar/')) {
-        const cacheControl = requestPath.startsWith('/_jar/assets/') ? immutableAsset : noStore
+        const cacheControl = requestPath.startsWith('/_jar/assets/')
+          || requestPath.startsWith('/_jar/vendor/')
+          ? immutableAsset
+          : noStore
         if (!await serveFile(request, response, join(root, '_jar'), requestPath.slice('/_jar/'.length), undefined, cacheControl)) {
           send(request, response, 404, 'text/plain; charset=utf-8', 'Not found')
         }

--- a/src/cli/modules.ts
+++ b/src/cli/modules.ts
@@ -3,7 +3,6 @@ import { readFile, realpath, stat } from 'node:fs/promises'
 import { basename, extname, relative, resolve, sep } from 'node:path'
 import { init, parse } from 'es-module-lexer'
 import { transformSync } from 'oxc-transform'
-import { createEsmShResolver } from '../cdn'
 import { sourceExtensions, withBase } from '../project'
 import { getTransformErrorMessage, getTransformOptions } from '../transform'
 import type { HmrUpdate } from './protocol'
@@ -45,8 +44,7 @@ export type CompiledProjectModule = {
 export type CompileProjectModuleOptions = {
   root: string
   projectPath: string
-  dependencies: Record<string, string>
-  cdn: string
+  resolveModule: (specifier: string) => string
   moduleUrl: (projectPath: string) => string
   assetUrl: (projectPath: string, contents: Buffer) => string
   runtimeModuleUrl: string
@@ -195,6 +193,31 @@ export async function usesDevjarRuntime(root: string, projectPaths: Set<string>)
   return false
 }
 
+export async function collectPackageImports(root: string, projectPaths: Set<string>) {
+  const specifiers = new Set<string>()
+  for (const projectPath of projectPaths) {
+    if (!sourceExtensions.includes(extname(projectPath))) continue
+    const source = await readFile(resolve(root, projectPath), 'utf8')
+    const output = transformSync(
+      projectPath,
+      source,
+      getTransformOptions(projectPath, false, false),
+    )
+    const error = getTransformErrorMessage(output.errors)
+    if (error) throw new Error(error)
+
+    await init
+    const [imports] = parse(output.code)
+    for (const imported of imports) {
+      if (imported.n
+        && imported.n !== 'devjar'
+        && !imported.n.startsWith('./')
+        && !imported.n.startsWith('../')) specifiers.add(imported.n)
+    }
+  }
+  return specifiers
+}
+
 export async function collectProjectFiles(root: string, entry: string) {
   const projectPaths = new Set<string>()
   const queue = [entry]
@@ -319,11 +342,6 @@ export async function compileProjectModule(
   const [imports, exports] = parse(output.code)
   const replacements: Array<{ start: number, end: number, value: string }> = []
   const localDependencies: string[] = []
-  const resolveModule = createEsmShResolver(
-    options.dependencies,
-    options.cdn,
-    options.development,
-  )
   for (const imported of imports) {
     if (!imported.n) continue
     let value: string
@@ -338,7 +356,7 @@ export async function compileProjectModule(
       value = options.moduleUrl(importedProjectPath)
       localDependencies.push(importedProjectPath)
     } else {
-      value = resolveModule(imported.n)
+      value = options.resolveModule(imported.n)
     }
     replacements.push({
       start: imported.s,

--- a/src/cli/prerender.ts
+++ b/src/cli/prerender.ts
@@ -61,6 +61,7 @@ export async function prerender(options: PrerenderOptions) {
     const projectFiles = new Set<string>()
     const routeFiles = new Map<string, Set<string>>()
     const projectStyles = new Map<string, string>()
+    const resolveModule = createEsmShResolver(options.dependencies, options.cdn, false)
     for (const [route, entry] of options.routes) {
       const files = await collectProjectFiles(options.root, entry)
       routeFiles.set(route, files)
@@ -71,8 +72,7 @@ export async function prerender(options: PrerenderOptions) {
       const compiled = await compileProjectModule({
         root: options.root,
         projectPath,
-        dependencies: options.dependencies,
-        cdn: options.cdn,
+        resolveModule,
         moduleUrl: importedPath => `./${serverModuleName(importedPath)}`,
         assetUrl: (projectPath, contents) => builtAssetUrl(
           projectPath,
@@ -89,7 +89,6 @@ export async function prerender(options: PrerenderOptions) {
     }
 
     const outputPath = join(temporaryRoot, 'rendered.json')
-    const resolveModule = createEsmShResolver(options.dependencies, options.cdn, false)
     const resolveRuntimeModule = createEsmShResolver({
       ...options.dependencies,
       ...options.devjarDependencies,

--- a/src/cli/vendor.ts
+++ b/src/cli/vendor.ts
@@ -1,0 +1,268 @@
+import { createHash } from 'node:crypto'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { extname, join } from 'node:path'
+import { init, parse } from 'es-module-lexer'
+import { withBase } from '../project'
+
+type Replacement = {
+  start: number
+  end: number
+  target: string
+  quoted: boolean
+}
+
+type VendorResource = {
+  url: string
+  contents: Buffer
+  contentType: string
+  replacements: Replacement[]
+  parsePromise: Promise<void> | undefined
+}
+
+export type VendorModulesOptions = {
+  moduleUrls: string[]
+  resolveModule: (specifier: string) => string
+}
+
+export type VendoredModules = {
+  moduleUrl: (sourceUrl: string, base: string) => string
+  write: (destination: string, base: string) => Promise<void>
+}
+
+function normalizedUrl(value: string) {
+  const url = new URL(value)
+  url.hash = ''
+  return url.href
+}
+
+function remoteUrl(specifier: string, parentUrl: string, resolveModule: (specifier: string) => string) {
+  if (/^https?:\/\//.test(specifier)) return normalizedUrl(specifier)
+  if (specifier.startsWith('//')
+    || specifier.startsWith('/')
+    || specifier.startsWith('./')
+    || specifier.startsWith('../')) {
+    return normalizedUrl(new URL(specifier, parentUrl).href)
+  }
+  return normalizedUrl(resolveModule(specifier))
+}
+
+function keepsOriginalUrl(specifier: string) {
+  return specifier.startsWith('#')
+    || (/^[a-z][a-z\d+.-]*:/i.test(specifier) && !/^https?:\/\//.test(specifier))
+}
+
+function contentExtension(resource: VendorResource) {
+  const type = resource.contentType.split(';', 1)[0].trim().toLowerCase()
+  const knownTypes: Record<string, string> = {
+    'application/javascript': '.js',
+    'application/json': '.json',
+    'application/pdf': '.pdf',
+    'application/wasm': '.wasm',
+    'application/x-javascript': '.js',
+    'application/ecmascript': '.js',
+    'audio/mpeg': '.mp3',
+    'audio/ogg': '.ogg',
+    'font/otf': '.otf',
+    'font/ttf': '.ttf',
+    'font/woff': '.woff',
+    'font/woff2': '.woff2',
+    'image/avif': '.avif',
+    'image/gif': '.gif',
+    'image/jpeg': '.jpg',
+    'image/png': '.png',
+    'image/svg+xml': '.svg',
+    'image/webp': '.webp',
+    'text/css': '.css',
+    'text/ecmascript': '.js',
+    'text/javascript': '.js',
+    'video/mp4': '.mp4',
+    'video/ogg': '.ogg',
+    'video/webm': '.webm',
+  }
+  if (knownTypes[type]) return knownTypes[type]
+  const extension = extname(new URL(resource.url).pathname).toLowerCase()
+  return /^\.[a-z0-9]{1,8}$/.test(extension) ? extension : '.bin'
+}
+
+function isJavaScript(resource: VendorResource) {
+  const type = resource.contentType.split(';', 1)[0].trim().toLowerCase()
+  if (['application/ecmascript', 'application/javascript', 'application/x-javascript', 'text/ecmascript', 'text/javascript'].includes(type)) return true
+  return ['.js', '.mjs'].includes(extname(new URL(resource.url).pathname).toLowerCase())
+}
+
+function isCss(resource: VendorResource) {
+  const type = resource.contentType.split(';', 1)[0].trim().toLowerCase()
+  return type === 'text/css' || extname(new URL(resource.url).pathname).toLowerCase() === '.css'
+}
+
+function resourceName(resource: VendorResource) {
+  const hash = createHash('sha256').update(resource.url).digest('hex').slice(0, 12)
+  return `${hash}${contentExtension(resource)}`
+}
+
+function stringReplacement(
+  match: RegExpMatchArray,
+  specifier: string,
+  target: string,
+) {
+  const matchStart = match.index!
+  const specifierStart = match[0].lastIndexOf(specifier)
+  return {
+    start: matchStart + specifierStart,
+    end: matchStart + specifierStart + specifier.length,
+    target,
+    quoted: false,
+  }
+}
+
+function graphHash(resources: Map<string, VendorResource>) {
+  const hash = createHash('sha256')
+  for (const resource of [...resources.values()].sort((a, b) => a.url.localeCompare(b.url))) {
+    hash.update(resource.url)
+    hash.update('\0')
+    hash.update(resource.contentType)
+    hash.update('\0')
+    hash.update(resource.contents)
+    hash.update('\0')
+  }
+  return hash.digest('hex').slice(0, 12)
+}
+
+function stripSourceMapReferences(source: string) {
+  return source
+    .replace(/^\s*\/\/[#@]\s*sourceMappingURL=.*$/gm, '')
+    .replace(/\/\*[#@]\s*sourceMappingURL=.*?\*\//gs, '')
+}
+
+export async function vendorModules(options: VendorModulesOptions): Promise<VendoredModules> {
+  const resources = new Map<string, VendorResource>()
+  const aliases = new Map<string, string>()
+  const fetches = new Map<string, Promise<VendorResource>>()
+
+  async function fetchResource(requestedUrl: string) {
+    const requested = normalizedUrl(requestedUrl)
+    const aliased = aliases.get(requested)
+    if (aliased && resources.has(aliased)) return resources.get(aliased)!
+    const existing = resources.get(requested)
+    if (existing) return existing
+    const pending = fetches.get(requested)
+    if (pending) return pending
+
+    const fetching = (async () => {
+      const response = await fetch(requested)
+      if (!response.ok) {
+        throw new Error(`Unable to vendor ${requested}: ${response.status} ${response.statusText}`)
+      }
+      const finalUrl = normalizedUrl(response.url || requested)
+      aliases.set(requested, finalUrl)
+      const finalResource = resources.get(finalUrl)
+      if (finalResource) return finalResource
+      const resource: VendorResource = {
+        url: finalUrl,
+        contents: Buffer.from(await response.arrayBuffer()),
+        contentType: response.headers.get('content-type') || '',
+        replacements: [],
+        parsePromise: undefined,
+      }
+      resources.set(finalUrl, resource)
+      return resource
+    })()
+    fetches.set(requested, fetching)
+    try {
+      return await fetching
+    } finally {
+      fetches.delete(requested)
+    }
+  }
+
+  async function parseResource(resource: VendorResource, ancestors: Set<string>): Promise<void> {
+    if (ancestors.has(resource.url)) return
+    if (resource.parsePromise) return resource.parsePromise
+    const nextAncestors = new Set(ancestors).add(resource.url)
+    resource.parsePromise = (async () => {
+      const source = resource.contents.toString('utf8')
+      const references: Array<{ target: string, replacement: Replacement }> = []
+
+      if (isJavaScript(resource)) {
+        await init
+        const [imports] = parse(source)
+        for (const imported of imports) {
+          if (!imported.n) continue
+          if (keepsOriginalUrl(imported.n)) continue
+          const target = remoteUrl(imported.n, resource.url, options.resolveModule)
+          references.push({
+            target,
+            replacement: {
+              start: imported.s,
+              end: imported.e,
+              target,
+              quoted: imported.d >= 0,
+            },
+          })
+        }
+        for (const match of source.matchAll(/new\s+URL\s*\(\s*(["'])([^"']+)\1\s*,\s*import\.meta\.url\s*\)/g)) {
+          const specifier = match[2]
+          if (keepsOriginalUrl(specifier)) continue
+          const target = remoteUrl(specifier, resource.url, options.resolveModule)
+          references.push({ target, replacement: stringReplacement(match, specifier, target) })
+        }
+      } else if (isCss(resource)) {
+        for (const match of source.matchAll(/@import\s+(["'])([^"']+)\1/g)) {
+          const specifier = match[2]
+          if (keepsOriginalUrl(specifier)) continue
+          const target = remoteUrl(specifier, resource.url, options.resolveModule)
+          references.push({ target, replacement: stringReplacement(match, specifier, target) })
+        }
+        for (const match of source.matchAll(/url\(\s*(?:(["'])(.*?)\1|([^)'"\s][^)]*))\s*\)/g)) {
+          const specifier = (match[2] || match[3] || '').trim()
+          if (!specifier || keepsOriginalUrl(specifier)) continue
+          const target = remoteUrl(specifier, resource.url, options.resolveModule)
+          references.push({ target, replacement: stringReplacement(match, specifier, target) })
+        }
+      }
+
+      resource.replacements.push(...references.map(reference => reference.replacement))
+      const dependencies = await Promise.all(references.map(({ target }) => fetchResource(target)))
+      for (const dependency of dependencies) {
+        await parseResource(dependency, nextAncestors)
+      }
+    })()
+    return resource.parsePromise
+  }
+
+  for (const url of options.moduleUrls) {
+    const resource = await fetchResource(url)
+    await parseResource(resource, new Set())
+  }
+
+  const revision = graphHash(resources)
+  function localUrl(sourceUrl: string, base: string) {
+    const requested = normalizedUrl(sourceUrl)
+    const canonical = aliases.get(requested) || requested
+    const resource = resources.get(canonical)
+    if (!resource) throw new Error(`Module was not vendored: ${sourceUrl}`)
+    return withBase(base, `/_jar/vendor/${revision}/${resourceName(resource)}`)
+  }
+
+  return {
+    moduleUrl: localUrl,
+    async write(destination, base) {
+      const outputRoot = join(destination, revision)
+      await mkdir(outputRoot, { recursive: true })
+      for (const resource of resources.values()) {
+        let contents = resource.contents
+        if (resource.replacements.length || isJavaScript(resource) || isCss(resource)) {
+          let source = contents.toString('utf8')
+          for (const replacement of [...resource.replacements].sort((a, b) => b.start - a.start)) {
+            const value = localUrl(replacement.target, base)
+            source = source.slice(0, replacement.start)
+              + (replacement.quoted ? JSON.stringify(value) : value)
+              + source.slice(replacement.end)
+          }
+          contents = Buffer.from(stripSourceMapReferences(source))
+        }
+        await writeFile(join(outputRoot, resourceName(resource)), contents)
+      }
+    },
+  }
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -125,8 +125,11 @@ describe('project loading', () => {
     const compiled = await compileProjectModule({
       root,
       projectPath: 'pages/about.tsx',
-      dependencies: { react: '19.2.0' },
-      cdn: 'https://modules.example.test/',
+      resolveModule: createEsmShResolver(
+        { react: '19.2.0' },
+        'https://modules.example.test/',
+        true,
+      ),
       moduleUrl: testModuleUrl,
       assetUrl: () => '/assets/test',
       runtimeModuleUrl: '/_jar/runtime.js',
@@ -138,6 +141,18 @@ describe('project loading', () => {
   })
 
   test('uses project dependencies for the app and Devjar dependencies for its runtime', async () => {
+    const requests: string[] = []
+    const cdn = createHttpServer((request, response) => {
+      const pathname = new URL(request.url || '/', 'http://localhost').pathname
+      requests.push(pathname)
+      response.writeHead(200, { 'Content-Type': 'text/javascript' })
+      response.end(testCdnModule(pathname))
+    })
+    await new Promise<void>((resolvePromise, reject) => {
+      cdn.once('error', reject)
+      cdn.listen(0, '127.0.0.1', resolvePromise)
+    })
+    const address = cdn.address() as import('node:net').AddressInfo
     const projectRoot = await mkdtemp(join(tmpdir(), 'devjar-zero-config-'))
     try {
       await cp(root, projectRoot, { recursive: true })
@@ -152,24 +167,25 @@ describe('project loading', () => {
       const result = await buildProject({
         root: projectRoot,
         outDir: 'dist',
-        cdn: undefined,
+        cdn: `http://127.0.0.1:${address.port}`,
         prerender: false,
         base: '/',
       })
       const manifest = JSON.parse(await readFile(join(result.outDir, 'manifest.json'), 'utf8'))
       const entry = await readFile(join(result.outDir, manifest.routes['/'].module), 'utf8')
       const document = await readFile(join(result.outDir, 'index.html'), 'utf8')
-      const devjarPackage = JSON.parse(
-        await readFile(resolve(import.meta.dir, '../package.json'), 'utf8'),
-      )
-      const lexerVersion = encodeURIComponent(devjarPackage.dependencies['es-module-lexer'])
-      expect(entry).toContain('https://esm.sh/react@19.2.0/jsx-runtime')
+      expect(entry).toMatch(/\/_jar\/vendor\/[a-f0-9]{12}\/[a-f0-9]{12}\.js/)
+      expect(entry).not.toContain('http://')
+      expect(entry).not.toContain('https://')
       expect(entry).not.toContain('jsx-dev-runtime')
       expect(entry).not.toContain('?dev')
       expect(entry).not.toContain('modules.example.test')
-      expect(document).toContain(`https://esm.sh/es-module-lexer@${lexerVersion}`)
-      expect(document).not.toContain('es-module-lexer@9.9.9')
+      expect(document).not.toContain('http://')
+      expect(document).not.toContain('https://')
+      expect(requests.some(path => path.includes('/es-module-lexer@1.6.0'))).toBe(true)
+      expect(requests.some(path => path.includes('/es-module-lexer@9.9.9'))).toBe(false)
     } finally {
+      await new Promise<void>(resolvePromise => cdn.close(() => resolvePromise()))
       await rm(projectRoot, { recursive: true, force: true })
     }
   })
@@ -233,8 +249,7 @@ describe('project loading', () => {
       const compiled = await compileProjectModule({
         root: await realpath(projectRoot),
         projectPath: 'pages/index.tsx',
-        dependencies: {},
-        cdn: CDN_HOST,
+        resolveModule: createEsmShResolver({}, CDN_HOST, true),
         moduleUrl: testModuleUrl,
         assetUrl: () => '/assets/test',
         runtimeModuleUrl: '/_jar/runtime.js',
@@ -464,15 +479,25 @@ export default function Page() { return <><img className="hero" src={icon} /><Ca
 describe('production build', () => {
   let projectRoot = ''
   let buildRoot = ''
+  let cdn: ReturnType<typeof createHttpServer> | undefined
   let server: Awaited<ReturnType<typeof startBuiltServer>> | undefined
 
   beforeAll(async () => {
+    cdn = createHttpServer((request, response) => {
+      response.writeHead(200, { 'Content-Type': 'text/javascript' })
+      response.end(testCdnModule(new URL(request.url || '/', 'http://localhost').pathname))
+    })
+    await new Promise<void>((resolvePromise, reject) => {
+      cdn!.once('error', reject)
+      cdn!.listen(0, '127.0.0.1', resolvePromise)
+    })
+    const address = cdn.address() as import('node:net').AddressInfo
     projectRoot = await mkdtemp(join(tmpdir(), 'devjar-build-'))
     await cp(dashboardRoot, projectRoot, { recursive: true })
     const result = await buildProject({
       root: projectRoot,
       outDir: 'dist',
-      cdn: 'https://modules.example.test/',
+      cdn: `http://127.0.0.1:${address.port}`,
       prerender: false,
       base: '/preview/',
     })
@@ -481,6 +506,7 @@ describe('production build', () => {
 
   afterAll(async () => {
     await server?.close()
+    if (cdn) await new Promise<void>(resolvePromise => cdn!.close(() => resolvePromise()))
     if (projectRoot) await rm(projectRoot, { recursive: true, force: true })
   })
 
@@ -497,7 +523,9 @@ describe('production build', () => {
       join(buildRoot, withoutBase(manifest.base, manifest.routes['/'].module)!),
       'utf8',
     )
-    expect(entryModule).toContain('https://modules.example.test/react@19.2.0/jsx-runtime')
+    expect(entryModule).toMatch(/\/preview\/_jar\/vendor\/[a-f0-9]{12}\/[a-f0-9]{12}\.js/)
+    expect(entryModule).not.toContain('http://')
+    expect(entryModule).not.toContain('https://')
     expect(entryModule).not.toContain('jsx-dev-runtime')
     expect(entryModule).not.toContain('?dev')
     expect(entryModule).not.toContain('__jarRegisterModule')
@@ -513,6 +541,7 @@ describe('production build', () => {
     expect(builtHtml).not.toContain('es-module-lexer')
     const runtimeFiles = await readdir(join(buildRoot, '_jar'))
     expect(runtimeFiles).toContain('client.js')
+    expect(runtimeFiles).toContain('vendor')
     expect(runtimeFiles).not.toContain('runtime.js')
     expect(runtimeFiles).not.toContain('transform-assets.json')
     expect(await readdir(join(buildRoot, '_jar/assets'))).toEqual([])
@@ -543,8 +572,14 @@ describe('production build', () => {
     expect(document.headers.get('cross-origin-embedder-policy')).toBeNull()
 
     const shell = await (await fetch(`${origin}/preview/projects`)).text()
-    expect(shell).toContain('https://modules.example.test/react@19.2.0')
+    expect(shell).toMatch(/\/preview\/_jar\/vendor\/[a-f0-9]{12}\/[a-f0-9]{12}\.js/)
+    expect(shell).not.toContain('http://')
+    expect(shell).not.toContain('https://')
     expect(shell).not.toContain('?dev')
+    const vendorPath = shell.match(/\/preview\/_jar\/vendor\/[a-f0-9]{12}\/[a-f0-9]{12}\.js/)![0]
+    const vendorModule = await fetch(`${origin}${vendorPath}`)
+    expect(vendorModule.status).toBe(200)
+    expect(vendorModule.headers.get('cache-control')).toBe('public, max-age=31536000, immutable')
     const routes = await (await fetch(`${origin}/preview/_jar/routes.json`)).json()
     expect(routes.routes['/projects'].page).toBe('pages/projects.tsx')
     expect(routes.liveReload).toBe(false)

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -16,6 +16,12 @@ describe('Vercel deployment', () => {
         ],
       },
       {
+        source: '/_jar/vendor/(.*)',
+        headers: [
+          { key: 'Cache-Control', value: 'public, max-age=31536000, immutable' },
+        ],
+      },
+      {
         source: '/(.*)',
         headers: [
           { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },

--- a/test/vendor.test.ts
+++ b/test/vendor.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { init, parse } from 'es-module-lexer'
+import { vendorModules } from '../src/cli/vendor'
+
+describe('production dependency vendoring', () => {
+  test('copies and rewrites transitive modules and assets', async () => {
+    const server = createServer((request, response) => {
+      const path = new URL(request.url || '/', 'http://localhost').pathname
+      if (path === '/entry') {
+        response.writeHead(302, { Location: '/entry.js' })
+        response.end()
+        return
+      }
+      const resources: Record<string, { type: string, body: string | Buffer }> = {
+        '/entry.js': {
+          type: 'text/javascript',
+          body: `import { value } from './dependency.js'
+import sheet from './style.css' with { type: 'css' }
+export { value, sheet }
+export const load = () => import('./dynamic.js')
+export const worker = new URL('./worker.js', import.meta.url)
+//# sourceMappingURL=entry.js.map`,
+        },
+        '/dependency.js': {
+          type: 'text/javascript',
+          body: `import './cycle.js'
+export const value = 1`,
+        },
+        '/cycle.js': { type: 'text/javascript', body: `import './dependency.js'` },
+        '/dynamic.js': { type: 'text/javascript', body: `export default 'dynamic'` },
+        '/worker.js': { type: 'text/javascript', body: `import './worker-dependency.js'` },
+        '/worker-dependency.js': { type: 'text/javascript', body: `export const ready = true` },
+        '/style.css': { type: 'text/css', body: `.logo { background: url('./logo.png') }` },
+        '/logo.png': { type: 'image/png', body: Buffer.from('logo') },
+      }
+      const resource = resources[path]
+      if (!resource) {
+        response.writeHead(404)
+        response.end()
+        return
+      }
+      response.writeHead(200, { 'Content-Type': resource.type })
+      response.end(resource.body)
+    })
+    await new Promise<void>((resolvePromise, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolvePromise)
+    })
+    const address = server.address() as import('node:net').AddressInfo
+    const origin = `http://127.0.0.1:${address.port}`
+    const output = await mkdtemp(join(tmpdir(), 'devjar-vendor-'))
+
+    try {
+      const vendored = await vendorModules({
+        moduleUrls: [`${origin}/entry`],
+        resolveModule: specifier => `${origin}/${specifier}`,
+      })
+      const entryUrl = vendored.moduleUrl(`${origin}/entry`, '/docs/')
+      expect(entryUrl).toMatch(/^\/docs\/_jar\/vendor\/[a-f0-9]{12}\/[a-f0-9]{12}\.js$/)
+      await vendored.write(output, '/docs/')
+
+      const revisions = await readdir(output)
+      expect(revisions).toHaveLength(1)
+      const files = await readdir(join(output, revisions[0]))
+      expect(files).toHaveLength(8)
+      expect(files.some(file => file.endsWith('.css'))).toBe(true)
+      expect(files.some(file => file.endsWith('.png'))).toBe(true)
+      const sourceFiles = files.filter(file => file.endsWith('.js') || file.endsWith('.css'))
+      const sources = await Promise.all(sourceFiles
+        .map(file => readFile(join(output, revisions[0], file), 'utf8')))
+      await init
+      for (const [index, source] of sources.entries()) {
+        if (sourceFiles[index].endsWith('.js')) expect(() => parse(source)).not.toThrow()
+      }
+      const source = sources.join('\n')
+      expect(source).not.toContain(origin)
+      expect(source).not.toContain(`from './`)
+      expect(source).not.toContain(`import('./`)
+      expect(source).not.toContain(`url('./`)
+      expect(source).not.toContain('sourceMappingURL')
+      expect(source).toContain('/docs/_jar/vendor/')
+    } finally {
+      await new Promise<void>(resolvePromise => server.close(() => resolvePromise()))
+      await rm(output, { recursive: true, force: true })
+    }
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -14,6 +14,15 @@
       ]
     },
     {
+      "source": "/_jar/vendor/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
       "source": "/(.*)",
       "headers": [
         {


### PR DESCRIPTION
## Summary

- recursively vendor production modules and referenced assets under a content-addressed `_jar/vendor` directory
- rewrite application imports, import maps, and the Tailwind runtime to local base-aware URLs while leaving embedded DevJar resolution unchanged
- cache vendored files immutably and verify host hydration without external network access
- show relative build output with a stable route tree
- let `jar start` accept a project directory and resolve its default or explicit output directory

## Verification

- `pnpm build:website`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:package`
- `bun scripts/test-package-browser.ts`
- offline Chromium checks for the website and Tailwind dashboard builds