### PR TITLE
fix(site): reuse the browser compiler across Vercel builds

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -33,6 +33,15 @@ each time. Cache misses build from source, reusing Cargo dependencies, target
 files, and the wasm-bindgen executable when available. Local builds continue
 to use Cargo's normal build cache.
 
+Vercel uses `bun scripts/build-vercel.ts` to keep the generated binding and WASM
+in `node_modules/.cache/devjar-compiler`, inside its persisted dependency cache.
+The cache key covers compiler sources, Cargo manifests and configuration, the
+toolchain, and compiler build/setup scripts. A hit restores `compiler/pkg` and
+skips Rust setup and compilation while still rebuilding the current worker,
+library, and website. Missing, damaged, or outdated artifacts trigger a source
+build. The first deployment, or a deployment without a restored build cache,
+still needs Rust; this cache is separate from GitHub Actions' cache.
+
 Keep the Oxc crate versions aligned with `oxc-transform` and the wasm-bindgen
 crate aligned with the CLI version in `scripts/setup-compiler.sh`. The wrapper
 matches `src/transform.ts` with development and Refresh enabled. Update the

--- a/scripts/build-vercel.ts
+++ b/scripts/build-vercel.ts
@@ -1,0 +1,24 @@
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { ensureCompiler } from './compiler-cache'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+async function run(args: string[], cacheHit: boolean) {
+  const child = Bun.spawn(args, {
+    cwd: root,
+    env: { ...process.env, DEVJAR_COMPILER_CACHE_HIT: String(cacheHit) },
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  if (await child.exited !== 0) throw new Error(`Vercel build failed: ${args.join(' ')}`)
+}
+
+const hit = await ensureCompiler(root, async () => {
+  console.log('Browser compiler cache miss; building from Rust sources')
+  await run(['pnpm', 'run', 'setup:compiler'], false)
+  await run(['pnpm', 'run', 'build:worker'], false)
+})
+console.log(hit ? 'Browser compiler cache hit; skipping Rust setup and compilation' : 'Saved browser compiler cache')
+// Always rebuild the worker, library, and website from the current TypeScript.
+await run(['pnpm', 'run', 'build:website'], true)

--- a/scripts/compiler-cache.ts
+++ b/scripts/compiler-cache.ts
@@ -1,0 +1,64 @@
+import { createHash } from 'node:crypto'
+import { copyFile, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const assets = ['devjar_browser_compiler.js', 'devjar_browser_compiler_bg.wasm']
+const digest = (value: Uint8Array) => createHash('sha256').update(value).digest('hex')
+
+async function compilerKey(root: string) {
+  const inputs = ['scripts/setup-compiler.sh', 'scripts/build-workers.ts', 'scripts/compiler-cache.ts']
+  async function visit(directory: string) {
+    for (const entry of await readdir(join(root, directory), { withFileTypes: true })) {
+      const path = `${directory}/${entry.name}`
+      if (entry.isDirectory()) await visit(path)
+      else inputs.push(path)
+    }
+  }
+  await visit('compiler/src')
+  for (const entry of await readdir(join(root, 'compiler'), { withFileTypes: true })) {
+    if (entry.isFile() && /\.(rs|toml|lock)$/.test(entry.name)) inputs.push(`compiler/${entry.name}`)
+    if (entry.isDirectory() && entry.name === '.cargo') await visit('compiler/.cargo')
+  }
+  const hash = createHash('sha256')
+  for (const path of inputs.sort()) {
+    hash.update(path).update('\0').update(await readFile(join(root, path))).update('\0')
+  }
+  return hash.digest('hex')
+}
+
+// Vercel's static builder persists node_modules, but not compiler/pkg or Cargo's
+// build directories. Cache only the platform-independent generated JS and WASM.
+export async function ensureCompiler(root: string, build: () => Promise<void>): Promise<boolean> {
+  const cache = join(root, 'node_modules/.cache/devjar-compiler')
+  const output = join(root, 'compiler/pkg')
+  const key = await compilerKey(root)
+  let hit = false
+  try {
+    const manifest = JSON.parse(await readFile(join(cache, 'manifest.json'), 'utf8'))
+    hit = manifest?.key === key
+    for (const asset of assets) {
+      if (!hit) break
+      hit = digest(await readFile(join(cache, asset))) === manifest.assets?.[asset]
+    }
+  } catch (error) {
+    hit = false
+    if (!(error instanceof SyntaxError) && (error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+  if (hit) {
+    await mkdir(output, { recursive: true })
+    for (const asset of assets) await copyFile(join(cache, asset), join(output, asset))
+    return true
+  }
+
+  await build()
+  // Do not trust existing output until the build has completed successfully.
+  const contents = await Promise.all(assets.map(asset => readFile(join(output, asset))))
+  await rm(cache, { recursive: true, force: true })
+  await mkdir(cache, { recursive: true })
+  for (const [index, asset] of assets.entries()) await writeFile(join(cache, asset), contents[index])
+  await writeFile(join(cache, 'manifest.json'), JSON.stringify({
+    key,
+    assets: Object.fromEntries(assets.map((asset, index) => [asset, digest(contents[index])])),
+  }))
+  return false
+}

--- a/test/deployment.test.ts
+++ b/test/deployment.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, test } from 'bun:test'
-import { readFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ensureCompiler } from '../scripts/compiler-cache'
 
 describe('Vercel deployment', () => {
   test('builds the static website without requiring isolation headers', async () => {
     const config = JSON.parse(await readFile(new URL('../vercel.json', import.meta.url), 'utf8'))
 
     expect(config.framework).toBeNull()
-    expect(config.buildCommand).toBe('pnpm run setup:compiler && pnpm run build:website')
+    expect(config.buildCommand).toBe('bun scripts/build-vercel.ts')
     expect(config.outputDirectory).toBe('site/dist')
     expect(config.headers).toEqual([
       {
@@ -29,4 +32,59 @@ describe('Vercel deployment', () => {
       },
     ])
   })
+})
+
+test('deployment cache skips unchanged compiler builds and invalidates compiler inputs or damaged assets', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'devjar-compiler-cache-'))
+  const output = join(root, 'compiler/pkg')
+  const cache = join(root, 'node_modules/.cache/devjar-compiler')
+  const wasm = 'devjar_browser_compiler_bg.wasm'
+  let builds = 0
+  async function build() {
+    builds++
+    await mkdir(output, { recursive: true })
+    await writeFile(join(output, 'devjar_browser_compiler.js'), `binding ${builds}`)
+    await writeFile(join(output, wasm), `wasm ${builds}`)
+  }
+  try {
+    for (const directory of ['compiler/src', 'scripts', 'src']) await mkdir(join(root, directory), { recursive: true })
+    const inputs = ['compiler/src/lib.rs', 'compiler/Cargo.toml', 'compiler/Cargo.lock', 'compiler/rust-toolchain.toml',
+      'scripts/setup-compiler.sh', 'scripts/build-workers.ts', 'scripts/compiler-cache.ts']
+    for (const input of inputs) await writeFile(join(root, input), 'original')
+    expect(await ensureCompiler(root, build)).toBe(false)
+    expect(builds).toBe(1)
+
+    // A new checkout restores only node_modules, not generated compiler outputs.
+    await rm(output, { recursive: true })
+    await writeFile(join(root, 'src/core.ts'), 'runtime edit')
+    await writeFile(join(root, 'src/transform-worker.ts'), 'worker edit')
+    expect(await ensureCompiler(root, build)).toBe(true)
+    expect(builds).toBe(1)
+    expect(await readFile(join(output, wasm), 'utf8')).toBe('wasm 1')
+
+    for (const input of inputs) {
+      await writeFile(join(root, input), 'changed')
+      expect(await ensureCompiler(root, build)).toBe(false)
+      expect(await ensureCompiler(root, build)).toBe(true)
+    }
+    await writeFile(join(root, 'compiler/src/extra.rs'), 'new module')
+    expect(await ensureCompiler(root, build)).toBe(false)
+    await rm(join(root, 'compiler/src/extra.rs'))
+    expect(await ensureCompiler(root, build)).toBe(false)
+
+    for (const damage of [
+      () => rm(join(cache, wasm)),
+      () => writeFile(join(cache, wasm), 'corrupt'),
+      () => writeFile(join(cache, 'manifest.json'), '{'),
+    ]) {
+      await damage()
+      expect(await ensureCompiler(root, build)).toBe(false)
+    }
+    await writeFile(join(root, 'compiler/src/lib.rs'), 'broken')
+    await expect(ensureCompiler(root, async () => { throw new Error('compile failed') })).rejects.toThrow('compile failed')
+    expect(await ensureCompiler(root, build)).toBe(false)
+    expect(await ensureCompiler(root, build)).toBe(true)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 })

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
-  "buildCommand": "pnpm run setup:compiler && pnpm run build:website",
+  "buildCommand": "bun scripts/build-vercel.ts",
   "outputDirectory": "site/dist",
   "headers": [
     {


### PR DESCRIPTION
Vercel rebuilds the Rust browser compiler for runtime-only PRs because its build command always runs `setup:compiler`, while the existing generated-compiler cache is restored only by GitHub Actions.

Use a Vercel build wrapper that caches the generated binding and WASM under `node_modules/.cache/devjar-compiler`. The key covers Rust sources, Cargo manifests/configuration, the toolchain, and compiler build/setup scripts. Validate artifact hashes before restoring `compiler/pkg`, then skip Rust setup and compilation while rebuilding the current worker, library, and website. Missing, damaged, or outdated artifacts fall back to a source build.

```text
Before: every Vercel build runs Rust setup and compilation
Cold:   build compiler → save generated JS/WASM → build website
Warm:   restore matching JS/WASM → build current worker and website
```

The first deployment still populates this cache. Vercel must restore its build cache for later deployments to hit it. This is separate from GitHub Actions caching and does not change the public API. The cache location follows Vercel's [default static-build cache paths](https://github.com/vercel/vercel/blob/main/packages/build-utils/src/default-cache-path-glob.ts).

Validation: ran the real Vercel build entry point cold and warm; warm output confirmed Rust setup/compilation was skipped and the website was rebuilt. The owning deployment test covers runtime/worker-only changes, compiler input changes, file additions/removals, missing/corrupt cache files, and failed compilation. All 70 source tests, typecheck, and package checks passed. Hosted cache restoration will be verified on subsequent Vercel deployments.
