### PR TITLE
fix(runtime): handle Strict Mode and preview option updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ export default function LiveExample() {
 Keep `files` and custom resolver functions stable between unrelated parent
 renders. To edit a file, replace its string in a new `files` object.
 
+The component reloads the current files when compilation options change. Changing
+`transform` or compiler asset URLs invalidates compiled-source caches. Changing
+`dependencies`, `resolveModule`, or `tailwind` starts a fresh iframe runtime;
+React state and iframe globals are reset. Equal dependency versions and compiler
+URLs do not trigger a reload just because their options objects are recreated.
+
+With `useLiveCode`, call `load` again to apply changed options. For automatic
+updates, include both `files` and `load` in your effect dependencies.
+
 </details>
 
 <details>

--- a/scripts/test-package-browser.ts
+++ b/scripts/test-package-browser.ts
@@ -14,6 +14,7 @@ const packageDirectory = join(temporaryRoot, 'package')
 const projectRoot = join(temporaryRoot, 'project')
 let browser: Browser | undefined
 let server: ChildProcess | undefined
+let strictServer: ReturnType<typeof Bun.serve> | undefined
 
 function executable(name: string) {
   return process.platform === 'win32' ? `${name}.cmd` : name
@@ -220,7 +221,7 @@ export default function Counter() {
   }, [])
   return <button onClick={() => setCount(count + 1)}>Hello {content.name} {text} {count}</button>
 }`
-  await writeFile(join(projectRoot, 'pages/playground.tsx'), `import { useMemo, useRef, useState } from 'react'
+  await writeFile(join(projectRoot, 'pages/playground.tsx'), `import { StrictMode, useMemo, useRef, useState } from 'react'
 import { DevJar } from 'devjar'
 const initial = ${JSON.stringify(source)}
 export default function Playground() {
@@ -228,13 +229,27 @@ export default function Playground() {
   const [code, setCode] = useState(initial)
   const [error, setError] = useState('')
   const [status, setStatus] = useState('idle')
+  const [readyCount, setReadyCount] = useState(0)
+  const [resetDone, setResetDone] = useState(false)
+  const [tailwind, setTailwind] = useState(false)
+  const [transform, setTransform] = useState(true)
   const files = useMemo(() => ({ 'pages/index.tsx': code, 'content.json': '{"name":"Devjar"}', 'message.txt': 'works' }), [code])
   return <main>
     <button onClick={() => void apiRef.current?.reset()}>Reset runtime</button>
+    <button onClick={() => {
+      const first = apiRef.current.reset()
+      const second = apiRef.current.reset()
+      if (first !== second) throw new Error('Concurrent resets must share a promise')
+      setCode(current => current.replace('Latest', 'Reset edit'))
+      void first.then(() => setResetDone(true))
+    }}>Reset and edit</button>
+    <span aria-label="Reset completed">{String(resetDone)}</span>
+    <button onClick={() => setTailwind(value => !value)}>Toggle Tailwind</button>
+    <button onClick={() => setTransform(value => !value)}>Toggle transform</button>
     <textarea aria-label="Code" value={code} onChange={event => setCode(event.target.value)} />
     <pre role="status">{error}</pre>
-    <output aria-label="Preview status">{status}</output>
-    <DevJar title="Live preview" apiRef={apiRef} tailwind={false} onStatusChange={setStatus} onError={error => setError(error ? String(error) : '')} files={files} />
+    <output aria-label="Preview status" data-ready-count={readyCount}>{status}</output>
+    <StrictMode><DevJar title="Live preview" apiRef={apiRef} tailwind={tailwind} transform={transform} dependencies={{ react: '19.2.0', 'react-dom': '19.2.0' }} onStatusChange={status => { setStatus(status); if (status === 'ready') setReadyCount(count => count + 1) }} onError={error => setError(error ? String(error) : '')} files={files} /></StrictMode>
   </main>
 }`)
   await run(devjar, ['build', '--base', '/preview/'], projectRoot)
