### PR TITLE
feat: compile Tailwind during production builds

### DIFF
--- a/scripts/build-cli-assets.ts
+++ b/scripts/build-cli-assets.ts
@@ -6,4 +6,5 @@ const root = join(import.meta.dir, '..')
 await Promise.all([
   cp(join(root, 'src/cli/http-loader.mjs'), join(root, 'dist/http-loader.mjs')),
   cp(join(root, 'src/cli/prerender-runner.mjs'), join(root, 'dist/prerender-runner.mjs')),
+  cp(join(root, 'src/cli/tailwind-runner.mjs'), join(root, 'dist/tailwind-runner.mjs')),
 ])

--- a/scripts/check-package.ts
+++ b/scripts/check-package.ts
@@ -36,6 +36,7 @@ const required = [
   'dist/http-loader.mjs',
   'dist/index.js',
   'dist/prerender-runner.mjs',
+  'dist/tailwind-runner.mjs',
   'dist/transform-assets.json',
   ...Object.values(transformAssets).map(file => `dist/${file}`),
 ]

--- a/scripts/test-cdn.ts
+++ b/scripts/test-cdn.ts
@@ -1,4 +1,16 @@
 export function testCdnModule(pathname: string) {
+  if (pathname.includes('/tailwindcss@') && pathname.endsWith('/index.css')) {
+    return '@tailwind utilities;'
+  }
+  if (pathname.includes('/tailwindcss@')) {
+    return `export async function compile() {
+  return {
+    build(candidates) {
+      return '/* ' + JSON.stringify(candidates) + ' */\\nbody { --devjar-tailwind-test: 1; }'
+    },
+  }
+}`
+  }
   if (pathname.includes('/es-module-lexer@')) {
     return `export const init = Promise.resolve()
 export function parse() { return [[], []] }`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -27,8 +27,9 @@ import {
   withBase,
   withoutBase,
 } from '../project'
-import { getTailwindBrowserUrl } from '../tailwind'
+import { getTailwindBrowserUrl, getTailwindBuildUrls } from '../tailwind'
 import { prerender, type PrerenderedRoute } from './prerender'
+import { compileTailwind } from './tailwind-build'
 import { vendorModules } from './vendor'
 
 type PackageJson = {
@@ -184,6 +185,7 @@ type HtmlOptions = {
   resolveModule: (specifier: string) => string
   resolveRuntimeModule: (specifier: string) => string
   tailwindUrl: string | undefined
+  tailwindStylesheetUrl: string | undefined
   base: string
   devjarRuntime: boolean
   liveReload: boolean
@@ -217,6 +219,9 @@ function html(options: HtmlOptions) {
   const tailwindScript = options.tailwindUrl
     ? `<script data-devjar-tailwind type="module" src="${options.tailwindUrl}"></script>`
     : ''
+  const tailwindStylesheet = options.tailwindStylesheetUrl
+    ? `<link data-devjar-tailwind rel="stylesheet" href="${options.tailwindStylesheetUrl}">`
+    : ''
   const clientScript = options.liveReload
     ? `<script type="module">
 import * as RefreshModule from 'react-refresh/runtime'
@@ -236,7 +241,7 @@ await import(${JSON.stringify(withBase(options.base, '/_jar/client.js'))})
 <html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
 <meta name="devjar-base" content="${options.base}">${documentHead}${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
 <style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>${staticStyles}
-</head><body><div id="root"><div id="__reactRoot">${options.content}</div></div><pre id="__jarError" class="devjar-error" hidden></pre><script>
+${tailwindStylesheet}</head><body><div id="root"><div id="__reactRoot">${options.content}</div></div><pre id="__jarError" class="devjar-error" hidden></pre><script>
 const errorRoot = document.getElementById('__jarError')
 const showBootstrapError = value => {
   errorRoot.hidden = false
@@ -470,6 +475,7 @@ export async function startDevServer(options: DevServerOptions) {
               ...devjarDependencies,
             }, cdn, true),
             tailwindUrl: getTailwindBrowserUrl(dependencies, cdn, true),
+            tailwindStylesheetUrl: undefined,
             base,
             devjarRuntime: true,
             liveReload: true,
@@ -678,6 +684,7 @@ async function writeRouteHtml(
     | 'resolveModule'
     | 'resolveRuntimeModule'
     | 'tailwindUrl'
+    | 'tailwindStylesheetUrl'
     | 'base'
     | 'devjarRuntime'
   >,
@@ -688,6 +695,7 @@ async function writeRouteHtml(
     resolveModule: options.resolveModule,
     resolveRuntimeModule: options.resolveRuntimeModule,
     tailwindUrl: options.tailwindUrl,
+    tailwindStylesheetUrl: options.tailwindStylesheetUrl,
     base: options.base,
     devjarRuntime: options.devjarRuntime,
     liveReload: false,
@@ -729,12 +737,11 @@ export async function buildProject(options: BuildOptions) {
   }, cdn, false)
   const packageImports = await collectPackageImports(root, projectPaths)
   const htmlImports = ['react', 'react-dom', 'react/jsx-runtime', 'react-dom/client']
-  const tailwindSourceUrl = getTailwindBrowserUrl(dependencies, cdn, false)
+  const tailwindBuildUrls = getTailwindBuildUrls(dependencies, cdn)
   const sourceUrls = new Set([
     ...htmlImports.map(resolveSourceModule),
     ...[...packageImports].map(resolveSourceModule),
     ...(devjarRuntime ? [resolveSourceRuntimeModule('es-module-lexer')] : []),
-    ...(tailwindSourceUrl ? [tailwindSourceUrl] : []),
   ])
   const vendored = await vendorModules({
     moduleUrls: [...sourceUrls],
@@ -765,6 +772,18 @@ export async function buildProject(options: BuildOptions) {
     : Object.fromEntries([...discovered.routes.keys()].map(route => (
         [route, { head: '', markup: '', styles: '' }]
       )))
+  const tailwindCss = tailwindBuildUrls
+    ? await compileTailwind({
+        root,
+        projectPaths,
+        renderedMarkup: Object.values(renderedRoutes).map(route => route.markup),
+        compilerUrl: tailwindBuildUrls.compiler,
+        stylesheetUrl: tailwindBuildUrls.stylesheet,
+      })
+    : undefined
+  const tailwindStylesheetUrl = tailwindCss
+    ? builtAssetUrl('tailwind.css', tailwindCss, base)
+    : undefined
   await rm(outDir, { recursive: true, force: true })
   await mkdir(outDir, { recursive: true })
   await copyPublicFiles(join(root, 'public'), outDir)
@@ -773,9 +792,8 @@ export async function buildProject(options: BuildOptions) {
     await writeRouteHtml(outDir, route, renderedRoutes[route], {
       resolveModule: resolveBuiltModule,
       resolveRuntimeModule: resolveBuiltRuntimeModule,
-      tailwindUrl: tailwindSourceUrl
-        ? vendored.moduleUrl(tailwindSourceUrl, base)
-        : undefined,
+      tailwindUrl: undefined,
+      tailwindStylesheetUrl,
       base,
       devjarRuntime,
     })
@@ -786,6 +804,9 @@ export async function buildProject(options: BuildOptions) {
   const projectAssetsRoot = join(outDir, '_jar/assets')
   await mkdir(modulesRoot, { recursive: true })
   await mkdir(projectAssetsRoot, { recursive: true })
+  if (tailwindCss) {
+    await writeFile(join(projectAssetsRoot, staticAssetName('tailwind.css', tailwindCss)), tailwindCss)
+  }
   for (const projectPath of projectPaths) {
     if (isStaticAsset(projectPath)) {
       const contents = await readFile(join(root, projectPath))

--- a/src/cli/tailwind-build.ts
+++ b/src/cli/tailwind-build.ts
@@ -1,0 +1,94 @@
+import { execFile } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { extname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+import { sourceExtensions } from '../project'
+
+type CompileTailwindOptions = {
+  root: string
+  projectPaths: Set<string>
+  renderedMarkup: string[]
+  compilerUrl: string
+  stylesheetUrl: string
+}
+
+type TailwindInput = {
+  candidates: string[]
+  compilerUrl: string
+  stylesheetUrl: string
+  outputPath: string
+}
+
+const runFile = promisify(execFile)
+const quotedValues = [
+  /"((?:\\[\s\S]|[^"\\])*)"/g,
+  /'((?:\\[\s\S]|[^'\\])*)'/g,
+  /`((?:\\[\s\S]|[^`\\])*)`/g,
+]
+
+function addCandidates(candidates: Set<string>, value: string) {
+  for (const candidate of value.split(/\s+/)) {
+    if (candidate && !candidate.includes('${')) candidates.add(candidate)
+  }
+}
+
+export function extractTailwindCandidates(source: string) {
+  // Tailwind validates candidates itself, so collecting quoted source values
+  // covers static JSX and conditional class strings without a separate parser.
+  const candidates = new Set<string>()
+  for (const pattern of quotedValues) {
+    for (const match of source.matchAll(pattern)) addCandidates(candidates, match[1])
+  }
+  return candidates
+}
+
+function nodeExecutable() {
+  const versions = process.versions as NodeJS.ProcessVersions & { bun?: string }
+  return versions.bun ? 'node' : process.execPath
+}
+
+function renderError(error: unknown) {
+  if (!(error instanceof Error)) return String(error)
+  const stderr = (error as Error & { stderr?: string }).stderr?.trim()
+  return stderr || error.message
+}
+
+export async function compileTailwind(options: CompileTailwindOptions) {
+  const candidates = new Set<string>()
+  for (const projectPath of options.projectPaths) {
+    if (!sourceExtensions.includes(extname(projectPath))) continue
+    const source = await readFile(join(options.root, projectPath), 'utf8')
+    for (const candidate of extractTailwindCandidates(source)) candidates.add(candidate)
+  }
+  for (const markup of options.renderedMarkup) {
+    for (const match of markup.matchAll(/\bclass\s*=\s*(["'])(.*?)\1/gs)) {
+      addCandidates(candidates, match[2])
+    }
+  }
+
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'devjar-tailwind-'))
+  try {
+    const outputPath = join(temporaryRoot, 'tailwind.css')
+    const input: TailwindInput = {
+      candidates: [...candidates].sort(),
+      compilerUrl: options.compilerUrl,
+      stylesheetUrl: options.stylesheetUrl,
+      outputPath,
+    }
+    const inputPath = join(temporaryRoot, 'input.json')
+    await writeFile(inputPath, JSON.stringify(input))
+    const runnerPath = fileURLToPath(new URL('./tailwind-runner.mjs', import.meta.url))
+    try {
+      await runFile(nodeExecutable(), ['--no-warnings', runnerPath, inputPath], {
+        maxBuffer: 10 * 1024 * 1024,
+      })
+    } catch (error) {
+      throw new Error(`Unable to compile Tailwind CSS: ${renderError(error)}`)
+    }
+    return Buffer.from(await readFile(outputPath))
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true })
+  }
+}

--- a/src/cli/tailwind-runner.mjs
+++ b/src/cli/tailwind-runner.mjs
@@ -1,0 +1,28 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import { register } from 'node:module'
+
+const input = JSON.parse(await readFile(process.argv[2], 'utf8'))
+register(new URL('./http-loader.mjs', import.meta.url), { data: { imports: {} } })
+
+async function loadStylesheet(url) {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Unable to load ${url}: ${response.status} ${response.statusText}`)
+  }
+  return {
+    path: response.url || url,
+    base: new URL('.', response.url || url).href,
+    content: await response.text(),
+  }
+}
+
+const tailwind = await import(input.compilerUrl)
+if (typeof tailwind.compile !== 'function') {
+  throw new Error(`Tailwind compiler is missing from ${input.compilerUrl}`)
+}
+const stylesheet = await loadStylesheet(input.stylesheetUrl)
+const compiler = await tailwind.compile(stylesheet.content, {
+  base: stylesheet.base,
+  loadStylesheet: (id, base) => loadStylesheet(new URL(id, base).href),
+})
+await writeFile(input.outputPath, compiler.build(input.candidates))

--- a/src/tailwind.ts
+++ b/src/tailwind.ts
@@ -1,15 +1,36 @@
 import { createEsmShResolver } from './cdn'
 
+function tailwindBrowserVersion(dependencies: Record<string, string>) {
+  return dependencies['@tailwindcss/browser'] || dependencies.tailwindcss
+}
+
+function tailwindCompilerVersion(dependencies: Record<string, string>) {
+  return dependencies.tailwindcss || dependencies['@tailwindcss/browser']
+}
+
 export function getTailwindBrowserUrl(
   dependencies: Record<string, string>,
   cdn: string,
   development: boolean,
 ) {
-  const version = dependencies['@tailwindcss/browser'] || dependencies.tailwindcss
+  const version = tailwindBrowserVersion(dependencies)
   if (!version) return
   return createEsmShResolver(
     { '@tailwindcss/browser': version },
     cdn,
     development,
   )('@tailwindcss/browser')
+}
+
+export function getTailwindBuildUrls(
+  dependencies: Record<string, string>,
+  cdn: string,
+) {
+  const version = tailwindCompilerVersion(dependencies)
+  if (!version) return
+  const resolveModule = createEsmShResolver({ tailwindcss: version }, cdn, false)
+  return {
+    compiler: resolveModule('tailwindcss'),
+    stylesheet: resolveModule('tailwindcss/index.css'),
+  }
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -13,7 +13,8 @@ import {
 import { CDN_HOST, createEsmShResolver } from '../src/cdn'
 import { createIframeRouteManifest, linkModules } from '../src/core'
 import { collectProjectFiles, compileProjectModule } from '../src/cli/modules'
-import { getTailwindBrowserUrl } from '../src/tailwind'
+import { getTailwindBrowserUrl, getTailwindBuildUrls } from '../src/tailwind'
+import { extractTailwindCandidates } from '../src/cli/tailwind-build'
 import { testCdnModule } from '../scripts/test-cdn'
 import { normalizeBase, withBase, withoutBase } from '../src/project'
 
@@ -234,6 +235,38 @@ describe('project loading', () => {
       'https://modules.example.test/@tailwindcss/browser@%5E4.1.0',
     )
     expect(getTailwindBrowserUrl({}, CDN_HOST, true)).toBeUndefined()
+  })
+
+  test('uses the project Tailwind version for production compilation', () => {
+    expect(getTailwindBuildUrls(
+      { '@tailwindcss/browser': '^4.1.0' },
+      'https://modules.example.test/',
+    )).toEqual({
+      compiler: 'https://modules.example.test/tailwindcss@%5E4.1.0',
+      stylesheet: 'https://modules.example.test/tailwindcss@%5E4.1.0/index.css',
+    })
+    expect(getTailwindBuildUrls(
+      { '@tailwindcss/browser': '4.1.0', tailwindcss: '4.2.0' },
+      'https://modules.example.test/',
+    )?.compiler).toBe('https://modules.example.test/tailwindcss@4.2.0')
+    expect(getTailwindBuildUrls({}, CDN_HOST)).toBeUndefined()
+  })
+
+  test('collects static Tailwind candidates from component source', () => {
+    const candidates = extractTailwindCandidates(`
+      <main className="grid content-['hello_world'] sm:grid-cols-2">
+        <aside className={open ? 'block' : 'hidden'} />
+        <div className={\`flex \${active ? 'bg-green-500' : 'bg-red-500'} text-white\`} />
+      </main>
+    `)
+    expect(candidates).toContain('grid')
+    expect(candidates).toContain("content-['hello_world']")
+    expect(candidates).toContain('sm:grid-cols-2')
+    expect(candidates).toContain('block')
+    expect(candidates).toContain('hidden')
+    expect(candidates).toContain('bg-green-500')
+    expect(candidates).toContain('bg-red-500')
+    expect(candidates).toContain('text-white')
   })
 
   test('rewrites dynamic local imports as module URLs', async () => {
@@ -533,7 +566,8 @@ describe('production build', () => {
     expect(builtHtml).toContain('<title data-devjar-default>Devjar</title>')
     expect(builtHtml).toContain('<meta name="devjar-base" content="/preview/">')
     expect(builtHtml).toContain('src="/preview/_jar/client.js"')
-    expect(builtHtml).toContain('data-devjar-tailwind')
+    expect(builtHtml).toMatch(/<link data-devjar-tailwind rel="stylesheet" href="\/preview\/_jar\/assets\/tailwind-[a-f0-9]{10}\.css">/)
+    expect(builtHtml).not.toContain('<script data-devjar-tailwind')
     expect(builtHtml).not.toContain('react-refresh')
     expect(builtHtml).not.toContain('jsx-dev-runtime')
     expect(builtHtml).not.toContain('?dev')
@@ -544,7 +578,12 @@ describe('production build', () => {
     expect(runtimeFiles).toContain('vendor')
     expect(runtimeFiles).not.toContain('runtime.js')
     expect(runtimeFiles).not.toContain('transform-assets.json')
-    expect(await readdir(join(buildRoot, '_jar/assets'))).toEqual([])
+    const assetFiles = await readdir(join(buildRoot, '_jar/assets'))
+    expect(assetFiles).toHaveLength(1)
+    expect(assetFiles[0]).toMatch(/^tailwind-[a-f0-9]{10}\.css$/)
+    const tailwindCss = await readFile(join(buildRoot, '_jar/assets', assetFiles[0]), 'utf8')
+    expect(tailwindCss).toContain('hover:bg-white')
+    expect(tailwindCss).toContain('shadow-[3px_3px_0_#1c1917]')
     expect(await readFile(join(buildRoot, 'api/projects.json'), 'utf8')).toContain('Mobile refresh')
     expect(await readFile(join(buildRoot, 'mark.svg'), 'utf8')).toContain('<svg')
   })


### PR DESCRIPTION
## Summary

- compile Tailwind utilities once during production builds using the project Tailwind version
- collect candidates from project source and prerendered route markup
- emit a hashed immutable stylesheet and remove the production browser compiler
- keep the Tailwind browser runtime for development and inner Devjar previews
- add no new npm dependencies

## Validation

- pnpm typecheck
- pnpm test
- pnpm test:package
- pnpm demo:build
- pnpm build:website
- Chromium verification: local stylesheet applied, no Tailwind runtime script, and no external Tailwind request