### PR TITLE
fix(runtime): skip superseded preview updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@
 - Use `docs`, `test`, `ci`, `chore`, and `style` for maintenance. Do not label visual polish as a core feature. Release notes include core `feat`, `fix`, and `perf` changes; breaking changes must use `!` or a `BREAKING CHANGE:` footer.
 - Write subjects as concise user-facing outcomes. If the subject needs implementation detail, add a one-line `Release-note: ...` footer with the public summary. Do not rewrite published history to retrofit these conventions.
 
+## Pull requests
+
+- When changing a public API, include a short code snippet in the PR description showing how to use the new feature or a before/after code diff showing the change for callers.
+
 ## TypeScript and API design
 
 - Avoid optional parameters and default arguments when callers can pass values explicitly.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ in the host's origin; it is not a security boundary for untrusted code.
 
 </details>
 
+### Scheduling edits
+
+Pass a new `files` object for each edit, keeping the object stable for unrelated
+renders. Devjar starts updates immediately; it does not impose a typing debounce.
+Use a host-side debounce if you want fewer updates, or call the hook's `load(files)`
+from a Run button for explicit scheduling.
+
+Each preview runs one load at a time and retains only the newest pending edit.
+Superseded pending loads are skipped, and their `load()` promises resolve without
+rendering. Work already executing (including synchronous WASM compilation and
+browser module imports) is allowed to finish; stale results and compilation errors
+are discarded at the load's asynchronous checkpoints. This does not roll back
+module side effects or a React commit that already happened.
+
+Incomplete source reports an error while leaving the last successful preview
+visible. The next valid edit clears the error and uses Fast Refresh where possible.
+`load()` resolves after completion or supersession; load failures are reported via
+`error`/`onError` and `status`, rather than rejecting that promise. Supersession is
+not an error. Unmounting discards pending edits and releases the compiler client.
+
 ### Preview lifecycle
 
 Use `onStatusChange` on `<DevJar>` or `status` from `useLiveCode` for a loading

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -36,6 +36,12 @@ export default function Preview() {
 
 To update a preview, replace the edited file's string in a new files object.
 Keep files and custom resolver functions stable between unrelated renders.
+Updates start immediately, with one active load and only the newest pending edit.
+Superseded queued edits are skipped; running compilation/imports finish and stale
+results are discarded. This cannot undo module side effects. Incomplete source
+reports an error while keeping the last successful preview. Debounce in the host
+if desired; load() promises resolve on completion or supersession, with failures
+reported through error/onError and status.
 DevJar accepts ordinary iframe props and a ref. Relevant options include
 onError, onStatusChange, dependencies (package versions), resolveModule (an ESM URL resolver),
 tailwind (defaults to true), transform (defaults to true), and compiler

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,5 @@
 import { textModuleSuffix, isTextImport, createTextModule } from './text'
+import { createLoadQueue } from './load-queue'
 import { createJsonModule } from './json'
 import { useEffect, useCallback, useState, useId, useMemo, useRef } from 'react'
 import { createModule } from './module'
@@ -557,6 +558,7 @@ function useLiveCode({
   const tailwindReadyRef = useRef<Promise<void>>(Promise.resolve())
   const transformClientRef = useRef<{ url: string; client: TransformClient } | undefined>(undefined)
   const transformCacheRef = useRef(new Map<string, { source: string, code: string }>())
+  const loadQueue = useMemo(createLoadQueue, [])
   const loadIdRef = useRef(0)
   const runtimeFailureRef = useRef<number | undefined>(undefined)
   const scriptReadyRef = useRef<Promise<void>>(Promise.resolve())
@@ -582,6 +584,7 @@ function useLiveCode({
   useEffect(() => {
     return () => {
       loadIdRef.current++
+      loadQueue.clear()
       transformClientRef.current?.client.release()
       transformClientRef.current = undefined
     }
@@ -662,16 +665,15 @@ function useLiveCode({
     return transformClientRef.current.client.transform(files)
   }, [compiler, transformWorkerUrl])
 
-  const load = useCallback(async (files: Record<string, string>) => {
-    const loadId = ++loadIdRef.current
-    setError(undefined)
-    setStatus('compiling')
+  const runLoad = useCallback(async (files: Record<string, string>, loadId: number) => {
+    if (loadId !== loadIdRef.current) return
 
     try {
       const resolveModuleForLoad = resolveModule
       const manifest = createIframeRouteManifest(files)
 
       await init
+      if (loadId !== loadIdRef.current) return
       const localFiles = new Map(Object.keys(files).map(path => [normalizeProjectPath(path), getModuleKey(path)]))
       const filenames = new Map(Object.keys(files).map(path => [getModuleKey(path), path]))
       const queue = [...Object.values(manifest.routes)]
@@ -728,6 +730,13 @@ function useLiveCode({
       setStatus('failed')
     }
   }, [resolveModule, transform, transformFiles])
+
+  const load = useCallback((files: Record<string, string>) => {
+    const loadId = ++loadIdRef.current
+    setError(undefined)
+    setStatus('compiling')
+    return loadQueue.enqueue(() => runLoad(files, loadId))
+  }, [loadQueue, runLoad])
 
   return { ref: iframeRef, error, status, load }
 }

--- a/src/load-queue.ts
+++ b/src/load-queue.ts
@@ -1,0 +1,40 @@
+// Keep one running load and one pending edit. Running work is allowed to settle;
+// the runtime's load generation checks prevent it from publishing stale results.
+export function createLoadQueue() {
+  type Job = { run: () => Promise<void>; resolve: () => void; reject: (error: unknown) => void }
+  let running = false
+  let pending: Job | undefined
+
+  async function drain() {
+    if (running) return
+    running = true
+    try {
+      while (pending) {
+        const job = pending
+        pending = undefined
+        try {
+          await job.run()
+          job.resolve()
+        } catch (error) {
+          job.reject(error)
+        }
+      }
+    } finally {
+      running = false
+    }
+  }
+
+  return {
+    enqueue(run: () => Promise<void>): Promise<void> {
+      pending?.resolve()
+      return new Promise((resolve, reject) => {
+        pending = { run, resolve, reject }
+        void drain()
+      })
+    },
+    clear() {
+      pending?.resolve()
+      pending = undefined
+    },
+  }
+}

--- a/test/load-queue.test.ts
+++ b/test/load-queue.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from 'bun:test'
+import { createLoadQueue } from '../src/load-queue'
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>(done => { resolve = done })
+  return { promise, resolve }
+}
+
+test('rapid edits skip obsolete pending work and keep only the newest edit', async () => {
+  const queue = createLoadQueue()
+  const gate = deferred()
+  const calls: string[] = []
+  const first = queue.enqueue(async () => { calls.push('first'); await gate.promise })
+  const skipped = queue.enqueue(async () => { calls.push('skipped') })
+  const newest = queue.enqueue(async () => { calls.push('newest') })
+  await skipped
+  expect(calls).toEqual(['first'])
+  gate.resolve()
+  await Promise.all([first, newest])
+  expect(calls).toEqual(['first', 'newest'])
+})
+
+test('clearing a preview discards pending edits without affecting another preview', async () => {
+  const first = createLoadQueue(), second = createLoadQueue()
+  const gate = deferred()
+  let obsoleteRan = false
+  const active = first.enqueue(() => gate.promise)
+  const pending = first.enqueue(async () => { obsoleteRan = true })
+  first.clear()
+  await pending
+  let otherRan = false
+  await second.enqueue(async () => { otherRan = true })
+  expect(otherRan).toBe(true)
+  gate.resolve()
+  await active
+  expect(obsoleteRan).toBe(false)
+})
+
+test('a failed job does not block the newest edit or later loads', async () => {
+  const queue = createLoadQueue(), gate = deferred()
+  const failed = queue.enqueue(async () => { await gate.promise; throw new Error('broken') })
+  const failure = failed.catch(error => error.message)
+  let recovered = false
+  const next = queue.enqueue(async () => { recovered = true })
+  gate.resolve()
+  expect(await failure).toBe('broken')
+  await next
+  expect(recovered).toBe(true)
+  await queue.enqueue(async () => {})
+})


### PR DESCRIPTION
Rapid typing can queue compilation for edits that have already been replaced.

Keep one active load and only the newest pending edit per preview. Superseded pending loads resolve without running, while generation checks suppress stale results and errors. Document immediate scheduling, host-controlled debounce, incomplete-source recovery, and promise behavior. Running WASM compilation and browser imports are allowed to finish; cancellation does not undo module side effects.

For example, using `load` from `useLiveCode` with three source snapshots:

```tsx
const first = load(filesV1)
const superseded = load(filesV2)
const latest = load(filesV3)

// The queued filesV2 load is skipped; filesV3 becomes the latest preview.
// Supersession resolves normally; failures are exposed through error/status.
await Promise.all([first, superseded, latest])
```

Also add repository guidance requiring a usage snippet or before/after code diff in PR descriptions when changing a public API.

Validation: three focused queue tests cover skipped edits, preview isolation/cleanup, and failure recovery. All 69 source tests, typecheck, package check, website build, Chromium/WebKit packaged-browser tests, and Next.js development/production tests passed on the completed stack. After rebasing, focused queue tests and typecheck passed; runtime code is unchanged.

Based on `main` after #99 merged. #101 builds on this PR.