@@ -272,11 +287,98 @@ export default function Playground() {
   await frame.getByRole('button', { name: /^Hello Devjar works \d+$/ }).waitFor()
   await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
   assert.equal(await preview.locator('pre[role="status"]').textContent(), '')
+  // Source stays identical while compiler options change: cached raw JSX must
+  // not prevent recovery when transformation is re-enabled.
+  await preview.getByRole('button', { name: 'Toggle transform' }).click()
+  await preview.getByLabel('Preview status').filter({ hasText: 'failed' }).waitFor()
+  await preview.getByRole('button', { name: 'Toggle transform' }).click()
+  await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
+
+  // Both directions must keep the project usable without editing its files.
+  await preview.route('https://unpkg.com/@tailwindcss/browser@4', route => route.fulfill({ contentType: 'text/javascript', body: '' }))
+  for (let toggle = 0; toggle < 2; toggle++) {
+    const previousReady = await preview.getByLabel('Preview status').getAttribute('data-ready-count')
+    await preview.getByRole('button', { name: 'Toggle Tailwind' }).click()
+    await preview.waitForFunction(previous => Number(document.querySelector('[aria-label="Preview status"]')?.getAttribute('data-ready-count')) > Number(previous), previousReady)
+    await frame.getByRole('button', { name: /^Hello Devjar works \d+$/ }).waitFor()
+    await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
+  }
+
+  // Hold a real worker request so an error from the visible old preview arrives
+  // during compilation. It must not poison readiness of the replacement.
+  await preview.evaluate(() => {
+    const postMessage = Worker.prototype.postMessage
+    Worker.prototype.postMessage = function (...args) {
+      Worker.prototype.postMessage = postMessage
+      ;(window as any).__releaseCompilation = () => postMessage.apply(this, args as [any])
+    }
+  })
+  await preview.getByRole('textbox', { name: 'Code' }).fill(source.replace('Hello', 'Latest'))
+  await preview.waitForFunction(() => typeof (window as any).__releaseCompilation === 'function')
+  await preview.evaluate(() => {
+    const frameWindow = document.querySelector('iframe')!.contentWindow! as any
+    frameWindow.dispatchEvent(new frameWindow.ErrorEvent('error', { message: 'Old preview failed', error: new frameWindow.Error('Old preview failed') }))
+    ;(window as any).__releaseCompilation()
+    delete (window as any).__releaseCompilation
+  })
+  await frame.getByRole('button', { name: /^Latest Devjar works \d+$/ }).waitFor()
+  await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
+  assert.equal(await preview.locator('pre[role="status"]').textContent(), '')
+  await preview.getByRole('button', { name: 'Reset and edit' }).click()
+  await preview.getByLabel('Reset completed').filter({ hasText: 'true' }).waitFor()
+  await frame.getByRole('button', { name: 'Reset edit Devjar works 0' }).waitFor()
+  await preview.getByLabel('Preview status').filter({ hasText: 'ready' }).waitFor()
   assert.deepEqual(previewErrors, [])
+  // A separate development React root makes Strict Mode's effect replay real;
+  // production React in the exported website intentionally does not replay it.
+  const strictFiles = { 'pages/index.js': 'export default function Page() { return "Strict preview" }' }
+  const strictHtml = `<div id="root"></div><script type="importmap">${JSON.stringify({ imports: {
+    react: 'https://esm.sh/react@19.2.0?dev',
+    'react/jsx-runtime': 'https://esm.sh/react@19.2.0/jsx-runtime?dev',
+    'es-module-lexer': '/lexer.js',
+    'react-dom/client': 'https://esm.sh/react-dom@19.2.0/client?dev&deps=react@19.2.0',
+  } })}</script><script type="module">
+import { createElement, StrictMode, useEffect } from 'react'
+import { createRoot } from 'react-dom/client'
+import { DevJar } from '/index.js'
+const files = ${JSON.stringify(strictFiles)}
+window.effectSetups = 0
+window.effectCleanups = 0
+function Probe() {
+  useEffect(() => {
+    window.effectSetups++
+    return () => { window.effectCleanups++ }
+  }, [])
+  return createElement(DevJar, { files, transform: false, tailwind: false,
+    onStatusChange: status => { document.body.dataset.status = status } })
+}
+const root = createRoot(document.getElementById('root'))
+root.render(createElement(StrictMode, null, createElement(Probe)))
+window.unmount = () => root.unmount()
+</script>`
+  strictServer = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch(request) {
+    const path = new URL(request.url).pathname
+    if (path === '/') return new Response(strictHtml, { headers: { 'content-type': 'text/html' } })
+    if (path === '/lexer.js') return new Response(Bun.file(join(projectRoot, 'node_modules/es-module-lexer/dist/lexer.js')))
+    return new Response(Bun.file(join(projectRoot, 'node_modules/devjar/dist', path)))
+  } })
+  const strictPage = await browser.newPage()
+  const strictErrors: string[] = []
+  strictPage.on('pageerror', error => strictErrors.push(error.message))
+  await strictPage.goto(strictServer.url.href)
+  await strictPage.frameLocator('iframe').getByText('Strict preview', { exact: true }).waitFor()
+  await strictPage.waitForFunction(() => document.body.dataset.status === 'ready')
+  assert.equal(await strictPage.evaluate(() => (window as any).effectSetups), 2)
+  assert.equal(await strictPage.evaluate(() => (window as any).effectCleanups), 1)
+  await strictPage.evaluate(() => (window as any).unmount())
+  assert.equal(await strictPage.evaluate(() => (window as any).effectCleanups), 2)
+  assert.deepEqual(strictErrors, [])
+  await strictPage.close()
   console.log('Packaged static export and live DevJar compilation, JSON/text imports, Refresh state preservation, and error recovery passed without isolation headers.')
 
 } finally {
   await browser?.close()
   if (server) await stopServer(server)
+  strictServer?.stop(true)
   await rm(temporaryRoot, { recursive: true, force: true })
 }

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -36,6 +36,12 @@ export default function Preview() {
 
 To update a preview, replace the edited file's string in a new files object.
 Keep files and custom resolver functions stable between unrelated renders.
+DevJar reloads current files when options change. Changing transform/compiler URLs
+invalidates compiled-source caches; changing dependencies, resolveModule, or
+tailwind recreates the iframe runtime and resets its state. Equal dependency and
+compiler values do not reload just because their options objects are recreated.
+With useLiveCode, call load again after options change, or include files and load
+in the dependencies of the effect that performs automatic loading.
 Updates start immediately, with one active load and only the newest pending edit.
 Superseded queued edits are skipped; running compilation/imports finish and stale
 results are discarded. This cannot undo module side effects. Incomplete source

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,8 @@
 import { textModuleSuffix, isTextImport, createTextModule } from './text'
+import { createFrameSession, type FrameSession } from './frame'
 import { createLoadQueue } from './load-queue'
 import { createJsonModule } from './json'
-import { useEffect, useCallback, useState, useId, useMemo, useRef } from 'react'
+import { useEffect, useCallback, useState, useMemo, useRef } from 'react'
 import { createModule } from './module'
 import type { ModuleRuntime } from './module'
 import { getCompilerWorkerUrl, type CompilerAssets } from './compiler'
@@ -17,23 +18,10 @@ export type IframeRouteManifest = {
   routes: Record<string, string>
   notFound: string | undefined
 }
-type RenderFunction = ((
-  files: Record<string, string>,
-  dependencies: Record<string, string[]>,
-  manifest: IframeRouteManifest,
-) => Promise<void>) & { dispose: () => void }
-
-declare global {
-  var __jar__: Record<string, { resolveModule?: ResolveModule }> | undefined
-  interface Window {
-    __render__?: RenderFunction
-  }
-}
 
 let esModuleLexerInit = false
 const isRelative = (specifier: string) => specifier.startsWith('./') || specifier.startsWith('../')
 const localImportPrefix = '__DEVJAR_LOCAL_IMPORT__'
-const tailwindSrc = 'https://unpkg.com/@tailwindcss/browser@4'
 const localExtensions = [...sourceExtensions, '.css', '.json']
 
 function createLocalImportPlaceholder(moduleKey: string) {
@@ -303,6 +291,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     typeof import('react-dom/client'),
     typeof import('react-dom'),
   ]> | undefined
+  let disposed = false
   let renderRequestId = 0
   let renderQueue = Promise.resolve()
   let revision = 0
@@ -321,6 +310,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     dependencies: Record<string, string[]>,
     manifest: IframeRouteManifest,
     requestId: number,
+    beforeCommit: () => void,
   ) {
     const cleanRoute = currentRoute.replace(/^\/+|\/+$/g, '')
     const route = cleanRoute ? `/${cleanRoute}` : '/'
@@ -348,7 +338,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
       ])
     }
     const [ReactMod, ReactDOMMod, { flushSync }] = await rendererModules
