### PR TITLE
Enable edge-to-edge viewport output

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -275,7 +275,7 @@ addEventListener('unhandledrejection', event => showBootstrapError(event.reason?
     ? '.devjar-error{box-sizing:border-box;position:fixed;z-index:10;inset:auto 0 0;margin:0;padding:6px 12px;max-height:25vh;overflow:auto;border:0;border-radius:0;background:#fff7f6;color:#9f2d20;font:11px/1.4 ui-monospace,monospace;white-space:pre-wrap}'
     : ''
   return `<!doctype html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 <meta name="devjar-base" content="${options.base}">${documentHead}${metadataHead}${tailwindPreload}<script type="importmap">${JSON.stringify({ imports })}</script>
 <style>html,body,#root,#__reactRoot{width:100%;min-height:100%;margin:0}${errorStyles}</style>${staticStyles}
 ${tailwindStylesheet}</head><body><div id="root"><div id="__reactRoot">${options.content}</div></div>${errorOverlay}${tailwindScript}${clientScript}</body></html>`

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -849,6 +849,7 @@ export default function Page() {
       expect(document).not.toContain('__jarError')
       expect(document).not.toContain('devjar-error')
       expect(document).toContain('<head><meta charset="utf-8"')
+      expect(document).toContain('<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">')
       expect(document).toContain('<title>Static title</title><meta name="description" content="Static description">')
       expect(document).not.toContain('<div id="__reactRoot"><title>')
       expect(document).toContain('<main class="page"><h1>Static now</h1>')


### PR DESCRIPTION
## Summary

- generate exported HTML with `viewport-fit=cover` by default
- preserve the existing UTF-8 charset and responsive viewport settings
- cover the viewport output in the static export test

This lets sites render edge-to-edge on devices with non-rectangular displays. Projects with edge-aligned interactive content should account for `env(safe-area-inset-*)`.

## Testing

- `bun test test/cli.test.ts --test-name-pattern "writes rendered page content and styles into route HTML"`