### PR TITLE
fix: support transform workers in Safari

### DIFF
--- a/scripts/build-workers.ts
+++ b/scripts/build-workers.ts
@@ -10,6 +10,12 @@ const distDirectory = join(root, 'dist')
 const assetsDirectory = join(distDirectory, 'assets')
 const stagingDirectory = await mkdtemp(join(tmpdir(), 'devjar-transform-assets-'))
 
+function replaceRequired(source: string, search: string, replacement: string, description: string) {
+  const contents = source.replace(search, replacement)
+  if (contents === source) throw new Error(`Unable to patch ${description}`)
+  return contents
+}
+
 try {
   const result = await Bun.build({
     entrypoints: [
@@ -28,19 +34,56 @@ try {
         setup(build) {
           build.onLoad({ filter: /transform\.wasi-browser\.js$/ }, async ({ path }) => {
             const source = await Bun.file(path).text()
-            const contents = source
-              .replace(
-                "new URL('./transform.wasm32-wasi.wasm', import.meta.url).href",
-                'globalThis.__devjarOxcWasmUrl',
-              )
-              .replace(
-                "new URL('@oxc-transform/binding-wasm32-wasi/wasi-worker-browser.mjs', import.meta.url)",
-                'globalThis.__devjarOxcWasiWorkerUrl',
-              )
+            const wasmContents = replaceRequired(
+              source,
+              "new URL('./transform.wasm32-wasi.wasm', import.meta.url).href",
+              'globalThis.__devjarOxcWasmUrl',
+              'Oxc WASM asset URL',
+            )
+            const contents = replaceRequired(
+              wasmContents,
+              "new URL('@oxc-transform/binding-wasm32-wasi/wasi-worker-browser.mjs', import.meta.url)",
+              'globalThis.__devjarOxcWasiWorkerUrl',
+              'Oxc WASI worker asset URL',
+            )
 
-            if (contents === source) {
-              throw new Error('Unable to patch Oxc browser asset URLs')
-            }
+            return { contents, loader: 'js' }
+          })
+
+          build.onLoad({ filter: /@emnapi\/wasi-threads\/dist\/wasi-threads\.js$/ }, async ({ path }) => {
+            const source = await Bun.file(path).text()
+            // Safari cannot clone a compiled WebAssembly.Module to a worker.
+            // Send the clone-safe asset URL and compile it in each WASI worker.
+            const contents = replaceRequired(
+              source,
+              'wasmModule: this.wasmModule,',
+              'wasmModule: globalThis.__devjarOxcWasmUrl ?? this.wasmModule,',
+              'Oxc WASM worker payload',
+            )
+
+            return { contents, loader: 'js' }
+          })
+
+          build.onLoad({ filter: /wasi-worker-browser\.mjs$/ }, async ({ path }) => {
+            const source = await Bun.file(path).text()
+            const contents = replaceRequired(
+              source,
+              `  onLoad({ wasmModule, wasmMemory }) {
+    const wasi`,
+              `  async onLoad({ wasmModule, wasmMemory }) {
+    if (typeof wasmModule === 'string') {
+      const response = await fetch(wasmModule)
+      if (!response.ok) {
+        throw new Error(
+          \`devjar: Failed to load WASM module: \${response.status} \${response.statusText}\`,
+        )
+      }
+      wasmModule = await response.arrayBuffer()
+    }
+
+    const wasi`,
+              'Oxc WASI worker module loader',
+            )
 
             return { contents, loader: 'js' }
           })

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -160,7 +160,8 @@ export async function loadRouteManifest(
 
 const isolationHeaders = {
   'Cross-Origin-Opener-Policy': 'same-origin',
-  'Cross-Origin-Embedder-Policy': 'credentialless',
+  // Safari does not support COEP credentialless, which leaves SharedArrayBuffer unavailable.
+  'Cross-Origin-Embedder-Policy': 'require-corp',
 }
 const noStore = 'no-store'
 const immutableAsset = 'public, max-age=31536000, immutable'

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -342,7 +342,7 @@ describe('dev server', () => {
     const shell = await fetch(`${base}/about`)
     expect(shell.status).toBe(200)
     expect(shell.headers.get('cross-origin-opener-policy')).toBe('same-origin')
-    expect(shell.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
+    expect(shell.headers.get('cross-origin-embedder-policy')).toBe('require-corp')
     const shellSource = await shell.text()
     expect(shellSource).toContain('/_jar/client.js')
     expect(shellSource).toContain("import * as RefreshModule from 'react-refresh/runtime'")
@@ -397,8 +397,12 @@ describe('dev server', () => {
     expect(transformAssets.wasm).toMatch(/^assets\/transform\.wasm32-wasi-[a-z0-9]+\.wasm$/)
     const worker = await fetch(`${base}/_jar/${transformAssets.worker}`)
     expect(worker.headers.get('content-type')).toContain('text/javascript')
-    expect(worker.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
+    expect(worker.headers.get('cross-origin-embedder-policy')).toBe('require-corp')
     expect(worker.headers.get('cache-control')).toBe('public, max-age=31536000, immutable')
+    const binding = await (await fetch(`${base}/_jar/${transformAssets.binding}`)).text()
+    expect(binding).toContain('wasmModule: globalThis.__devjarOxcWasmUrl ?? this.wasmModule')
+    const wasiWorker = await (await fetch(`${base}/_jar/${transformAssets.wasiWorker}`)).text()
+    expect(wasiWorker).toContain('typeof wasmModule === "string"')
     const wasm = await fetch(`${base}/_jar/${transformAssets.wasm}`)
     expect(wasm.headers.get('content-type')).toBe('application/wasm')
 
@@ -737,7 +741,7 @@ export default function Page() {
         expect(builtServer.devjarRuntime).toBe(true)
         const response = await fetch(`http://${builtServer.host}:${builtServer.port}`)
         expect(response.headers.get('cross-origin-opener-policy')).toBe('same-origin')
-        expect(response.headers.get('cross-origin-embedder-policy')).toBe('credentialless')
+        expect(response.headers.get('cross-origin-embedder-policy')).toBe('require-corp')
       } finally {
         await builtServer.close()
       }

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -25,7 +25,7 @@ describe('Vercel deployment', () => {
         source: '/(.*)',
         headers: [
           { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
-          { key: 'Cross-Origin-Embedder-Policy', value: 'credentialless' },
+          { key: 'Cross-Origin-Embedder-Policy', value: 'require-corp' },
         ],
       },
     ])

--- a/vercel.json
+++ b/vercel.json
@@ -31,7 +31,7 @@
         },
         {
           "key": "Cross-Origin-Embedder-Policy",
-          "value": "credentialless"
+          "value": "require-corp"
         }
       ]
     }


### PR DESCRIPTION
## Summary

- send the WASM asset URL to nested Oxc workers instead of cloning a compiled WebAssembly module
- compile the WASM module inside each worker for Safari compatibility
- use COEP require-corp so Safari enables cross-origin isolation
- add regression coverage for deployment headers and generated worker assets

## Verification

- pnpm typecheck
- pnpm test (25 passed)
- pnpm test:package
- Playwright WebKit: live preview rendered with crossOriginIsolated enabled and no console, page, or clone errors