### PR TITLE
feat: refine website experience

### DIFF
--- a/API.md
+++ b/API.md
@@ -15,11 +15,11 @@ pnpm add devjar
 
 ### `<DevJar />`
 
-```tsx
+```jsx
 import { DevJar } from 'devjar'
 
 const files = {
-  'pages/index.tsx': `export default function Page() {
+  'pages/index.jsx': `export default function Page() {
     return <h1>Hello world</h1>
   }`,
 }
@@ -43,14 +43,14 @@ Props:
 
 Page files, shared modules, and CSS use project-relative paths:
 
-```ts
+```js
 const files = {
-  'pages/index.tsx': `import '../styles.css'
+  'pages/index.jsx': `import '../styles.css'
 import { Button } from '../components/button'
 export default function Page() {
   return <Button>Save</Button>
 }`,
-  'components/button.tsx': `export function Button({ children }) {
+  'components/button.jsx': `export function Button({ children }) {
   return <button className="button">{children}</button>
 }`,
   'styles.css': `.button { font: inherit; }`,
@@ -65,7 +65,7 @@ a built-in 404 page unless the project provides `pages/404.*`.
 
 Lower-level hook used by `<DevJar />`.
 
-```tsx
+```jsx
 import { useLiveCode } from 'devjar'
 import { useEffect } from 'react'
 

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ directory:
 my-prototype/
 ├── package.json
 ├── pages/
-│   ├── index.tsx
-│   └── about.tsx
+│   ├── index.jsx
+│   └── about.jsx
 ├── components/
-│   └── card.tsx
+│   └── card.jsx
 ├── api/
 │   ├── status.json
 │   └── message.txt
@@ -171,11 +171,11 @@ The pages directory maps directly to URLs:
 
 | File | URL |
 | --- | --- |
-| `pages/index.tsx` | `/` |
-| `pages/about.tsx` | `/about` |
-| `pages/docs/index.tsx` | `/docs` |
-| `pages/docs/start.tsx` | `/docs/start` |
-| `pages/404.tsx` | unmatched routes |
+| `pages/index.jsx` | `/` |
+| `pages/about.jsx` | `/about` |
+| `pages/docs/index.jsx` | `/docs` |
+| `pages/docs/start.jsx` | `/docs/start` |
+| `pages/404.jsx` | unmatched routes |
 
 Pages can import local JavaScript, TypeScript, JSX, TSX, and CSS files. Image,
 font, audio, video, and PDF imports export their public URL, and relative

--- a/site/components/codesandbox.css
+++ b/site/components/codesandbox.css
@@ -41,13 +41,11 @@ textarea:focus-visible {
   position: absolute;
   inset: 0;
   z-index: 2;
-  display: grid;
-  grid-template-columns: minmax(0, 0.82fr) minmax(240px, 1.18fr);
+  display: flex;
   align-items: center;
-  gap: 20px;
-  padding: 18px;
+  justify-content: center;
   background: #f7f7f7;
-  color: #171717;
+  color: #a3a3a3;
   pointer-events: none;
   opacity: 1;
   transition: opacity 0.32s ease, visibility 0.32s ease;
@@ -58,154 +56,48 @@ textarea:focus-visible {
   visibility: hidden;
 }
 
-.preview--loading-copy {
-  max-width: 360px;
-  min-width: 0;
-  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
-  color: #171717;
+.preview--loading-ascii {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
 }
 
-.preview--loading-kicker {
+.preview--loading-frames {
   position: relative;
-  margin: 0;
-  color: transparent;
-  font-size: 0.75rem;
-  font-weight: 700;
-  line-height: 1.45;
+  width: 10ch;
+  height: 1.5em;
+  color: #737373;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.preview--loading-frames > span {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  animation: preview-ascii-frame 1.12s steps(1, end) infinite;
+}
+
+.preview--loading-frames > span:nth-child(2) { animation-delay: -0.98s; }
+.preview--loading-frames > span:nth-child(3) { animation-delay: -0.84s; }
+.preview--loading-frames > span:nth-child(4) { animation-delay: -0.7s; }
+.preview--loading-frames > span:nth-child(5) { animation-delay: -0.56s; }
+.preview--loading-frames > span:nth-child(6) { animation-delay: -0.42s; }
+.preview--loading-frames > span:nth-child(7) { animation-delay: -0.28s; }
+.preview--loading-frames > span:nth-child(8) { animation-delay: -0.14s; }
+
+.preview--loading-label {
+  color: #a3a3a3;
+  font-size: 0.625rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-.preview--loading-copy h1 {
-  margin: 0 0 10px;
-  color: #171717;
-  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
-  font-size: clamp(2.25rem, 7cqw, 4.25rem);
-  font-weight: 700;
-  line-height: 0.92;
-}
-
-.preview--loading-button {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-top: 18px;
-  border: 1px solid #d4d4d4;
-  border-radius: 999px;
-  padding: 10px 16px;
-  background: #ffffff;
-  color: transparent;
-  font: inherit;
-  font-weight: 700;
-  line-height: 1.25;
-  height: calc(1.25em + 22px);
-  cursor: default;
-}
-
-.preview--loading-noise {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  color: #a3a3a3;
-  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-  font-variant-ligatures: none;
-  letter-spacing: 0;
-  opacity: 0.72;
-  white-space: pre;
-  pointer-events: none;
-}
-
-.preview--loading-measure {
-  position: relative;
-  display: inline-block;
-  color: transparent;
-}
-
-.preview--loading-cell {
-  flex: 0 0 1ch;
-  overflow: hidden;
-  text-align: center;
-}
-
-.preview--loading-cell.is-space {
-  opacity: 0;
-}
-
-.preview--loading-kicker .preview--loading-noise {
-  color: #737373;
-  opacity: 0.68;
-}
-
-.preview--loading-button .preview--loading-noise {
-  inset: 0;
-  color: #a3a3a3;
-  opacity: 0.72;
-  overflow: hidden;
-}
-
-.preview--loading-art {
-  position: relative;
-  margin: 0;
-  width: 100%;
-  height: 100%;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 18px;
-  border: 1px solid #e5e5e5;
-  border-radius: 8px;
-  background: #fbfbfb;
-  color: #737373;
-  overflow: hidden;
-  opacity: 0.7;
-  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-  font-size: clamp(0.72rem, 1.45cqw, 1rem);
-  font-weight: 300;
-  line-height: 1.34;
-  letter-spacing: 0;
-  white-space: pre;
-  text-align: left;
-  font-variant-ligatures: none;
-}
-
-.preview--loading-art::after {
-  content: '';
-  position: absolute;
-  inset: 18px;
-  background:
-    linear-gradient(90deg, transparent 0 7px, rgba(212, 212, 212, 0.42) 7px 8px),
-    linear-gradient(0deg, transparent 0 7px, rgba(212, 212, 212, 0.28) 7px 8px);
-  background-size: 8px 8px;
-  opacity: 0.16;
-  pointer-events: none;
-}
-
-.preview--loading-art span {
-  position: relative;
-  z-index: 1;
-  display: block;
-  width: max-content;
-  white-space: pre;
-}
-
-.preview--loading-art span:nth-child(7),
-.preview--loading-art span:nth-child(8),
-.preview--loading-art span:nth-child(11),
-.preview--loading-art span:nth-child(12) {
-  opacity: 0.62;
-}
-
-.preview--loading-art span:nth-child(3),
-.preview--loading-art span:nth-child(5),
-.preview--loading-art span:nth-child(7),
-.preview--loading-art span:nth-child(8),
-.preview--loading-art span:nth-child(12) {
-  color: #a3a3a3;
+@keyframes preview-ascii-frame {
+  0%, 12.49% { opacity: 1; }
+  12.5%, 100% { opacity: 0; }
 }
 
 .codesandbox-layout {
@@ -439,7 +331,7 @@ textarea:focus-visible {
 
 [data-codesandbox="react"] .preview {
   width: 100%;
-  min-height: 440px;
+  min-height: 340px;
   border-top: 0;
   background: #f5f5f4;
 }
@@ -450,8 +342,8 @@ textarea:focus-visible {
 }
 
 [data-codesandbox="react"] .codesandbox-layout {
-  width: min(960px, calc(100% - 1rem));
-  height: 360px;
+  width: min(840px, calc(100% - 1rem));
+  height: 320px;
   margin: 0 auto;
   flex: none;
   overflow: hidden;
@@ -461,23 +353,17 @@ textarea:focus-visible {
   box-shadow: 0 12px 36px 4px rgb(200 200 200 / 45%);
 }
 
-@media (max-width: 760px) {
-  .preview--loading {
-    grid-template-columns: 1fr;
-    gap: 18px;
-    padding: 16px;
-  }
-
-  .preview--loading-art {
-    height: auto;
-    min-height: 220px;
-    font-size: clamp(0.68rem, 2.85cqw, 0.9rem);
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
   .preview--loading,
   .preview--result {
     transition: none;
+  }
+
+  .preview--loading-frames > span {
+    animation: none;
+  }
+
+  .preview--loading-frames > span:first-child {
+    opacity: 1;
   }
 }

--- a/site/components/codesandbox.tsx
+++ b/site/components/codesandbox.tsx
@@ -41,46 +41,15 @@ function getDisplayName(filename: string): string {
   return normalized + '.js'
 }
 
-const loaderChars = '░▒▓█▄▀■□▪▫'
-
-function loaderChar(index: number, frame: number) {
-  return loaderChars[(index * 17 + frame * 11) % loaderChars.length]
-}
-
-function scrambleText(text: string, frame: number) {
-  let index = 0
-  return text.replace(/\S/g, () => loaderChar(index++, frame))
-}
-
-function scrambleTemplate(template: string, frame: number) {
-  let index = 0
-  return template.replace(/x/g, () => loaderChar(index++, frame))
-}
-
-function renderLoaderCells(text: string, frame: number) {
-  return Array.from(scrambleText(text, frame), (char, index) => (
-    <span className={char === ' ' ? 'preview--loading-cell is-space' : 'preview--loading-cell'} key={index}>
-      {char === ' ' ? '\u00a0' : char}
-    </span>
-  ))
-}
-
-const previewFallbackArtTemplate = [
-  '           DEVJAR             ',
-  '  .------------------------.  ',
-  ' /  xxxxxx        xxxxxxx  /| ',
-  '+------------------------+  | ',
-  '| xxxxxxxx               |  | ',
-  '|                        |  | ',
-  '|  xxxxxxxxxxxxxxxxxx    |  | ',
-  '|  xxxxxxxxxxxxxx        |  | ',
-  '|                        |  | ',
-  '|  .------------------.  |  | ',
-  '|  |                  |  |  | ',
-  '|  |    xxxxxxxxxx    |  |  | ',
-  '|  |                  |  |  | ',
-  '|  +------------------+  | /  ',
-  '+------------------------+    ',
+const previewLoaderFrames = [
+  '[■·······]',
+  '[·■······]',
+  '[··■·····]',
+  '[···■····]',
+  '[····■···]',
+  '[·····■··]',
+  '[······■·]',
+  '[·······■]',
 ]
 
 export function Codesandbox({
@@ -106,9 +75,9 @@ export function Codesandbox({
   const [deletingItems, setDeletingItems] = useState<Set<string>>(new Set())
   const previewRef = useRef<HTMLDivElement>(null)
   const iframeRef = useRef<HTMLIFrameElement>(null)
-  const [previewHeight, setPreviewHeight] = useState(440)
+  const editorLayoutRef = useRef<HTMLDivElement>(null)
+  const [previewHeight, setPreviewHeight] = useState(340)
   const [previewReady, setPreviewReady] = useState(false)
-  const [loaderFrame, setLoaderFrame] = useState(0)
   const activeExtension = activeFile?.split('.').pop() || ''
   const projectFolders = [...new Set([
     ...folders,
@@ -120,13 +89,15 @@ export function Codesandbox({
   ])]
 
   useEffect(() => {
-    if (previewReady) return
-    const interval = window.setInterval(() => {
-      setLoaderFrame((frame) => (frame + 1) % 997)
-    }, 120)
+    const handleEditRequest = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow) return
+      if (event.data !== 'devjar:edit-demo') return
+      editorLayoutRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
 
-    return () => window.clearInterval(interval)
-  }, [previewReady])
+    window.addEventListener('message', handleEditRequest)
+    return () => window.removeEventListener('message', handleEditRequest)
+  }, [])
 
   useEffect(() => {
     const iframe = iframeRef.current
@@ -148,7 +119,7 @@ export function Codesandbox({
         doc.body?.offsetHeight || 0,
         doc.documentElement?.scrollHeight || 0,
         doc.documentElement?.offsetHeight || 0,
-        440
+        340
       ))
 
       setPreviewHeight(nextHeight)
@@ -276,26 +247,12 @@ export function Codesandbox({
     <div data-codesandbox="react">
       <div className="preview" ref={previewRef} style={{ height: previewHeight }}>
         <div className={previewReady ? 'preview--loading is-hidden' : 'preview--loading'} aria-hidden="true">
-          <div className="preview--loading-copy">
-            <h1>DEVJAR</h1>
-            <p className="preview--loading-kicker">
-              <span className="preview--loading-measure">
-                React Live Preview in browser
-                <span className="preview--loading-noise">{renderLoaderCells('React Live Preview in browser', loaderFrame)}</span>
-              </span>
-            </p>
-            <button className="preview--loading-button" type="button" tabIndex={-1}>
-              <span className="preview--loading-measure">
-                WIGGLE
-                <span className="preview--loading-noise">{renderLoaderCells('WIGGLE', loaderFrame + 2)}</span>
-              </span>
-            </button>
+          <div className="preview--loading-ascii">
+            <span className="preview--loading-frames">
+              {previewLoaderFrames.map((frame) => <span key={frame}>{frame}</span>)}
+            </span>
+            <span className="preview--loading-label">rendering preview</span>
           </div>
-          <pre className="preview--loading-art">
-            {previewFallbackArtTemplate.map((line, index) => (
-              <span key={index}>{scrambleTemplate(line, loaderFrame + index)}</span>
-            ))}
-          </pre>
         </div>
         <DevJar
           className={'preview--result ' + (previewReady ? 'is-ready' : '')}
@@ -308,7 +265,7 @@ export function Codesandbox({
           resolveModule={resolveModule}
         />
       </div>
-      <div className="codesandbox-layout">
+      <div className="codesandbox-layout" ref={editorLayoutRef}>
         <div className="filetree">
           <div className="filetree-root">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" className="react-icon">

--- a/site/lib/demo-files.ts
+++ b/site/lib/demo-files.ts
@@ -7,97 +7,171 @@ function source(parts: TemplateStringsArray) {
 
   return lines.map((line) => line.slice(indentation)).join('\n').trimEnd()
 }
+
 export const demoFiles = {
   'pages/index.jsx': source`\
-  import { useState } from 'react'
-  import { art } from '../components/ascii'
+  import Intro from '../components/intro'
+  import Routes from '../components/routes'
   import '../styles.css'
 
-  const site = {
-    name: 'DEVJAR',
-    cta: 'WIGGLE',
-    accent: '#525252',
-  }
-
-  export default function App() {
-    const [refreshes, setRefreshes] = useState(0)
-
+  export default function Page() {
     return (
-      <div className="page" style={{ '--accent': site.accent }}>
+      <div className="page">
         <main>
-          <section className="copy">
-            <h1>{site.name}</h1>
-            <p className="eyebrow">React Live Preview in browser</p>
-            <button type="button" onClick={() => setRefreshes((count) => count + 1)}>
-              {site.cta}
-            </button>
-          </section>
-
-          <pre className={refreshes > 0 ? 'ascii is-shuffling' : 'ascii'} aria-label="Devjar preview">
-            <code key={refreshes}>
-              {art.map((line, index) => (
-                <span className="ascii-line" key={index}>{line}</span>
-              ))}
-            </code>
-          </pre>
+          <Intro
+            name="devjar"
+            title="Prototype with React."
+            description={
+              'CDN dependencies while developing. ' +
+              'Prerendered static pages when you build.'
+            }
+            action="Edit"
+          />
+          <Routes
+            routes={[
+              { file: '├── index.tsx', path: '/' },
+              { file: '├── about.tsx', path: '/about' },
+              {
+                file: '└── docs/\\n    └── start.tsx',
+                path: '/docs/start',
+              },
+            ]}
+          />
         </main>
       </div>
     )
   }`,
-  'components/ascii.js': source`\
-  const copy = {
-    title: 'DEVJAR',
-    editorLabel: 'editor',
-    previewLabel: 'preview',
-    filename: 'pages/index.jsx',
-    codeLine: 'const title = "Ship"',
-    renderLine: 'return <Demo />',
-    resultLabel: 'live result',
-    actionLabel: '[ Button ]',
+  'components/intro.jsx': source`\
+  export default function Intro({ name, title, description, action }) {
+    function editDemo() {
+      window.parent.postMessage('devjar:edit-demo', '*')
+    }
+
+    return (
+      <section className="intro">
+        <p className="eyebrow">{name}</p>
+        <h1>{title}</h1>
+        <p className="description">{description}</p>
+        <p className="edit-prompt">
+          <span className="edit-pointer" aria-hidden="true">→</span>
+          <a
+            href="#editor"
+            onClick={(event) => {
+              event.preventDefault()
+              editDemo()
+            }}
+          >
+            {action}
+          </a>
+          <span> this demo</span>
+        </p>
+      </section>
+    )
+  }`,
+  'components/routes.jsx': source`\
+  import { useEffect, useState } from 'react'
+
+  const pixels = '░▒▓█▄▀■□▪▫'
+  const lowPixels = '·.ˑ'
+
+  function TerminalIcon() {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <path d="m2 4 4 4-4 4M8 12h6" />
+      </svg>
+    )
   }
 
-  function fit(value, width) {
-    return String(value).slice(0, width)
+  function BrowserIcon() {
+    return (
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <rect x="1.5" y="2.5" width="13" height="11" rx="2" />
+        <path d="M2 6h12" />
+        <circle cx="4" cy="4.25" r=".5" />
+      </svg>
+    )
   }
 
-  function left(value, width) {
-    return fit(value, width).padEnd(width, ' ')
+  function transformCharacter(character, column, row, frame) {
+    const wave = (frame % 48) - 8 + Math.sin(row * 1.35) * 2.4
+    const distance = Math.abs(column - wave)
+    if (distance > 2.2) return character
+
+    if (character === ' ') {
+      return lowPixels[(frame + column + row) % lowPixels.length]
+    }
+    return pixels[(frame * 7 + column * 3 + row * 11) % pixels.length]
   }
 
-  function center(value, width) {
-    const text = fit(value, width)
-    const before = Math.floor((width - text.length) / 2)
-    const after = width - text.length - before
-    return ' '.repeat(before) + text + ' '.repeat(after)
-  }
+  export default function Routes({ routes }) {
+    const [frame, setFrame] = useState(0)
 
-  function codeLine(value) {
-    return '|  ' + left(value, 22) + '|  | '
-  }
+    useEffect(() => {
+      const timer = setInterval(() => {
+        setFrame((current) => current + 1)
+      }, 80)
 
-  function previewLine(value) {
-    return '|  |' + center(value, 18) + '|  |  | '
-  }
+      return () => clearInterval(timer)
+    }, [])
 
-  const art = [
-    center(copy.title, 30),
-    '  .------------------------.  ',
-    ' /  ' + left(copy.editorLabel, 6) + '        ' + left(copy.previewLabel, 7) + '  /| ',
-    '+------------------------+  | ',
-    '| ' + left(copy.filename, 23) + '|  | ',
-    '|                        |  | ',
-    codeLine(copy.codeLine),
-    codeLine(copy.renderLine),
-    '|                        |  | ',
-    '|  .------------------.  |  | ',
-    previewLine(copy.resultLabel),
-    previewLine(copy.actionLabel),
-    '|  |                  |  |  | ',
-    '|  +------------------+  | /  ',
-    '+------------------------+    ',
-  ]
-
-  export { art }`,
+    return (
+      <section className="route-demo" aria-label="File routes">
+        <div className="route-heading">
+          <TerminalIcon />
+          <BrowserIcon />
+        </div>
+        <div className="route-map">
+          <code className="route-root">pages/</code>
+          {routes.map((route, row) => (
+            <div className="route-row" key={route.path}>
+              <code className="route-source">
+                {route.file.split('\\n').map((line, lineIndex) => (
+                  <span className="route-source-line" key={line}>
+                    {Array.from(line).map((character, column) => {
+                      const transformed = transformCharacter(
+                        character,
+                        column,
+                        row + lineIndex * 0.5,
+                        frame,
+                      )
+                      return (
+                        <span
+                          className={transformed === character ? '' : 'pixel'}
+                          key={column}
+                        >
+                          {transformed}
+                        </span>
+                      )
+                    })}
+                  </span>
+                ))}
+              </code>
+              <span className="route-arrow" aria-hidden="true">→</span>
+              <code className="browser-route" aria-label={route.path}>
+                {Array.from(route.path).map((character, column) => {
+                  const transformed = transformCharacter(
+                    character,
+                    column + 22,
+                    row,
+                    frame,
+                  )
+                  return (
+                    <span
+                      className={transformed === character ? '' : 'pixel'}
+                      key={column}
+                      aria-hidden="true"
+                    >
+                      {transformed}
+                    </span>
+                  )
+                })}
+              </code>
+            </div>
+          ))}
+        </div>
+      </section>
+    )
+  }`,
   'styles.css': source`\
   * {
     box-sizing: border-box;
@@ -109,197 +183,236 @@ export const demoFiles = {
     font-family: Inter, ui-sans-serif, system-ui, sans-serif;
     color: #171717;
     background: #f7f7f7;
-    overflow-x: hidden;
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-  }
-
-  html::-webkit-scrollbar,
-  body::-webkit-scrollbar {
-    display: none;
-    width: 0;
-    height: 0;
   }
 
   .page {
-    display: flex;
-    flex-direction: column;
     min-height: 100vh;
     padding: 18px;
-    overflow-x: hidden;
     background: #f7f7f7;
   }
 
   main {
-    flex: 1;
-    min-height: 0;
+    width: min(960px, 100%);
+    min-height: calc(100vh - 36px);
     display: grid;
-    grid-template-columns: minmax(0, 0.82fr) minmax(240px, 1.18fr);
-    gap: 20px;
+    grid-template-columns: minmax(0, 0.86fr) minmax(300px, 1.14fr);
+    gap: 30px;
     align-items: center;
+    margin: 0 auto;
   }
 
-  .copy {
-    max-width: 360px;
+  .intro {
+    max-width: 400px;
     min-width: 0;
   }
 
   .eyebrow {
-    margin: 0;
-    color: var(--accent);
-    font-size: 0.75rem;
+    margin: 0 0 12px;
+    color: #737373;
+    font-size: 0.7rem;
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
   }
 
   h1 {
-    margin: 0 0 10px;
-    font-size: clamp(2.25rem, 7vw, 4.25rem);
-    font-weight: 700;
-    line-height: 0.92;
+    margin: 0;
+    color: #404040;
+    font-size: clamp(1.75rem, 3.5vw, 2.75rem);
+    font-weight: 600;
+    letter-spacing: -0.035em;
+    line-height: 1.02;
   }
 
-  p {
-    margin: 0;
+  .description {
+    max-width: 350px;
+    margin: 18px 0 0;
     color: #57534e;
-    font-size: 0.95rem;
-    line-height: 1.45;
+    font-size: 0.9rem;
+    line-height: 1.5;
   }
 
-  button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    margin-top: 18px;
-    border: 1px solid #d4d4d4;
-    border-radius: 999px;
-    padding: 10px 16px;
-    background: #ffffff;
-    color: #171717;
-    font: inherit;
-    font-weight: 700;
-    line-height: 1.25;
-    height: calc(1.25em + 22px);
-    cursor: pointer;
-    transition: background 0.15s ease, border-color 0.15s ease;
-  }
-
-  button:hover,
-  button:focus-visible {
-    border-color: #a3a3a3;
-    background: #f5f5f5;
-  }
-
-  button:active {
-    border-color: #a3a3a3;
-    background: #eeeeee;
-  }
-
-  .ascii {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-    min-height: 0;
+  .edit-prompt {
     display: flex;
     align-items: center;
-    justify-content: center;
-    padding: 18px;
+    gap: 5px;
+    margin: 18px 0 0;
+    color: #737373;
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  .edit-prompt a {
+    color: #404040;
+    background: linear-gradient(
+      105deg,
+      #404040 35%,
+      #fafafa 48%,
+      #404040 61%
+    );
+    background-clip: text;
+    background-size: 250% 100%;
+    color: transparent;
+    font-weight: 700;
+    text-decoration-color: #404040;
+    text-underline-offset: 3px;
+    animation: edit-shine 2.4s ease-in-out infinite;
+  }
+
+  .edit-pointer {
+    color: #737373;
+    animation: point-to-edit 1s ease-in-out infinite;
+  }
+
+  @keyframes point-to-edit {
+    50% { transform: translateX(3px); }
+  }
+
+  @keyframes edit-shine {
+    0%, 55% { background-position: 100% 0; }
+    100% { background-position: -100% 0; }
+  }
+
+  .route-demo {
+    width: min(440px, 100%);
+    justify-self: end;
+    overflow: hidden;
     border: 1px solid #e5e5e5;
     border-radius: 8px;
-    background: #fbfbfb;
-    color: #404040;
+    background: transparent;
+  }
+
+  .route-heading {
+    min-height: 42px;
+    display: grid;
+    grid-template-columns: 180px 10px max-content;
+    align-items: center;
+    justify-content: start;
+    gap: 5px;
+    padding: 14px 24px 0;
+    color: #737373;
+    font-size: 0.7rem;
+    font-weight: 600;
+  }
+
+  .route-heading svg {
+    width: 14px;
+    height: 14px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.2;
+  }
+
+  .route-heading svg:last-child {
+    grid-column: 3;
+    justify-self: start;
+  }
+
+  .route-heading circle {
+    fill: currentColor;
+    stroke: none;
+  }
+
+  .route-map {
+    min-height: 120px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 12px 24px 18px;
     overflow: hidden;
+    color: #737373;
+    font-family: SFMono-Regular, Consolas, 'Liberation Mono',
+      Menlo, monospace;
+    font-size: clamp(0.72rem, 1.65vw, 0.95rem);
+    font-weight: 500;
+    line-height: 1.65;
   }
 
-  .ascii code {
+  .route-root {
     display: block;
-    max-width: 100%;
-    max-height: 100%;
-    font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-    font-size: clamp(0.72rem, 1.45vw, 1rem);
-    font-weight: 400;
-    line-height: 1.34;
-    letter-spacing: 0;
-    white-space: pre;
-    tab-size: 2;
-    text-align: left;
-    font-variant-ligatures: none;
-    overflow: visible;
+    margin-bottom: 4px;
+    color: #404040;
+    font-weight: 700;
   }
 
-  .ascii-line {
-    display: block;
-    white-space: pre;
+  .route-row {
+    display: grid;
+    grid-template-columns: 180px 10px max-content;
+    align-items: end;
+    justify-content: start;
+    gap: 5px;
+  }
+
+  .route-source {
+    min-width: 0;
+    color: #737373;
     font: inherit;
   }
 
-  .ascii.is-shuffling .ascii-line:nth-child(7),
-  .ascii.is-shuffling .ascii-line:nth-child(8),
-  .ascii.is-shuffling .ascii-line:nth-child(11),
-  .ascii.is-shuffling .ascii-line:nth-child(12) {
-    animation: shuffle-line 0.58s cubic-bezier(0.22, 1, 0.36, 1);
-    will-change: transform, opacity;
+  .route-source-line {
+    display: block;
+    white-space: pre;
   }
 
-  .ascii.is-shuffling .ascii-line:nth-child(8),
-  .ascii.is-shuffling .ascii-line:nth-child(12) {
-    animation-delay: 0.06s;
+  .route-source-line > span {
+    display: inline-block;
+    width: 1ch;
+    text-align: center;
   }
 
-  @keyframes shuffle-line {
-    0% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-
-    22% {
-      opacity: 0.58;
-      transform: translateX(1ch);
-    }
-
-    44% {
-      opacity: 0.86;
-      transform: translateX(-0.72ch);
-    }
-
-    66% {
-      opacity: 0.7;
-      transform: translateX(0.38ch);
-    }
-
-    100% {
-      opacity: 1;
-      transform: translateX(0);
-    }
+  .route-arrow {
+    color: #a3a3a3;
   }
 
-  .ascii::selection,
-  .ascii code::selection {
-    background: #e5e5e5;
-    color: #171717;
+  .browser-route {
+    min-width: 0;
+    color: #57534e;
+    font: inherit;
+    white-space: nowrap;
+  }
+
+  .browser-route > span {
+    display: inline-block;
+    width: 1ch;
+    text-align: center;
   }
 
   @media (max-width: 760px) {
     .page {
       min-height: 100vh;
-      height: auto;
-      overflow: auto;
       padding: 16px;
     }
 
     main {
+      min-height: auto;
       grid-template-columns: 1fr;
-      gap: 18px;
+      gap: 28px;
     }
 
-    .ascii {
-      height: auto;
-      min-height: 220px;
+    .intro {
+      padding-top: 12px;
     }
 
-    .ascii code {
-      font-size: clamp(0.68rem, 2.85vw, 0.9rem);
+    .route-map {
+      min-height: 115px;
+      padding: 10px 16px 16px;
+      font-size: clamp(0.67rem, 3.1vw, 0.85rem);
+    }
+
+    .route-heading {
+      padding: 14px 16px 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.01ms !important;
+      transition-duration: 0.01ms !important;
+    }
+
+    .edit-prompt a {
+      background: none;
+      color: #404040;
     }
   }
   `,

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -2,7 +2,7 @@ import { Codesandbox } from '../components/codesandbox'
 import { demoFiles } from '../lib/demo-files'
 import '../styles.css'
 
-const description = 'React Live Preview in Browser'
+const description = 'Turn a folder of React pages into a self-contained static site.'
 const socialImage = '/og-image.png'
 
 export default function Page() {
@@ -18,11 +18,72 @@ export default function Page() {
       <meta name="twitter:image" content={socialImage} />
       <link rel="icon" href="/icon.svg" type="image/svg+xml" />
       <main>
+        <section className="intro-section">
+          <nav className="intro-links" aria-label="Project links">
+            <a href="https://github.com/huozhi/devjar" target="_blank" rel="noopener noreferrer">
+              GitHub
+            </a>
+            <a href="https://x.com/huozhi" target="_blank" rel="noopener noreferrer">
+              X
+            </a>
+          </nav>
+          <h1>devjar</h1>
+          <p className="intro-copy">Zero-dependency React prototyping.</p>
+        </section>
+
         <div className="playground-container">
           <div className="playground-wrapper">
             <Codesandbox files={demoFiles} />
           </div>
         </div>
+
+        <section className="usage-section" aria-labelledby="build-heading">
+          <div className="usage-content">
+            <h2 id="build-heading">Build a site without the setup</h2>
+            <p className="section-intro">
+              Devjar keeps the project structure simple and handles the production details for you.
+            </p>
+
+            <div className="section">
+              <h3>Routes from files</h3>
+              <p>Files inside <code>pages/</code> become routes, including nested pages and a custom 404.</p>
+              <div className="code-block" aria-label="Example project structure">
+                <pre><code>{`pages/
+├── index.jsx       → /
+├── about.jsx       → /about
+└── docs/
+    └── start.jsx   → /docs/start`}</code></pre>
+              </div>
+            </div>
+
+            <div className="section">
+              <h3>Self-contained production builds</h3>
+              <p>
+                Routes are prerendered to HTML. Dependencies are vendored, and imported assets and Tailwind CSS are emitted with content hashes.
+              </p>
+            </div>
+
+            <div className="section">
+              <h3>Three commands</h3>
+              <p>Develop locally, create the static output, then preview exactly what you will deploy.</p>
+              <div className="code-block" aria-label="Devjar commands">
+                <pre><code>{`npx devjar dev
+npx devjar build
+npx devjar start`}</code></pre>
+              </div>
+            </div>
+
+            <div className="section section-links">
+              <h3>Ready for any static host</h3>
+              <p>
+                Deploy the generated files at the domain root or use <code>--base</code> for a subdirectory.
+              </p>
+              <a href="https://github.com/huozhi/devjar#cli" target="_blank" rel="noopener noreferrer">
+                Read the CLI documentation →
+              </a>
+            </div>
+          </div>
+        </section>
       </main>
       <footer>
         <nav className="site-footer" aria-label="Footer links">

--- a/site/styles.css
+++ b/site/styles.css
@@ -106,6 +106,60 @@ footer {
   color: #fff;
 }
 
+.intro-section {
+  position: relative;
+  width: 100%;
+  max-width: 680px;
+  margin: 5rem auto 4rem;
+  padding: 0 0.5rem;
+  color: #171717;
+}
+
+.intro-links {
+  position: absolute;
+  top: 0;
+  right: 0.5rem;
+  display: flex;
+  gap: 0.875rem;
+  color: #737373;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+}
+
+.intro-links a {
+  text-decoration: none;
+}
+
+.intro-links a:hover {
+  color: #171717;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.intro-section h1 {
+  max-width: 620px;
+  margin: 0;
+  color: #171717;
+  font-size: clamp(2.5rem, 7vw, 4.25rem);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+}
+
+.intro-copy {
+  max-width: 580px;
+  margin: 1.25rem 0 0;
+  color: #57534e;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.section-links a {
+  color: #404756;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-underline-offset: 3px;
+}
 
 .playground-container {
   display: flex;
@@ -114,6 +168,13 @@ footer {
   justify-content: flex-start;
   width: 100%;
   padding: 0 0 2rem;
+}
+
+.section-intro {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9375rem;
+  line-height: 1.6;
 }
 
 .playground-wrapper {
@@ -140,7 +201,8 @@ footer {
   margin: 0 0 1rem 0;
 }
 
-.usage-example h3 {
+.usage-example h3,
+.section h3 {
   font-size: 18px;
   font-weight: 500;
   color: #404756;
@@ -154,9 +216,16 @@ footer {
   margin: 1.5rem 0 0.75rem 0;
 }
 
-.usage-example p {
+.usage-example p,
+.section p {
   color: #6b7280;
   margin: 0 0 1rem 0;
+  line-height: 1.6;
+}
+
+.section p code {
+  color: #404756;
+  font-size: 0.875em;
 }
 
 .code-block {
@@ -214,12 +283,27 @@ footer {
   padding: 32px 0;
 }
 
+.section:last-child {
+  border-bottom: 0;
+}
+
 @media (max-width: 640px) {
   main {
     padding: 0 0.5rem;
   }
   footer {
     padding: 0 0.5rem 2rem;
+  }
+  .intro-section {
+    margin: 3.5rem auto 3rem;
+    padding: 0 0.5rem;
+  }
+  .intro-section h1 {
+    font-size: clamp(2.5rem, 13vw, 3.5rem);
+  }
+  .usage-section {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
   }
   .site-footer {
     align-items: flex-start;

--- a/src/cli/client.tsx
+++ b/src/cli/client.tsx
@@ -25,7 +25,7 @@ function getRoot(id: string) {
 }
 
 const hostRoot = getRoot('root')
-const errorRoot = getRoot('__jarError')
+const errorRoot = document.getElementById('__jarError')
 
 function getBase() {
   const base = document.querySelector<HTMLMetaElement>('meta[name="devjar-base"]')?.content
@@ -135,11 +135,17 @@ function errorMessage(error: unknown) {
 }
 
 function showError(error: unknown) {
-  errorRoot.textContent = errorMessage(error)
+  const message = errorMessage(error)
+  if (!errorRoot) {
+    console.error(message)
+    return
+  }
+  errorRoot.textContent = message
   errorRoot.hidden = false
 }
 
 function hideError() {
+  if (!errorRoot) return
   errorRoot.hidden = true
   errorRoot.textContent = ''
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -237,11 +237,8 @@ await import(${JSON.stringify(withBase(options.base, '/_jar/client.js'))})
   const documentHead = /<title(?:\s|>)/i.test(options.head)
     ? options.head
     : `<title data-devjar-default>Devjar</title>${options.head}`
-  return `<!doctype html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<meta name="devjar-base" content="${options.base}">${documentHead}${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
-<style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:1px solid #ffb4ab;border-radius:8px;background:#330a08;color:#ffdad6;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}</style>${staticStyles}
-${tailwindStylesheet}</head><body><div id="root"><div id="__reactRoot">${options.content}</div></div><pre id="__jarError" class="devjar-error" hidden></pre><script>
+  const errorOverlay = options.liveReload
+    ? `<pre id="__jarError" class="devjar-error" hidden></pre><script>
 const errorRoot = document.getElementById('__jarError')
 const showBootstrapError = value => {
   errorRoot.hidden = false
@@ -249,7 +246,16 @@ const showBootstrapError = value => {
 }
 addEventListener('error', event => showBootstrapError(event.message || 'A browser module failed to load'))
 addEventListener('unhandledrejection', event => showBootstrapError(event.reason?.stack || event.reason || 'An asynchronous module failed'))
-</script>${tailwindScript}${clientScript}</body></html>`
+</script>`
+    : ''
+  const errorStyles = options.liveReload
+    ? '.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 16px 16px;padding:14px 16px;border:0;border-radius:8px;background:#fff7f6;box-shadow:0 8px 30px rgba(0,0,0,.12);color:#9f2d20;font:13px/1.5 ui-monospace,monospace;white-space:pre-wrap}'
+    : ''
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="devjar-base" content="${options.base}">${documentHead}${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
+<style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}${errorStyles}</style>${staticStyles}
+${tailwindStylesheet}</head><body><div id="root"><div id="__reactRoot">${options.content}</div></div>${errorOverlay}${tailwindScript}${clientScript}</body></html>`
 }
 
 const contentTypes: Record<string, string> = {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -350,6 +350,7 @@ describe('dev server', () => {
     expect(shellSource).toContain('https://esm.sh/@tailwindcss/browser@%5E4.1.0')
     expect(shellSource).toContain('Devjar could not start')
     expect(shellSource).toContain(`Devjar could not start:\\n\\n`)
+    expect(shellSource).toContain('id="__jarError"')
     expect(shellSource).not.toContain('<iframe')
     expect(await (await fetch(`${base}/about`, { method: 'HEAD' })).text()).toBe('')
     const bootstrap = shellSource.match(/<script>\n([\s\S]+?)<\/script>/)?.[1]
@@ -694,6 +695,8 @@ export default function Page() {
       })
       expect(result.devjarRuntime).toBe(true)
       const document = await readFile(join(result.outDir, 'index.html'), 'utf8')
+      expect(document).not.toContain('__jarError')
+      expect(document).not.toContain('devjar-error')
       expect(document).toContain('<head><meta charset="utf-8"')
       expect(document).toContain('<title>Static title</title><meta name="description" content="Static description">')
       expect(document).not.toContain('<div id="__reactRoot"><title>')


### PR DESCRIPTION
## Summary
- expand the homepage with concise product and deployment guidance
- refine the interactive demo, loading state, editor handoff, and route animation
- keep the development error overlay out of production builds
- use JSX in user-facing examples

## Checks
- pnpm typecheck
- pnpm test
- pnpm build:website