### PR TITLE
feat(runtime): expose preview lifecycle and runtime errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ export default function LiveExample() {
 | `resolveModule` | `(specifier: string) => string` | Optional resolver override returning browser-loadable ESM URLs |
 | `transform` | `boolean` | Default `true`; compile JSX and TypeScript in a worker |
 | `tailwind` | `boolean` | Default `true`; enable the iframe's Tailwind browser runtime |
+| `onStatusChange` | `(status: PreviewStatus) => void` | Reports lifecycle state changes |
 | `onError` | `(error: unknown) => void` | Called when error state changes; defaults to `console.error` in the browser |
 | `compiler` | `CompilerAssets` | Complete worker, binding, and WASM URL override; bypasses default asset discovery |
 | `transformWorkerUrl` | `string` or `URL` | Legacy worker-only override; uses default binding and WASM assets |
@@ -135,6 +136,20 @@ in the host's origin; it is not a security boundary for untrusted code.
 
 </details>
 
+### Preview lifecycle
+
+Use `onStatusChange` on `<DevJar>` or `status` from `useLiveCode` for a loading
+indicator. `idle` means no load has started, `compiling` covers source compilation
+and linking, and `loading` covers iframe initialization and module loading.
+`ready` means React committed the preview; it does not wait for application data,
+images, or every asynchronous effect. `failed` accompanies an error. React can
+batch rapid transitions, so callbacks are state notifications, not a phase log.
+
+`onError` also receives React render errors, uncaught iframe errors, and unhandled
+promise rejections. A new load clears the previous error (`undefined`); syntax
+errors leave the previous preview visible. Handle both status and error to explain
+a loading or failed preview. The iframe's native `onLoad` is not preview readiness.
+
 ### useLiveCode hook
 
 Use `useLiveCode` when you want to own the iframe and decide when a project runs.
@@ -173,7 +188,8 @@ export default function ManualPreview() {
 | Return value | Meaning |
 | --- | --- |
 | `ref` | Attach to the iframe that will run the project |
-| `error` | Current runtime error, if any |
+| `error` | Current compilation, loading, or runtime error, if any |
+| `status` | `idle`, `compiling`, `loading`, `ready`, or `failed` |
 | `load(files)` | Load or update the virtual project; returns `Promise<void>` |
 
 </details>

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -216,20 +216,19 @@ export default function Counter() {
   const [count, setCount] = useState<number>(0)
   return <button onClick={() => setCount(count + 1)}>Hello {content.name} {text} {count}</button>
 }`
-  await writeFile(join(projectRoot, 'pages/playground.tsx'), `import { useState } from 'react'
+  await writeFile(join(projectRoot, 'pages/playground.tsx'), `import { useMemo, useState } from 'react'
 import { DevJar } from 'devjar'
 const initial = ${JSON.stringify(source)}
 export default function Playground() {
   const [code, setCode] = useState(initial)
   const [error, setError] = useState('')
+  const [status, setStatus] = useState('idle')
+  const files = useMemo(() => ({ 'pages/index.tsx': code, 'content.json': '{"name":"Devjar"}', 'message.txt': 'works' }), [code])
   return <main>
     <textarea aria-label="Code" value={code} onChange={event => setCode(event.target.value)} />
     <pre role="status">{error}</pre>
-    <DevJar title="Live preview" tailwind={false} onError={error => setError(error ? String(error) : '')} files={{
-      'pages/index.tsx': code,
-      'content.json': '{"name":"Devjar"}',
-      'message.txt': 'works',
-    }} />
+    <output aria-label="Preview status">{status}</output>
+    <DevJar title="Live preview" tailwind={false} onStatusChange={setStatus} onError={error => setError(error ? String(error) : '')} files={files} />
   </main>
 }`)
   await run(devjar, ['build', '--base', '/preview/'], projectRoot)
@@ -253,6 +252,14 @@ export default function Playground() {
   await preview.waitForFunction(() => document.querySelector('[role="status"]')?.textContent?.includes('Unexpected token'))
   await preview.getByRole('textbox', { name: 'Code' }).fill(source.replace('Hello', 'Recovered'))
   await frame.getByRole('button', { name: 'Recovered Devjar works 1' }).waitFor()
+  await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
+  await preview.getByRole('textbox', { name: 'Code' }).fill('export default function Broken() { throw new Error("Render failed") }')
+  await preview.getByLabel('Preview status').filter({ hasText: 'failed' }).waitFor()
+  await preview.waitForFunction(() => document.querySelector('[role="status"]')?.textContent?.includes('Render failed'))
+  await preview.getByRole('textbox', { name: 'Code' }).fill(source)
+  await frame.getByRole('button', { name: 'Hello Devjar works 0' }).waitFor()
+  await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
+  assert.equal(await preview.getByRole('status').textContent(), '')
   assert.deepEqual(previewErrors, [])
   console.log('Packaged static export and live DevJar compilation, JSON/text imports, Refresh state preservation, and error recovery passed without isolation headers.')
 

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -259,7 +259,7 @@ export default function Playground() {
   await preview.getByRole('textbox', { name: 'Code' }).fill(source)
   await frame.getByRole('button', { name: /^Hello Devjar works \d+$/ }).waitFor()
   await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
-  assert.equal(await preview.getByRole('status').textContent(), '')
+  assert.equal(await preview.locator('pre[role="status"]').textContent(), '')
   assert.deepEqual(previewErrors, [])
   console.log('Packaged static export and live DevJar compilation, JSON/text imports, Refresh state preservation, and error recovery passed without isolation headers.')
 

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -257,7 +257,7 @@ export default function Playground() {
   await preview.getByLabel('Preview status').filter({ hasText: 'failed' }).waitFor()
   await preview.waitForFunction(() => document.querySelector('[role="status"]')?.textContent?.includes('Render failed'))
   await preview.getByRole('textbox', { name: 'Code' }).fill(source)
-  await frame.getByRole('button', { name: 'Hello Devjar works 0' }).waitFor()
+  await frame.getByRole('button', { name: /^Hello Devjar works \d+$/ }).waitFor()
   await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
   assert.equal(await preview.getByRole('status').textContent(), '')
   assert.deepEqual(previewErrors, [])

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -37,12 +37,16 @@ export default function Preview() {
 To update a preview, replace the edited file's string in a new files object.
 Keep files and custom resolver functions stable between unrelated renders.
 DevJar accepts ordinary iframe props and a ref. Relevant options include
-onError, dependencies (package versions), resolveModule (an ESM URL resolver),
+onError, onStatusChange, dependencies (package versions), resolveModule (an ESM URL resolver),
 tailwind (defaults to true), transform (defaults to true), and compiler
 ({ workerUrl, bindingUrl, wasmUrl }) for a complete asset URL override.
 
-useLiveCode returns { ref, load, error }. Attach ref to an iframe and call
+useLiveCode returns { ref, load, error, status }. Attach ref to an iframe and call
 load(files) when the project should run. load returns a promise.
+status (or the component's onStatusChange) reports idle, compiling, loading,
+ready, or failed. ready means React committed, not that application data is loaded.
+onError reports compilation, module loading, React render errors, uncaught iframe
+errors, and unhandled rejections. A new load clears the previous error.
 
 Embedded previews compile in a browser worker using non-shared WebAssembly.
 No cross-origin isolation headers or server-side compiler are required.

--- a/src/core.ts
+++ b/src/core.ts
@@ -427,6 +427,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
       }
 
       if (result?.changed) {
+        const recovering = Boolean(errorBoundary?.state.error)
         errorBoundary?.reset()
         const refreshRuntime = moduleRuntime.refreshRuntime
         if (!refreshRuntime) throw new Error('devjar: refresh runtime was not initialized')
@@ -435,7 +436,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
           ? refreshRuntime._getMountedRootCount()
           : 0
 
-        if (!refreshUpdate || mountedRootCount === 0) {
+        if (recovering || !refreshUpdate || mountedRootCount === 0) {
           revision++
           reactRoot.render(_jsx(
             ErrorBoundary!,
@@ -619,12 +620,17 @@ function useLiveCode({
     }
     const onRuntimeError = (event: ErrorEvent) => reportError(event.error || new Error(event.message))
     const onRejection = (event: PromiseRejectionEvent) => reportError(event.reason)
-    const onReactError = (event: Event) => reportError((event as CustomEvent).detail)
+    const onReactError = (event: Event) => {
+      setError((event as CustomEvent).detail)
+      setStatus('failed')
+    }
     const frameWindow = iframe.contentWindow!
     frameWindow.addEventListener('error', onRuntimeError)
     frameWindow.addEventListener('unhandledrejection', onRejection)
     doc.addEventListener('devjar:error', onReactError)
+    let resolveScript: (() => void) | undefined
     scriptReadyRef.current = new Promise<void>((resolve, reject) => {
+      resolveScript = resolve
       appScript.onload = () => resolve()
       appScript.onerror = () => reject(new Error('devjar: application script failed to load'))
     })
@@ -643,6 +649,7 @@ function useLiveCode({
       body.removeChild(appScript)
       if (tailwindScript) body.removeChild(tailwindScript)
       resolveTailwind?.()
+      resolveScript?.()
     }
   }, [])
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -9,6 +9,8 @@ import { init, parse } from 'es-module-lexer'
 import { createPreviewResolver } from './cdn'
 import { routeFromPagePath, sourceExtensions } from './project'
 
+export type PreviewStatus = 'idle' | 'compiling' | 'loading' | 'ready' | 'failed'
+
 type ResolveModule = (specifier: string) => string
 export type IframeRouteManifest = {
   routes: Record<string, string>
@@ -298,6 +300,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
   let rendererModules: Promise<[
     typeof import('react'),
     typeof import('react-dom/client'),
+    typeof import('react-dom'),
   ]> | undefined
   let renderRequestId = 0
   let renderQueue = Promise.resolve()
@@ -340,9 +343,10 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
       rendererModules = Promise.all([
         import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ reactModuleUrl),
         import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ reactDomModuleUrl),
+        import(/* webpackIgnore: true */ /* turbopackIgnore: true */ /* @vite-ignore */ resolveModule('react-dom')),
       ])
     }
-    const [ReactMod, ReactDOMMod] = await rendererModules
+    const [ReactMod, ReactDOMMod, { flushSync }] = await rendererModules
     if (requestId !== renderRequestId) return
 
     const _jsx = ReactMod.createElement
@@ -376,6 +380,9 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
         reset() {
           if (this.state.error) this.setState({ error: null })
         }
+        componentDidCatch(error: unknown) {
+          document.dispatchEvent(new CustomEvent('devjar:error', { detail: error }))
+        }
         componentDidUpdate(previousProps: ErrorBoundaryProps) {
           if (previousProps.revision !== this.props.revision && this.state.error) {
             this.setState({ error: null })
@@ -393,49 +400,52 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
       }
     }
 
-    if (!reactRoot) {
-      reactRoot = ReactDOMMod.createRoot(root)
-      revision++
-      reactRoot.render(_jsx(
-        ErrorBoundary,
-        { revision, ref: setErrorBoundaryRef },
-        _jsx(App)
-      ))
-      renderedEntry = renderedPage
-      moduleRuntime.hasRendered = true
-      return
-    }
-
-    if (renderedEntry !== renderedPage) {
-      revision++
-      renderedEntry = renderedPage
-      errorBoundary?.reset()
-      reactRoot.render(_jsx(
-        ErrorBoundary,
-        { revision, ref: setErrorBoundaryRef },
-        _jsx(App)
-      ))
-      return
-    }
-
-    if (result?.changed) {
-      errorBoundary?.reset()
-      const refreshRuntime = moduleRuntime.refreshRuntime
-      if (!refreshRuntime) throw new Error('devjar: refresh runtime was not initialized')
-      const refreshUpdate = refreshRuntime.performReactRefresh()
-      const mountedRootCount = typeof refreshRuntime._getMountedRootCount === 'function'
-        ? refreshRuntime._getMountedRootCount()
-        : 0
-
-      if (!refreshUpdate || mountedRootCount === 0) {
+    flushSync(() => {
+      if (!reactRoot) {
+        reactRoot = ReactDOMMod.createRoot(root)
         revision++
         reactRoot.render(_jsx(
-          ErrorBoundary,
+          ErrorBoundary!,
           { revision, ref: setErrorBoundaryRef },
           _jsx(App)
         ))
+        renderedEntry = renderedPage
+        moduleRuntime.hasRendered = true
+        return
       }
-    }
+
+      if (renderedEntry !== renderedPage) {
+        revision++
+        renderedEntry = renderedPage
+        errorBoundary?.reset()
+        reactRoot.render(_jsx(
+          ErrorBoundary!,
+          { revision, ref: setErrorBoundaryRef },
+          _jsx(App)
+        ))
+        return
+      }
+
+      if (result?.changed) {
+        errorBoundary?.reset()
+        const refreshRuntime = moduleRuntime.refreshRuntime
+        if (!refreshRuntime) throw new Error('devjar: refresh runtime was not initialized')
+        const refreshUpdate = refreshRuntime.performReactRefresh()
+        const mountedRootCount = typeof refreshRuntime._getMountedRootCount === 'function'
+          ? refreshRuntime._getMountedRootCount()
+          : 0
+
+        if (!refreshUpdate || mountedRootCount === 0) {
+          revision++
+          reactRoot.render(_jsx(
+            ErrorBoundary!,
+            { revision, ref: setErrorBoundaryRef },
+            _jsx(App)
+          ))
+        }
+      }
+    })
+    if (errorBoundary?.state.error) throw errorBoundary.state.error
   }
 
   function render(
@@ -509,7 +519,7 @@ function createScript(
   const script = scriptRef.current || document.createElement('script')
   scriptRef.current = script
   if (type) script.type = type
-  
+
   if (content) {
     script.src = `data:text/javascript;utf-8,${encodeURIComponent(content)}`
   }
@@ -540,13 +550,15 @@ function useLiveCode({
   )
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
   const [error, setError] = useState<unknown>()
-  const rerender = useState({})[1]
+  const [status, setStatus] = useState<PreviewStatus>('idle')
   const appScriptRef = useScript()
   const tailwindcssScriptRef = useScript()
   const tailwindReadyRef = useRef<Promise<void>>(Promise.resolve())
   const transformClientRef = useRef<{ url: string; client: TransformClient } | undefined>(undefined)
   const transformCacheRef = useRef(new Map<string, { source: string, code: string }>())
   const loadIdRef = useRef(0)
+  const runtimeFailureRef = useRef<number | undefined>(undefined)
+  const scriptReadyRef = useRef<Promise<void>>(Promise.resolve())
   const uid = useId()
 
   // Let resolveModule execute on parent window side since it might involve
@@ -577,14 +589,14 @@ function useLiveCode({
   useEffect(() => {
     const iframe = iframeRef.current
     if (!iframe || !iframe.contentDocument) return
-    
+
     const doc = iframe.contentDocument
     const body = doc.body
     const div = document.createElement('div')
     div.id = '__reactRoot'
-    
+
     const appScriptContent = createMainScript({ uid })
-    
+
     const appScript = createScript(appScriptRef, { content: appScriptContent })
     const tailwindScript = tailwind
       ? createScript(tailwindcssScriptRef, { src: tailwindSrc })
@@ -600,12 +612,33 @@ function useLiveCode({
         })
       : Promise.resolve()
 
+    const reportError = (error: unknown) => {
+      runtimeFailureRef.current = loadIdRef.current
+      setError(error)
+      setStatus('failed')
+    }
+    const onRuntimeError = (event: ErrorEvent) => reportError(event.error || new Error(event.message))
+    const onRejection = (event: PromiseRejectionEvent) => reportError(event.reason)
+    const onReactError = (event: Event) => reportError((event as CustomEvent).detail)
+    const frameWindow = iframe.contentWindow!
+    frameWindow.addEventListener('error', onRuntimeError)
+    frameWindow.addEventListener('unhandledrejection', onRejection)
+    doc.addEventListener('devjar:error', onReactError)
+    scriptReadyRef.current = new Promise<void>((resolve, reject) => {
+      appScript.onload = () => resolve()
+      appScript.onerror = () => reject(new Error('devjar: application script failed to load'))
+    })
+    // A load may start after the script fails; keep the rejection observable then.
+    void scriptReadyRef.current.catch(() => {})
     body.appendChild(div)
     if (tailwindScript) body.appendChild(tailwindScript)
     body.appendChild(appScript)
-    
+
     return () => {
       if (!iframe || !iframe.contentDocument) return
+      frameWindow.removeEventListener('error', onRuntimeError)
+      frameWindow.removeEventListener('unhandledrejection', onRejection)
+      doc.removeEventListener('devjar:error', onReactError)
       body.removeChild(div)
       body.removeChild(appScript)
       if (tailwindScript) body.removeChild(tailwindScript)
@@ -624,6 +657,8 @@ function useLiveCode({
 
   const load = useCallback(async (files: Record<string, string>) => {
     const loadId = ++loadIdRef.current
+    setError(undefined)
+    setStatus('compiling')
 
     try {
       const resolveModuleForLoad = resolveModule
@@ -667,48 +702,30 @@ function useLiveCode({
       const linked = await linkModules(transformedSources, resolveModuleForLoad, files)
       if (loadId !== loadIdRef.current) return
 
+      setStatus('loading')
+      await Promise.all([tailwindReadyRef.current, scriptReadyRef.current])
+      if (loadId !== loadIdRef.current) return
       const iframe = iframeRef.current
-      const script = appScriptRef.current
-      if (iframe) {
-        const contentWindow = iframe.contentWindow
-        if (!contentWindow) throw new Error('devjar: iframe window is unavailable')
-        const renderFiles = async () => {
-          await tailwindReadyRef.current
-          if (loadId !== loadIdRef.current) return
-          const render = contentWindow.__render__
-          if (!render) throw new Error('devjar: renderer was not initialized')
-          await render(linked.files, linked.dependencies, manifest)
-          if (loadId === loadIdRef.current) {
-            iframe.dispatchEvent(new CustomEvent('devjar:render'))
-          }
-        }
-
-        const render = contentWindow.__render__
-        if (render) {
-          await renderFiles()
-        } else {
-          // if render is not loaded yet, wait until it's loaded
-          if (!script) throw new Error('devjar: application script was not initialized')
-          script.onload = () => {
-            renderFiles().catch((err) => {
-              if (loadId === loadIdRef.current) setError(err)
-            })
-          }
-        }
-      }
-      if (loadId === loadIdRef.current) setError(undefined)
+      const render = iframe?.contentWindow?.__render__
+      if (!render) throw new Error('devjar: renderer was not initialized')
+      await render(linked.files, linked.dependencies, manifest)
+      if (loadId !== loadIdRef.current) return
+      if (runtimeFailureRef.current === loadId) return
+      setError(undefined)
+      setStatus('ready')
+      iframe.dispatchEvent(new CustomEvent('devjar:render'))
     } catch (e) {
       if (loadId !== loadIdRef.current) return
       console.warn(e)
       setError(e)
+      setStatus('failed')
     }
-    rerender({})
   }, [resolveModule, transform, transformFiles])
 
-  return { ref: iframeRef, error, load }
+  return { ref: iframeRef, error, status, load }
 }
 
-export { 
+export {
   createModule,
   createIframeRouteManifest,
   createRenderer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { useLiveCode } from './core'
 export { DevJar } from './render'
 export type { CompilerAssets } from './compiler'
+export type { PreviewStatus } from './core'

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useImperativeHandle, useRef } from 'react'
-import { useLiveCode } from './core'
+import { useLiveCode, type PreviewStatus } from './core'
 import type { CompilerAssets } from './compiler'
 
 const defaultOnError: (error: unknown) => void = typeof window !== 'undefined'
@@ -13,6 +13,7 @@ export function DevJar({
   transform,
   tailwind,
   onError = defaultOnError,
+  onStatusChange,
   transformWorkerUrl,
   compiler,
   ref: forwardedRef,
@@ -23,19 +24,27 @@ export function DevJar({
   dependencies?: Record<string, string>
   transform?: boolean
   tailwind?: boolean
+  onStatusChange?: (status: PreviewStatus) => void
   onError?: (error: unknown) => void
   transformWorkerUrl?: string | URL
   compiler?: CompilerAssets
   ref?: React.Ref<HTMLIFrameElement>
 } & React.IframeHTMLAttributes<HTMLIFrameElement>) {
   const onErrorRef = useRef(onError)
-  const { ref, error, load } = useLiveCode({ resolveModule, dependencies, transform, tailwind, transformWorkerUrl, compiler })
+  const onStatusRef = useRef(onStatusChange)
+  onErrorRef.current = onError
+  onStatusRef.current = onStatusChange
+  const { ref, error, status, load } = useLiveCode({ resolveModule, dependencies, transform, tailwind, transformWorkerUrl, compiler })
 
   useImperativeHandle(forwardedRef, () => ref.current!, [ref])
 
   useEffect(() => {
     onErrorRef.current(error)
   }, [error])
+
+  useEffect(() => {
+    onStatusRef.current?.(status)
+  }, [status])
 
   // load code files and execute them as live code
   useEffect(() => {


### PR DESCRIPTION
Embedded playgrounds cannot distinguish compilation, dependency loading, and a committed preview, and React render failures currently stay inside the iframe.

Expose `status` from `useLiveCode` and `onStatusChange` on `DevJar` (`idle`, `compiling`, `loading`, `ready`, `failed`). Report ready after React commits while preserving Fast Refresh state. Forward React render failures, uncaught iframe errors, and unhandled rejections to the host, and recover readiness after a valid edit. Document the contract in the README and agent reference.

Validation: typecheck, source tests, package check, and website build passed on the completed stack. Chromium and WebKit packaged-browser tests cover state preservation, syntax/render errors, and recovery; Next.js development and production embedding tests passed.

First of three stacked PRs; scheduling and reset build on this lifecycle contract.