-    if (requestId !== renderRequestId) return
+    if (disposed || requestId !== renderRequestId) return
 
     const _jsx = ReactMod.createElement
     const root = document.getElementById('__reactRoot')
@@ -401,6 +391,7 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
       }
     }
 
+    beforeCommit()
     flushSync(() => {
       if (!reactRoot) {
         reactRoot = ReactDOMMod.createRoot(root)
@@ -454,20 +445,22 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     files: Record<string, string>,
     dependencies: Record<string, string[]>,
     manifest: IframeRouteManifest,
+    beforeCommit: () => void,
   ) {
+    if (disposed) return Promise.resolve()
     const requestId = ++renderRequestId
     currentFiles = files
     currentDependencies = dependencies
     currentManifest = manifest
     const pendingRender = renderQueue.then(() => {
-      if (requestId !== renderRequestId) return
-      return renderCurrent(files, dependencies, manifest, requestId)
+      if (disposed || requestId !== renderRequestId) return
+      return renderCurrent(files, dependencies, manifest, requestId, beforeCommit)
     })
     renderQueue = pendingRender.catch(() => {})
     return pendingRender
   }
 
-  document.addEventListener('click', (event) => {
+  const onClick = (event: MouseEvent) => {
     if (event.defaultPrevented || event.button !== 0) return
     if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
     const anchor = event.target instanceof Element
@@ -485,11 +478,15 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
     event.preventDefault()
     currentRoute = url.pathname
     if (currentManifest) {
-      void render(currentFiles, currentDependencies, currentManifest)
+      void render(currentFiles, currentDependencies, currentManifest, () => {})
     }
-  })
+  }
+  document.addEventListener('click', onClick)
 
   render.dispose = () => {
+    if (disposed) return
+    disposed = true
+    document.removeEventListener('click', onClick)
     renderRequestId++
     reactRoot?.unmount()
     reactRoot = undefined
@@ -497,43 +494,17 @@ function createRenderer(createModule_: typeof createModule, resolveModule: Resol
   return render
 }
 
-function createMainScript({ uid }: { uid: string }) {
-  const code = (`\
+function createMainScript() {
+  return `(() => {
 'use strict';
-const _createModule = ${createModule.toString()};
-const _createRenderer = ${createRenderer.toString()};
-
-const resolveModule = (specifier) => window.parent.__jar__[globalThis.uid].resolveModule(specifier)
-
-globalThis.uid = ${JSON.stringify(uid)};
-globalThis.__render__ = _createRenderer(_createModule, resolveModule);
-`)
-  return code
-}
-
-function useScript() {
-  return useRef<HTMLScriptElement | null>(null)
-}
-
-function createScript(
-  scriptRef: React.RefObject<HTMLScriptElement | null>,
-  { content, src, type }: {
-    content?: string
-    src?: string
-    type?: string
-  } = {}
-) {
-  const script = scriptRef.current || document.createElement('script')
-  scriptRef.current = script
-  if (type) script.type = type
-
-  if (content) {
-    script.src = `data:text/javascript;utf-8,${encodeURIComponent(content)}`
-  }
-  if (src) {
-    script.src = src
-  }
-  return script
+const script = document.currentScript;
+if (!script?.isConnected) return;
+const createModule = ${createModule.toString()};
+const createRenderer = ${createRenderer.toString()};
+script.dispatchEvent(new CustomEvent('devjar:initialize', {
+  detail: resolveModule => createRenderer(createModule, resolveModule),
+}));
+})();`
 }
 
 function useLiveCode({
@@ -551,147 +522,72 @@ function useLiveCode({
   transformWorkerUrl?: string | URL
   compiler?: CompilerAssets
 }) {
+  // Equal dependency/asset values must not reload a preview merely because a
+  // parent creates fresh options objects while handling status notifications.
+  const dependenciesKey = JSON.stringify(Object.entries(dependencies || {}).sort(([a], [b]) => a.localeCompare(b)))
   const resolveModule = useMemo(
-    () => customResolveModule || createPreviewResolver(dependencies || {}),
-    [customResolveModule, dependencies]
+    () => customResolveModule || createPreviewResolver(Object.fromEntries(JSON.parse(dependenciesKey))),
+    [customResolveModule, dependenciesKey]
   )
+  const workerUrl = compiler?.workerUrl.toString()
+  const bindingUrl = compiler?.bindingUrl.toString()
+  const wasmUrl = compiler?.wasmUrl.toString()
+  const legacyUrl = compiler ? undefined : transformWorkerUrl?.toString()
+  const transformKey = JSON.stringify([transform, workerUrl, bindingUrl, wasmUrl, legacyUrl])
   const iframeRef = useRef<HTMLIFrameElement | null>(null)
-  const [error, setError] = useState<unknown>()
-  const [status, setStatus] = useState<PreviewStatus>('idle')
-  const appScriptRef = useScript()
-  const tailwindcssScriptRef = useScript()
-  const tailwindReadyRef = useRef<Promise<void>>(Promise.resolve())
-  const transformClientRef = useRef<{ url: string; client: TransformClient } | undefined>(undefined)
-  const transformCacheRef = useRef(new Map<string, { source: string, code: string }>())
+  const [{ error, status }, setPreview] = useState<{ error: unknown; status: PreviewStatus }>({ error: undefined, status: 'idle' })
+  const sessionRef = useRef<FrameSession | undefined>(undefined)
+  const transformClientRef = useRef<TransformClient | undefined>(undefined)
+  const transformCacheRef = useRef<{ key: string; files: Map<string, { source: string; code: string }> } | undefined>(undefined)
   const loadQueueRef = useRef(createLoadQueue())
-  const lastFilesRef = useRef<Record<string, string> | undefined>(undefined)
-  const cleanupFrameRef = useRef<(() => void) | undefined>(undefined)
-  const frameReadyRef = useRef<Promise<void>>(Promise.resolve())
-  const cancelNavigationRef = useRef<(() => void) | undefined>(undefined)
+  const lastLoadRef = useRef<{ files: Record<string, string>; promise: Promise<void> } | undefined>(undefined)
   const pendingResetRef = useRef<Promise<void> | undefined>(undefined)
   const loadIdRef = useRef(0)
-  const runtimeFailureRef = useRef<number | undefined>(undefined)
-  const scriptReadyRef = useRef<Promise<void>>(Promise.resolve())
-  const uid = useId()
 
-  // Let resolveModule execute on parent window side since it might involve
-  // variables that iframe cannot access.
   useEffect(() => {
-    if (!globalThis.__jar__) {
-      globalThis.__jar__ = {};
-    }
-    globalThis.__jar__[uid] = {
+    const iframe = iframeRef.current
+    if (!iframe) return
+    const queue = createLoadQueue()
+    loadQueueRef.current = queue
+    const session = createFrameSession(iframe, {
+      script: createMainScript(),
       resolveModule,
-    }
-
-    return () => {
-      if (globalThis.__jar__) {
-        delete globalThis.__jar__[uid]
-      }
-    }
-  }, [resolveModule, uid])
-
-  useEffect(() => {
+      tailwind,
+      onError: error => setPreview({ error, status: 'failed' }),
+    })
+    sessionRef.current = session
+    setPreview({ error: undefined, status: 'idle' })
     return () => {
       loadIdRef.current++
       loadQueueRef.current.clear()
-      transformClientRef.current?.client.release()
+      session.dispose()
+      transformClientRef.current?.release()
       transformClientRef.current = undefined
+      pendingResetRef.current = undefined
+      if (sessionRef.current === session) sessionRef.current = undefined
     }
-  }, [])
-
-  const initializeFrame = useCallback(() => {
-    const iframe = iframeRef.current
-    if (!iframe || !iframe.contentDocument) return
-
-    const doc = iframe.contentDocument
-    const body = doc.body
-    const div = document.createElement('div')
-    div.id = '__reactRoot'
-
-    const appScriptContent = createMainScript({ uid })
-
-    const appScript = createScript(appScriptRef, { content: appScriptContent })
-    const tailwindScript = tailwind
-      ? createScript(tailwindcssScriptRef, { src: tailwindSrc })
-      : null
-
-    let resolveTailwind: (() => void) | undefined
-    tailwindReadyRef.current = tailwindScript
-      ? new Promise<void>((resolve) => {
-          const ready = () => resolve()
-          resolveTailwind = ready
-          tailwindScript.addEventListener('load', ready, { once: true })
-          tailwindScript.addEventListener('error', ready, { once: true })
-        })
-      : Promise.resolve()
-
-    const reportError = (error: unknown) => {
-      runtimeFailureRef.current = loadIdRef.current
-      setError(error)
-      setStatus('failed')
-    }
-    const onRuntimeError = (event: ErrorEvent) => reportError(event.error || new Error(event.message))
-    const onRejection = (event: PromiseRejectionEvent) => reportError(event.reason)
-    const onReactError = (event: Event) => {
-      setError((event as CustomEvent).detail)
-      setStatus('failed')
-    }
-    const frameWindow = iframe.contentWindow!
-    frameWindow.addEventListener('error', onRuntimeError)
-    frameWindow.addEventListener('unhandledrejection', onRejection)
-    doc.addEventListener('devjar:error', onReactError)
-    let resolveScript: (() => void) | undefined
-    scriptReadyRef.current = new Promise<void>((resolve, reject) => {
-      resolveScript = resolve
-      appScript.onload = () => resolve()
-      appScript.onerror = () => reject(new Error('devjar: application script failed to load'))
-    })
-    // A load may start after the script fails; keep the rejection observable then.
-    void scriptReadyRef.current.catch(() => {})
-    body.appendChild(div)
-    if (tailwindScript) body.appendChild(tailwindScript)
-    body.appendChild(appScript)
-
-    return () => {
-      frameWindow.__render__?.dispose()
-      appScriptRef.current = null
-      tailwindcssScriptRef.current = null
-      frameWindow.removeEventListener('error', onRuntimeError)
-      frameWindow.removeEventListener('unhandledrejection', onRejection)
-      doc.removeEventListener('devjar:error', onReactError)
-      div.remove()
-      appScript.remove()
-      tailwindScript?.remove()
-      resolveTailwind?.()
-      resolveScript?.()
-    }
-  }, [uid, tailwind])
-
-  useEffect(() => {
-    cleanupFrameRef.current = initializeFrame()
-    return () => {
-      cancelNavigationRef.current?.()
-      cleanupFrameRef.current?.()
-      cleanupFrameRef.current = undefined
-    }
-  }, [initializeFrame])
+  }, [resolveModule, tailwind])
 
   const transformFiles = useCallback((files: Record<string, string>) => {
-    const url = getCompilerWorkerUrl(compiler, transformWorkerUrl)
-    if (transformClientRef.current?.url !== url) {
-      transformClientRef.current?.client.release()
-      transformClientRef.current = { url, client: acquireTransformClient(url) }
+    if (!transformClientRef.current) {
+      const assets = workerUrl === undefined ? undefined : { workerUrl, bindingUrl: bindingUrl!, wasmUrl: wasmUrl! }
+      transformClientRef.current = acquireTransformClient(getCompilerWorkerUrl(assets, legacyUrl))
     }
-    return transformClientRef.current.client.transform(files)
-  }, [compiler, transformWorkerUrl])
+    return transformClientRef.current.transform(files)
+  }, [workerUrl, bindingUrl, wasmUrl, legacyUrl])
 
   const runLoad = useCallback(async (files: Record<string, string>, loadId: number) => {
     if (loadId !== loadIdRef.current) return
 
     try {
-      await frameReadyRef.current
-      if (loadId !== loadIdRef.current) return
+      const session = sessionRef.current
+      if (!session) return
+      if (transformCacheRef.current?.key !== transformKey) {
+        transformClientRef.current?.release()
+        transformClientRef.current = undefined
+        transformCacheRef.current = { key: transformKey, files: new Map() }
+      }
+      const cache = transformCacheRef.current.files
       const resolveModuleForLoad = resolveModule
       const manifest = createIframeRouteManifest(files)
 
@@ -715,12 +611,12 @@ function useLiveCode({
         if (!sourceExtensions.some(extension => filename.endsWith(extension))) {
           throw new Error(`Cannot import ${filename} as JavaScript. Use with { type: "text" } to import its contents.`)
         }
-        let cached = transformCacheRef.current.get(filename)
+        let cached = cache.get(filename)
         if (cached?.source !== source) {
           const output = transform ? await transformFiles({ [filename]: source }) : { [filename]: source }
           if (loadId !== loadIdRef.current) return
           cached = { source, code: output[filename] }
-          transformCacheRef.current.set(filename, cached)
+          cache.set(filename, cached)
         }
         transformedSources[filename] = cached.code
         for (const imported of parse(cached.code)[0]) {
@@ -728,85 +624,57 @@ function useLiveCode({
           queue.push(resolveRelativeModule(filename, imported.n, localFiles, false))
         }
       }
-      for (const filename of transformCacheRef.current.keys()) {
-        if (!(filename in files)) transformCacheRef.current.delete(filename)
+      for (const filename of cache.keys()) {
+        if (!(filename in files)) cache.delete(filename)
       }
       const linked = await linkModules(transformedSources, resolveModuleForLoad, files)
       if (loadId !== loadIdRef.current) return
 
-      setStatus('loading')
-      await Promise.all([tailwindReadyRef.current, scriptReadyRef.current])
+      setPreview({ error: undefined, status: 'loading' })
+      await session.render(linked.files, linked.dependencies, manifest)
       if (loadId !== loadIdRef.current) return
-      const iframe = iframeRef.current
-      const render = iframe?.contentWindow?.__render__
-      if (!render) throw new Error('devjar: renderer was not initialized')
-      await render(linked.files, linked.dependencies, manifest)
+      setPreview({ error: undefined, status: 'ready' })
+      iframeRef.current?.dispatchEvent(new CustomEvent('devjar:render'))
+    } catch (error) {
       if (loadId !== loadIdRef.current) return
-      if (runtimeFailureRef.current === loadId) return
-      setError(undefined)
-      setStatus('ready')
-      iframe.dispatchEvent(new CustomEvent('devjar:render'))
-    } catch (e) {
-      if (loadId !== loadIdRef.current) return
-      console.warn(e)
-      setError(e)
-      setStatus('failed')
+      setPreview({ error, status: 'failed' })
     }
-  }, [resolveModule, transform, transformFiles])
+  }, [resolveModule, transform, transformFiles, transformKey])
 
+  // Changing Tailwind also replaces the session and must retrigger the component load.
   const load = useCallback((files: Record<string, string>) => {
-    lastFilesRef.current = files
     const loadId = ++loadIdRef.current
-    setError(undefined)
-    setStatus('compiling')
-    return loadQueueRef.current.enqueue(() => runLoad(files, loadId))
-  }, [runLoad])
+    setPreview({ error: undefined, status: 'compiling' })
+    const promise = loadQueueRef.current.enqueue(() => runLoad(files, loadId))
+    lastLoadRef.current = { files, promise }
+    return promise
+  }, [runLoad, tailwind])
 
   const reset = useCallback((): Promise<void> => {
     if (pendingResetRef.current) return pendingResetRef.current
-    const iframe = iframeRef.current
-    if (!iframe) return Promise.resolve()
-    loadIdRef.current++
+    const session = sessionRef.current
+    if (!session) return Promise.resolve()
+    const resetId = ++loadIdRef.current
     loadQueueRef.current.clear()
     loadQueueRef.current = createLoadQueue()
-    transformClientRef.current?.client.release()
+    transformClientRef.current?.release()
     transformClientRef.current = undefined
-    transformCacheRef.current.clear()
-    cleanupFrameRef.current?.()
-    cleanupFrameRef.current = undefined
-    setError(undefined)
-    setStatus('loading')
-    frameReadyRef.current = new Promise<void>((resolve, reject) => {
-      const cleanup = () => {
-        clearTimeout(timeout)
-        iframe.removeEventListener('load', ready)
-        cancelNavigationRef.current = undefined
-      }
-      const ready = () => {
-        cleanup()
-        if (iframeRef.current === iframe) cleanupFrameRef.current = initializeFrame()
-        resolve()
-      }
-      const timeout = setTimeout(() => {
-        cleanup()
-        reject(new Error('devjar: reset timed out waiting for the iframe'))
-      }, 10000)
-      cancelNavigationRef.current = () => { cleanup(); resolve() }
-      iframe.addEventListener('load', ready)
-      iframe.srcdoc = '<!doctype html><html><head></head><body></body></html>'
-    })
-    const pending = frameReadyRef.current.then(async () => {
-      if (iframeRef.current !== iframe) return
-      if (lastFilesRef.current) await load(lastFilesRef.current)
-      else setStatus('idle')
+    transformCacheRef.current = undefined
+    setPreview({ error: undefined, status: 'loading' })
+    const pending = session.reset().then(async () => {
+      if (sessionRef.current !== session) return
+      const latest = lastLoadRef.current
+      if (!latest) setPreview({ error: undefined, status: 'idle' })
+      else if (loadIdRef.current === resetId) await load(latest.files)
+      else await latest.promise
     }).catch(error => {
-      if (iframeRef.current !== iframe) return
-      setError(error)
-      setStatus('failed')
-    }).finally(() => { pendingResetRef.current = undefined })
+      if (sessionRef.current === session) setPreview({ error, status: 'failed' })
+    }).finally(() => {
+      if (pendingResetRef.current === pending) pendingResetRef.current = undefined
+    })
     pendingResetRef.current = pending
     return pending
-  }, [initializeFrame, load])
+  }, [load])
 
   return { ref: iframeRef, error, status, load, reset }
 }

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -1,0 +1,134 @@
+import type { IframeRouteManifest } from './core'
+
+export type RenderFunction = ((
+  files: Record<string, string>,
+  dependencies: Record<string, string[]>,
+  manifest: IframeRouteManifest,
+  beforeCommit: () => void,
+) => Promise<void>) & { dispose: () => void }
+
+let nextDocumentId = 0
+
+// One owner for the iframe document, bootstrap, event listeners, and navigation.
+// Disposing also settles waits so superseded loads can leave the queue.
+export function createFrameSession(iframe: HTMLIFrameElement, options: {
+  script: string
+  resolveModule: (specifier: string) => string
+  tailwind: boolean
+  onError: (error: unknown) => void
+}) {
+  let disposed = false
+  let generation = 0
+  let cleanup = () => {}
+  let renderer: RenderFunction | undefined
+  let failure: { error: unknown } | undefined
+  let ready: Promise<void>
+
+  function reset(): Promise<void> {
+    const current = ++generation
+    cleanup()
+    renderer = undefined
+    failure = undefined
+    const documentId = String(++nextDocumentId)
+    ready = new Promise<void>((resolve, reject) => {
+      const finishNavigation = () => {
+        clearTimeout(timeout)
+        iframe.removeEventListener('load', initialize)
+      }
+      const initialize = () => {
+        const doc = iframe.contentDocument
+        if (disposed || current !== generation || doc?.documentElement.dataset.devjarDocument !== documentId) return
+        finishNavigation()
+        const frameWindow = iframe.contentWindow!
+        const root = doc.createElement('div')
+        root.id = '__reactRoot'
+        const script = doc.createElement('script')
+        script.src = `data:text/javascript;utf-8,${encodeURIComponent(options.script)}`
+        const tailwind = options.tailwind ? doc.createElement('script') : undefined
+        let scriptReady = false
+        let stylesReady = !tailwind
+        const finish = () => { if (scriptReady && stylesReady) resolve() }
+        const report = (error: unknown) => {
+          if (disposed || current !== generation) return
+          failure = { error }
+          options.onError(error)
+        }
+        const onError = (event: ErrorEvent) => report(event.error ?? new Error(event.message))
+        const onRejection = (event: PromiseRejectionEvent) => report(event.reason)
+        // The renderer checks the final boundary state after committing. A
+        // transient caught error during Refresh must not poison recovery.
+        const onReactError = (event: Event) => options.onError((event as CustomEvent).detail)
+        const onInitialize = (event: Event) => {
+          const initializeRenderer = (event as CustomEvent<(resolve: (specifier: string) => string) => RenderFunction>).detail
+          renderer = initializeRenderer(options.resolveModule)
+        }
+        script.addEventListener('devjar:initialize', onInitialize)
+        script.onload = () => {
+          if (!renderer) { reject(new Error('devjar: renderer was not initialized')); return }
+          scriptReady = true
+          finish()
+        }
+        script.onerror = () => reject(new Error('devjar: application script failed to load'))
+        if (tailwind) {
+          tailwind.src = 'https://unpkg.com/@tailwindcss/browser@4'
+          tailwind.onload = tailwind.onerror = () => { stylesReady = true; finish() }
+        }
+        frameWindow.addEventListener('error', onError)
+        frameWindow.addEventListener('unhandledrejection', onRejection)
+        doc.addEventListener('devjar:error', onReactError)
+        cleanup = () => {
+          frameWindow.removeEventListener('error', onError)
+          frameWindow.removeEventListener('unhandledrejection', onRejection)
+          doc.removeEventListener('devjar:error', onReactError)
+          script.removeEventListener('devjar:initialize', onInitialize)
+          script.onload = script.onerror = null
+          if (tailwind) tailwind.onload = tailwind.onerror = null
+          renderer?.dispose()
+          script.remove()
+          tailwind?.remove()
+          root.remove()
+          resolve()
+        }
+        doc.body.append(root)
+        if (tailwind) doc.body.append(tailwind)
+        doc.body.append(script)
+      }
+      const timeout = setTimeout(() => {
+        finishNavigation()
+        reject(new Error('devjar: timed out waiting for the iframe'))
+      }, 10000)
+      cleanup = () => { finishNavigation(); resolve() }
+      iframe.addEventListener('load', initialize)
+      iframe.srcdoc = `<!doctype html><html data-devjar-document="${documentId}"><head></head><body></body></html>`
+    })
+    // The hook may not load any files yet. Preserve failure for the first load.
+    void ready.catch(() => {})
+    return ready
+  }
+
+  reset()
+  return {
+    reset,
+    async render(files: Record<string, string>, dependencies: Record<string, string[]>, manifest: IframeRouteManifest) {
+      const current = generation
+      await ready
+      if (disposed || current !== generation) return
+      if (!renderer) throw new Error('devjar: renderer was not initialized')
+      // An error from the old visible preview must not poison a replacement.
+      // Clear it at commit, after imports finish, so errors from the new React
+      // render and its effects still fail this load.
+      await renderer(files, dependencies, manifest, () => { failure = undefined })
+      if (disposed || current !== generation) return
+      if (failure) throw failure.error
+    },
+    dispose() {
+      if (disposed) return
+      disposed = true
+      generation++
+      cleanup()
+      renderer = undefined
+    },
+  }
+}
+
+export type FrameSession = ReturnType<typeof createFrameSession>

--- a/src/render.tsx
+++ b/src/render.tsx
@@ -36,12 +36,15 @@ export function DevJar({
 } & React.IframeHTMLAttributes<HTMLIFrameElement>) {
   const onErrorRef = useRef(onError)
   const onStatusRef = useRef(onStatusChange)
-  onErrorRef.current = onError
-  onStatusRef.current = onStatusChange
   const { ref, error, status, load, reset } = useLiveCode({ resolveModule, dependencies, transform, tailwind, transformWorkerUrl, compiler })
 
   useImperativeHandle(apiRef, () => ({ reset }), [reset])
   useImperativeHandle(forwardedRef, () => ref.current!, [ref])
+
+  useEffect(() => {
+    onErrorRef.current = onError
+    onStatusRef.current = onStatusChange
+  }, [onError, onStatusChange])
 
   useEffect(() => {
     onErrorRef.current(error)
@@ -54,7 +57,7 @@ export function DevJar({
   // load code files and execute them as live code
   useEffect(() => {
     load(files)
-  }, [files])
+  }, [files, load])
 
   // Attach the ref to an iframe element for runtime of code execution
   return <iframe {...props} ref={ref} />


### PR DESCRIPTION
Strict Mode effect replay could leave a blank preview, option-only updates could reuse incompatible compiled source, and an error from the previous visible preview could leave a valid replacement stuck at `loading`.

Give each iframe session ownership of its document, bootstrap, readiness, listeners, and disposal. Scope bootstrap declarations and pass the renderer directly through its script initialization event, removing the global renderer/resolver registry. The hook keeps compilation scheduling and publishes status/error together, reducing its refs from fifteen to eight.

- Reload the component's current files when options change, invalidating compilation caches when transform mode or compiler URLs change.
- Compare dependency versions and compiler URLs by value so equivalent inline options objects do not cause reload loops.
- Clear previous-runtime errors immediately before the replacement React commit while retaining errors from the new render and effects.
- Update notification callbacks after commit, remove navigation listeners on disposal, and guard pending work across reset/unmount.

Existing API, corrected reactive behavior:

```tsx
const [transform, setTransform] = useState(true)

return <>
  <button onClick={() => setTransform(value => !value)}>
    Toggle compilation
  </button>
  <DevJar files={files} transform={transform} onError={setError} />
</>
```

Re-enabling transformation now recompiles the unchanged JSX source and recovers the preview. Changing dependency versions, the resolver, or Tailwind starts a fresh iframe runtime and resets its state; changing compiler options invalidates compiled source. The README and agent reference describe this behavior and the hook's explicit `load` scheduling. Public signatures, React 19.0 compatibility, worker sharing, latest-edit scheduling, and the committed-preview readiness contract are preserved.

Validation: all 70 source tests, typecheck, package checks, and website build passed. Chromium and WebKit packaged-browser tests cover option changes without file edits, stable inline dependency options, stale errors during a held real compilation, concurrent reset calls with an edit, and a development React root that verifies actual Strict Mode setup/cleanup replay. Next.js development and production embedding tests also passed.
